### PR TITLE
 feat: add creator tracking and member management operations

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/model/integration/FirestoreDiscussionTests.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/model/integration/FirestoreDiscussionTests.kt
@@ -184,12 +184,12 @@ class FirestoreDiscussionTests : FirestoreTests() {
   fun canChangeDiscussionDescription() = runTest {
     val (acc, discussion) = viewModels[0].createDiscussion("Test", "", account1)
     account1 = acc
-    val newDescription = "A non empty discussion"
+    val newDescription = "A non empty description"
     val updated = viewModels[1].setDiscussionDescription(discussion, account1, newDescription)
-    val getDiscussion = viewModels[2].getDiscussion(updated.uid)
+    val getDiscussion = viewModels[2].getDiscussion(discussion.uid)
 
     assertEquals(updated.uid, getDiscussion.uid)
-    assertEquals(updated.description, newDescription)
+    assertEquals(newDescription, getDiscussion.description)
   }
 
   @Test(expected = DiscussionNotFoundException::class)
@@ -258,5 +258,109 @@ class FirestoreDiscussionTests : FirestoreTests() {
     val (acc, discussion) = viewModels[0].createDiscussion("Test", "", account1)
     account1 = acc
     viewModels[1].addAdminsToDiscussion(discussion, account2, account2, account3)
+  }
+
+  @Test
+  fun canRemoveUserFromDiscussion() = runTest {
+    val (acc, discussion) = viewModels[0].createDiscussion("Test", "", account1)
+    account1 = acc
+    var updated = viewModels[1].addUserToDiscussion(discussion, account1, account2)
+    updated = viewModels[2].removeUserFromDiscussion(updated, account1, account2)
+    val getDiscussion = viewModels[3].getDiscussion(updated.uid)
+
+    assertEquals(updated.uid, getDiscussion.uid)
+    assertFalse(getDiscussion.participants.contains(account2.uid))
+  }
+
+  @Test(expected = PermissionDeniedException::class)
+  fun nonAdminCannotRemoveUserFromDiscussion() = runTest {
+    val (acc, discussion) = viewModels[0].createDiscussion("Test", "", account1)
+    account1 = acc
+    var updated = viewModels[1].addUsersToDiscussion(discussion, account1, account2, account3)
+    viewModels[2].removeUserFromDiscussion(updated, account2, account3)
+  }
+
+  @Test(expected = PermissionDeniedException::class)
+  fun nonOwnerCannotRemoveUserFromDiscussion() = runTest {
+    val (acc, discussion) = viewModels[0].createDiscussion("Test", "", account1)
+    account1 = acc
+    var updated = viewModels[1].addUsersToDiscussion(discussion, account1, account2, account3)
+    updated = viewModels[2].addAdminToDiscussion(updated, account1, account2)
+    viewModels[3].removeUserFromDiscussion(updated, account2, account1)
+  }
+
+  @Test
+  fun canRemoveUsersFromDiscussion() = runTest {
+    val (acc, discussion) = viewModels[0].createDiscussion("Test", "", account1)
+    account1 = acc
+    var updated = viewModels[1].addUsersToDiscussion(discussion, account1, account2, account3)
+    updated = viewModels[2].removeUsersFromDiscussion(updated, account1, account2, account3)
+    val getDiscussion = viewModels[3].getDiscussion(updated.uid)
+
+    assertEquals(updated.uid, getDiscussion.uid)
+    assertFalse(getDiscussion.participants.contains(account2.uid))
+    assertFalse(getDiscussion.participants.contains(account3.uid))
+  }
+
+  @Test(expected = PermissionDeniedException::class)
+  fun nonAdminCannotRemoveUsersFromDiscussion() = runTest {
+    val (acc, discussion) = viewModels[0].createDiscussion("Test", "", account1)
+    account1 = acc
+    val updated = viewModels[1].addUsersToDiscussion(discussion, account1, account2, account3)
+    viewModels[2].removeUsersFromDiscussion(updated, account2, account3)
+  }
+
+  @Test(expected = PermissionDeniedException::class)
+  fun cannotRemoveOwnerFromDiscussion() = runTest {
+    val (acc, discussion) = viewModels[0].createDiscussion("Test", "", account1)
+    account1 = acc
+    val updated = viewModels[1].addUsersToDiscussion(discussion, account1, account2, account3)
+    viewModels[2].removeUsersFromDiscussion(updated, account2, account1, account3)
+  }
+
+  @Test
+  fun canRemoveAdminFromDiscussion() = runTest {
+    val (acc, discussion) = viewModels[0].createDiscussion("Test", "", account1)
+    account1 = acc
+    var updated = viewModels[1].addAdminToDiscussion(discussion, account1, account2)
+    updated = viewModels[2].removeAdminToDiscussion(updated, account1, account2)
+    val getDiscussion = viewModels[3].getDiscussion(updated.uid)
+
+    assertEquals(updated.uid, getDiscussion.uid)
+    assertTrue(getDiscussion.participants.contains(account2.uid))
+    assertFalse(getDiscussion.admins.contains(account2.uid))
+  }
+
+  @Test(expected = PermissionDeniedException::class)
+  fun nonAdminCannotRemoveAdminFromDiscussion() = runTest {
+    val (acc, discussion) = viewModels[0].createDiscussion("Test", "", account1)
+    account1 = acc
+    var updated = viewModels[1].addUsersToDiscussion(discussion, account1, account2, account3)
+    updated = viewModels[2].addAdminToDiscussion(updated, account1, account2)
+    viewModels[3].removeAdminToDiscussion(updated, account3, account2)
+  }
+
+  @Test
+  fun canRemoveAdminsFromDiscussion() = runTest {
+    val (acc, discussion) = viewModels[0].createDiscussion("Test", "", account1)
+    account1 = acc
+    var updated = viewModels[1].addAdminsToDiscussion(discussion, account1, account2, account3)
+    updated = viewModels[2].removeAdminsToDiscussion(updated, account1, account2, account3)
+    val getDiscussion = viewModels[3].getDiscussion(updated.uid)
+
+    assertEquals(updated.uid, getDiscussion.uid)
+    assertTrue(getDiscussion.participants.contains(account2.uid))
+    assertTrue(getDiscussion.participants.contains(account3.uid))
+    assertFalse(getDiscussion.admins.contains(account2.uid))
+    assertFalse(getDiscussion.admins.contains(account3.uid))
+  }
+
+  @Test(expected = PermissionDeniedException::class)
+  fun nonAdminCannotRemoveAdminsFromDiscussion() = runTest {
+    val (acc, discussion) = viewModels[0].createDiscussion("Test", "", account1)
+    account1 = acc
+    var updated = viewModels[1].addUsersToDiscussion(discussion, account1, account2, account3)
+    updated = viewModels[2].addAdminToDiscussion(updated, account1, account2)
+    viewModels[3].removeAdminsToDiscussion(updated, account3, account2)
   }
 }

--- a/app/src/main/java/com/github/meeplemeet/model/structures/Discussion.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/structures/Discussion.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.Serializable
  *
  * @property uid Globally unique identifier of the discussion (Firestore document ID).
  * @property name Human-readable title of the discussion.
+ * @property creatorId The unique identifier of the account that created this discussion
  * @property description Optional textual description of the discussion.
  * @property messages Ordered list of messages sent in the discussion.
  * @property participants List of account UIDs participating in this discussion.
@@ -16,6 +17,7 @@ import kotlinx.serialization.Serializable
  */
 data class Discussion(
     val uid: String,
+    val creatorId: String,
     val name: String,
     val description: String = "",
     val messages: List<Message> = emptyList(),
@@ -31,6 +33,7 @@ data class Discussion(
  */
 @Serializable
 data class DiscussionNoUid(
+    val creatorId: String = "",
     val name: String = "",
     val description: String = "",
     val messages: List<Message> = emptyList(),
@@ -47,6 +50,7 @@ data class DiscussionNoUid(
  */
 fun toNoUid(discussion: Discussion): DiscussionNoUid =
     DiscussionNoUid(
+        discussion.creatorId,
         discussion.name,
         discussion.description,
         discussion.messages,
@@ -64,6 +68,7 @@ fun toNoUid(discussion: Discussion): DiscussionNoUid =
 fun fromNoUid(id: String, discussionNoUid: DiscussionNoUid): Discussion =
     Discussion(
         id,
+        discussionNoUid.creatorId,
         discussionNoUid.name,
         discussionNoUid.description,
         discussionNoUid.messages,

--- a/app/src/main/java/com/github/meeplemeet/model/viewmodels/FirestoreViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/viewmodels/FirestoreViewModel.kt
@@ -74,8 +74,8 @@ class FirestoreViewModel(
 
   /** Delete a discussion (admin-only). */
   suspend fun deleteDiscussion(discussion: Discussion, changeRequester: Account) {
-    if (!isAdmin(changeRequester, discussion))
-        throw PermissionDeniedException("Only discussion admins can perform this operation")
+    if (discussion.creatorId != changeRequester.uid)
+        throw PermissionDeniedException("Only discussion owner can perform this operation")
     repository.deleteDiscussion(discussion.uid)
   }
 
@@ -90,6 +90,20 @@ class FirestoreViewModel(
     throw PermissionDeniedException("Only discussion admins can perform this operation")
   }
 
+  /** Remove a user from a discussion (admin-only). */
+  suspend fun removeUserFromDiscussion(
+      discussion: Discussion,
+      changeRequester: Account,
+      user: Account
+  ): Discussion {
+    if (isAdmin(changeRequester, discussion)) {
+      if (discussion.creatorId != changeRequester.uid)
+          throw PermissionDeniedException("Only discussion owner can perform this operation")
+      return repository.removeUserFromDiscussion(discussion, user.uid)
+    }
+    throw PermissionDeniedException("Only discussion admins can perform this operation")
+  }
+
   /** Add multiple users (admin-only). */
   suspend fun addUsersToDiscussion(
       discussion: Discussion,
@@ -98,6 +112,20 @@ class FirestoreViewModel(
   ): Discussion {
     if (isAdmin(changeRequester, discussion))
         return repository.addUsersToDiscussion(discussion, users.map { it.uid })
+    throw PermissionDeniedException("Only discussion admins can perform this operation")
+  }
+
+  /** Remove multiple users (admin-only). */
+  suspend fun removeUsersFromDiscussion(
+      discussion: Discussion,
+      changeRequester: Account,
+      vararg users: Account
+  ): Discussion {
+    if (isAdmin(changeRequester, discussion)) {
+      if (users.any { user -> discussion.creatorId == user.uid })
+          throw PermissionDeniedException("Only discussion owner can perform this operation")
+      return repository.removeUsersFromDiscussion(discussion, users.map { it.uid })
+    }
     throw PermissionDeniedException("Only discussion admins can perform this operation")
   }
 
@@ -112,6 +140,17 @@ class FirestoreViewModel(
     throw PermissionDeniedException("Only discussion admins can perform this operation")
   }
 
+  /** Remove a single admin (admin-only). */
+  suspend fun removeAdminToDiscussion(
+      discussion: Discussion,
+      changeRequester: Account,
+      admin: Account
+  ): Discussion {
+    if (isAdmin(changeRequester, discussion))
+        return repository.removeAdminFromDiscussion(discussion, admin.uid)
+    throw PermissionDeniedException("Only discussion admins can perform this operation")
+  }
+
   /** Add multiple admins (admin-only). */
   suspend fun addAdminsToDiscussion(
       discussion: Discussion,
@@ -120,6 +159,17 @@ class FirestoreViewModel(
   ): Discussion {
     if (isAdmin(changeRequester, discussion))
         return repository.addAdminsToDiscussion(discussion, admins.map { it.uid })
+    throw PermissionDeniedException("Only discussion admins can perform this operation")
+  }
+
+  /** Remove multiple admins (admin-only). */
+  suspend fun removeAdminsToDiscussion(
+      discussion: Discussion,
+      changeRequester: Account,
+      vararg admins: Account
+  ): Discussion {
+    if (isAdmin(changeRequester, discussion))
+        return repository.removeAdminsFromDiscussion(discussion, admins.map { it.uid })
     throw PermissionDeniedException("Only discussion admins can perform this operation")
   }
 


### PR DESCRIPTION
Add creatorId field to Discussion model to track the discussion owner, enabling owner-only operations such as deleting discussions and removing participants. Implement methods for removing users and admins from discussions with appropriate permission checks. Additionally, optimise the sendMessage operation to use batch writes for atomic updates to discussion messages and participant previews.