### PR TITLE
Add DiscussionScreen UI and Tests

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/model/ui/DiscussionScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/model/ui/DiscussionScreenTest.kt
@@ -1,0 +1,222 @@
+package com.github.meeplemeet.ui
+
+import android.text.format.DateFormat
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.github.meeplemeet.model.structures.*
+import com.github.meeplemeet.model.systems.FirestoreRepository
+import com.github.meeplemeet.model.viewmodels.FirestoreViewModel
+import com.github.meeplemeet.ui.navigation.NavigationActions
+import com.google.firebase.Timestamp
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.verify
+import java.util.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DiscussionScreenTest {
+
+  /** Compose test rule to run UI tests */
+  @get:Rule val composeTestRule = createComposeRule()
+
+  /** Mocked Firestore repository */
+  private lateinit var repository: FirestoreRepository
+
+  /** Real ViewModel instance under test */
+  private lateinit var viewModel: FirestoreViewModel
+
+  /** Mocked navigation actions for UI testing */
+  private lateinit var mockNavigation: NavigationActions
+
+  /** Current user for discussion tests */
+  private lateinit var currentUser: Account
+
+  /** Coroutine test scope */
+  private lateinit var testScope: TestScope
+
+  /** Fully initialized safe discussion used for all tests */
+  private lateinit var safeDiscussion: Discussion
+
+  /**
+   * Setup method executed before each test Initializes the repository, ViewModel, navigation, and
+   * safe discussion Injects safe discussion into the ViewModel's internal flow to prevent NPEs
+   */
+  @Before
+  fun setup() {
+    val dispatcher = StandardTestDispatcher()
+    testScope = TestScope(dispatcher)
+
+    repository = mockk(relaxed = true)
+    mockNavigation = mockk(relaxed = true)
+    currentUser = Account(uid = "user1", name = "Alice")
+
+    val messages =
+        listOf(
+            Message("user1", "Hi there!", Timestamp(Date())),
+            Message("user2", "Hey Alice!", Timestamp(Date())))
+    val participants = listOf(currentUser.uid, "user2")
+
+    safeDiscussion =
+        Discussion(
+            uid = "disc1",
+            name = "Test Discussion",
+            messages = messages,
+            participants = participants,
+            creatorId = currentUser.uid)
+
+    coEvery { repository.getDiscussion("disc1") } returns safeDiscussion
+
+    viewModel = FirestoreViewModel(repository)
+
+    val discussionFlowsField = viewModel::class.java.getDeclaredField("discussionFlows")
+    discussionFlowsField.isAccessible = true
+    @Suppress("UNCHECKED_CAST")
+    val map =
+        discussionFlowsField.get(viewModel) as MutableMap<String, MutableStateFlow<Discussion>>
+    map["disc1"] = MutableStateFlow(safeDiscussion)
+  }
+
+  // ---------- UNIT TESTS ----------
+
+  /** Tests that isSameDay returns true for two dates on the same day */
+  @Test
+  fun isSameDay_returns_true_for_same_day() {
+    val cal1 = Calendar.getInstance().apply { set(2025, 0, 1) }
+    val cal2 = Calendar.getInstance().apply { set(2025, 0, 1) }
+    assertTrue(isSameDay(cal1, cal2))
+  }
+
+  /** Tests that isSameDay returns false for dates on different days */
+  @Test
+  fun isSameDay_returns_false_for_different_days() {
+    val cal1 = Calendar.getInstance().apply { set(2025, 0, 1) }
+    val cal2 = Calendar.getInstance().apply { set(2025, 0, 2) }
+    assertFalse(isSameDay(cal1, cal2))
+  }
+
+  /** Tests that shouldShowDateHeader returns true if previous date is null */
+  @Test
+  fun shouldShowDateHeader_returns_true_when_previous_is_null() {
+    val now = Date()
+    assertTrue(shouldShowDateHeader(now, null))
+  }
+
+  /** Tests that shouldShowDateHeader returns false for messages on the same day */
+  @Test
+  fun shouldShowDateHeader_returns_false_for_same_day() {
+    val now = Date()
+    val laterSameDay = Date(now.time + 1000 * 60)
+    assertFalse(shouldShowDateHeader(now, laterSameDay))
+  }
+
+  /** Tests that shouldShowDateHeader returns true for messages on different days */
+  @Test
+  fun shouldShowDateHeader_returns_true_for_different_days() {
+    val now = Calendar.getInstance().apply { set(2025, 0, 1) }.time
+    val nextDay = Calendar.getInstance().apply { set(2025, 0, 2) }.time
+    assertTrue(shouldShowDateHeader(nextDay, now))
+  }
+
+  /** Tests that formatDateBubble returns "Today" for today's date */
+  @Test
+  fun formatDateBubble_returns_Today_for_todays_date() {
+    val today = Date()
+    assertEquals("Today", formatDateBubble(today))
+  }
+
+  /** Tests that formatDateBubble returns "Yesterday" for yesterday's date */
+  @Test
+  fun formatDateBubble_returns_Yesterday_for_yesterdays_date() {
+    val yesterday = Calendar.getInstance().apply { add(Calendar.DAY_OF_YEAR, -1) }.time
+    assertEquals("Yesterday", formatDateBubble(yesterday))
+  }
+
+  /** Tests that formatDateBubble formats older dates correctly */
+  @Test
+  fun formatDateBubble_returns_formatted_date_for_older_date() {
+    val date = Calendar.getInstance().apply { set(2020, 0, 1) }.time
+    val expected = DateFormat.format("MMM dd, yyyy", date).toString()
+    assertEquals(expected, formatDateBubble(date))
+  }
+
+  // ---------- COMPOSE UI TESTS ----------
+
+  /** Tests that DiscussionScreen displays discussion title and messages */
+  @Test
+  fun discussionScreen_displays_messages_and_title() {
+    composeTestRule.setContent {
+      DiscussionScreen(
+          viewModel = viewModel,
+          discussionId = "disc1",
+          currentUser = currentUser,
+          navigation = mockNavigation)
+    }
+
+    composeTestRule.onNodeWithText("Test Discussion").assertExists()
+    composeTestRule.onNodeWithText("Hi there!").assertExists()
+    composeTestRule.onNodeWithText("Hey Alice!").assertExists()
+  }
+
+  /** Tests that the send button clears the text field after sending a message */
+  @Test
+  fun sendButton_clears_text_field_after_sending() = runTest {
+    composeTestRule.setContent {
+      DiscussionScreen(
+          viewModel = viewModel,
+          discussionId = "disc1",
+          currentUser = currentUser,
+          navigation = mockNavigation)
+    }
+
+    val textField = composeTestRule.onNodeWithText("Type something...")
+    val sendButton = composeTestRule.onNodeWithContentDescription("Send")
+
+    textField.performTextInput("Hello!")
+    sendButton.performClick()
+
+    composeTestRule.onNodeWithText("Type something...").assertExists()
+  }
+
+  /** Tests that pressing the back button calls navigation.goBack */
+  @Test
+  fun backButton_calls_navigation_goBack() {
+    composeTestRule.setContent {
+      DiscussionScreen(
+          viewModel = viewModel,
+          discussionId = "disc1",
+          currentUser = currentUser,
+          navigation = mockNavigation)
+    }
+
+    composeTestRule.onNodeWithContentDescription("Back").performClick()
+    verify { mockNavigation.goBack() }
+  }
+
+  /** Tests that ChatBubble displays the message and sender name correctly */
+  @Test
+  fun chatBubble_displays_message_and_sender() {
+    val msg = Message("user2", "Hey!", Timestamp.now())
+    composeTestRule.setContent { ChatBubble(message = msg, isMine = false, senderName = "Bob") }
+
+    composeTestRule.onNodeWithText("Hey!").assertExists()
+    composeTestRule.onNodeWithText("Bob").assertExists()
+  }
+
+  /** Tests that DateSeparator displays the formatted date correctly */
+  @Test
+  fun dateSeparator_displays_formatted_date() {
+    val date = Calendar.getInstance().apply { set(2025, 0, 1) }.time
+    composeTestRule.setContent { DateSeparator(date = date) }
+
+    composeTestRule.onNodeWithText(formatDateBubble(date)).assertExists()
+  }
+}

--- a/app/src/main/java/com/github/meeplemeet/ui/DiscussionScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/DiscussionScreen.kt
@@ -1,278 +1,231 @@
 package com.github.meeplemeet.ui
 
+import android.text.format.DateFormat
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.AttachFile
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Send
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.github.meeplemeet.model.structures.Account
 import com.github.meeplemeet.model.structures.Message
 import com.github.meeplemeet.model.viewmodels.FirestoreViewModel
-import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.launch
-import android.text.format.DateFormat
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.filled.AttachFile
-import androidx.compose.material.icons.filled.Search
-import androidx.compose.material.icons.filled.Send
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.draw.shadow
+import com.github.meeplemeet.ui.navigation.NavigationActions
 import java.util.Calendar
 import java.util.Date
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DiscussionScreen(
     viewModel: FirestoreViewModel,
     discussionId: String,
-    currentUser: Account
+    currentUser: Account,
+    navigation: NavigationActions
 ) {
-    val scope = rememberCoroutineScope()
-    var messageText by remember { mutableStateOf("") }
-    val messages = remember { mutableStateListOf<Message>() }
-    val listState = rememberLazyListState()
-    var isSending by remember { mutableStateOf(false) }
-    var discussionName by remember { mutableStateOf("Loading...") }
-    val userCache = remember { mutableStateMapOf<String, Account>() }
+  val scope = rememberCoroutineScope()
+  var messageText by remember { mutableStateOf("") }
+  val messages = remember { mutableStateListOf<Message>() }
+  val listState = rememberLazyListState()
+  var isSending by remember { mutableStateOf(false) }
+  var discussionName by remember { mutableStateOf("Loading...") }
+  val userCache = remember { mutableStateMapOf<String, Account>() }
 
-    LaunchedEffect(discussionId) {
-        viewModel.discussionFlow(discussionId).collectLatest { discussion ->
-            discussion?.messages?.let { msgs ->
-                messages.clear()
-                messages.addAll(msgs)
-                scope.launch {
-                    listState.animateScrollToItem(messages.size)
-                }
-                msgs.forEach { msg ->
-                    if (!userCache.containsKey(msg.senderId) && msg.senderId != currentUser.uid) {
-                        try {
-                            val account = viewModel.getAccount(msg.senderId)
-                            userCache[msg.senderId] = account
-                        } catch (_: Exception) { }
-                    }
-                }
-                discussionName = discussion?.name ?: "Loading..."
-            }
+  LaunchedEffect(discussionId) {
+    viewModel.discussionFlow(discussionId).collectLatest { discussion ->
+      discussion?.messages?.let { msgs ->
+        messages.clear()
+        messages.addAll(msgs)
+        scope.launch { listState.animateScrollToItem(messages.size) }
+        msgs.forEach { msg ->
+          if (!userCache.containsKey(msg.senderId) && msg.senderId != currentUser.uid) {
+            try {
+              val account = viewModel.getAccount(msg.senderId)
+              userCache[msg.senderId] = account
+            } catch (_: Exception) {}
+          }
         }
+        discussionName = discussion?.name ?: "Loading..."
+      }
     }
+  }
 
-    Column(
-        modifier = Modifier.fillMaxSize()
-    ) {
-        TopAppBar(
-            title = {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Box(
-                        modifier = Modifier
-                            .size(40.dp)
-                            .background(Color.Gray, shape = CircleShape)
-                    )
-                    Spacer(Modifier.width(8.dp))
-                    Text(text = discussionName, style = MaterialTheme.typography.titleMedium)
-                }
-            },
-            navigationIcon = {
-                IconButton(onClick = { /* TODO GO BACK */ }) {
-                    Icon(Icons.Filled.ArrowBack, contentDescription = "Back")
-                }
-            },
-            actions = {
-                IconButton(onClick = { }) {
-                    Icon(Icons.Default.Search, contentDescription = "Search")
-                }
-            }
-        )
+  Column(modifier = Modifier.fillMaxSize()) {
+    TopAppBar(
+        title = {
+          Row(verticalAlignment = Alignment.CenterVertically) {
+            Box(modifier = Modifier.size(40.dp).background(Color.Gray, shape = CircleShape))
+            Spacer(Modifier.width(8.dp))
+            Text(text = discussionName, style = MaterialTheme.typography.titleMedium)
+          }
+        },
+        navigationIcon = {
+          IconButton(onClick = { navigation.goBack() }) {
+            Icon(Icons.Filled.ArrowBack, contentDescription = "Back")
+          }
+        },
+        actions = {
+          IconButton(onClick = {}) { Icon(Icons.Default.Search, contentDescription = "Search") }
+        })
 
-        LazyColumn(
-            state = listState,
-            modifier = Modifier
-                .weight(1f)
-                .fillMaxWidth(),
-            contentPadding = PaddingValues(8.dp),
-            verticalArrangement = Arrangement.spacedBy(10.dp)
-        ) {
-            itemsIndexed(messages) { index, message ->
-                val isMine = message.senderId == currentUser.uid
-                val sender = if (!isMine) userCache[message.senderId]?.name ?: "Unknown" else "You"
+    LazyColumn(
+        state = listState,
+        modifier = Modifier.weight(1f).fillMaxWidth(),
+        contentPadding = PaddingValues(8.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp)) {
+          itemsIndexed(messages) { index, message ->
+            val isMine = message.senderId == currentUser.uid
+            val sender = if (!isMine) userCache[message.senderId]?.name ?: "Unknown" else "You"
 
-                val showDateHeader = shouldShowDateHeader(
+            val showDateHeader =
+                shouldShowDateHeader(
                     current = message.createdAt.toDate(),
-                    previous = messages.getOrNull(index - 1)?.createdAt?.toDate()
-                )
-                if (showDateHeader) {
-                    DateSeparator(date = message.createdAt.toDate())
-                }
-
-                ChatBubble(message, isMine, sender)
+                    previous = messages.getOrNull(index - 1)?.createdAt?.toDate())
+            if (showDateHeader) {
+              DateSeparator(date = message.createdAt.toDate())
             }
+
+            ChatBubble(message, isMine, sender)
+          }
         }
 
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
+    Row(
+        modifier =
+            Modifier.fillMaxWidth()
                 .padding(8.dp)
                 .background(Color(0xFFF0F0F0), shape = CircleShape)
                 .padding(horizontal = 12.dp, vertical = 4.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            IconButton(onClick = { }) {
-                Icon(Icons.Default.AttachFile, contentDescription = "Attach")
-            }
-            Spacer(Modifier.width(8.dp))
-            BasicTextField(
-                value = messageText,
-                onValueChange = { messageText = it },
-                modifier = Modifier.weight(1f),
-                singleLine = true,
-                decorationBox = { innerTextField ->
-                    if (messageText.isEmpty()) {
-                        Text("Type something...", color = Color.Gray)
-                    }
-                    innerTextField()
+        verticalAlignment = Alignment.CenterVertically) {
+          IconButton(onClick = {}) { Icon(Icons.Default.AttachFile, contentDescription = "Attach") }
+          Spacer(Modifier.width(8.dp))
+          BasicTextField(
+              value = messageText,
+              onValueChange = { messageText = it },
+              modifier = Modifier.weight(1f),
+              singleLine = true,
+              decorationBox = { innerTextField ->
+                if (messageText.isEmpty()) {
+                  Text("Type something...", color = Color.Gray)
                 }
-            )
-            Spacer(Modifier.width(8.dp))
-            IconButton(
-                onClick = {
-                    if (messageText.isNotBlank() && !isSending) {
-                        scope.launch {
-                            isSending = true
-                            try {
-                                viewModel.sendMessageToDiscussion(
-                                    viewModel.getDiscussion(discussionId),
-                                    currentUser,
-                                    messageText
-                                )
-                                messageText = ""
-                            } finally {
-                                isSending = false
-                            }
-                        }
+                innerTextField()
+              })
+          Spacer(Modifier.width(8.dp))
+          IconButton(
+              onClick = {
+                if (messageText.isNotBlank() && !isSending) {
+                  scope.launch {
+                    isSending = true
+                    try {
+                      viewModel.sendMessageToDiscussion(
+                          viewModel.getDiscussion(discussionId), currentUser, messageText)
+                      messageText = ""
+                    } finally {
+                      isSending = false
                     }
-                },
-                enabled = !isSending
-            ) {
+                  }
+                }
+              },
+              enabled = !isSending) {
                 Icon(Icons.Default.Send, contentDescription = "Send")
-            }
+              }
         }
-    }
+  }
 }
 
 @Composable
 fun ChatBubble(message: Message, isMine: Boolean, senderName: String?) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = if (isMine) Arrangement.End else Arrangement.Start
-    ) {
+  Row(
+      modifier = Modifier.fillMaxWidth(),
+      horizontalArrangement = if (isMine) Arrangement.End else Arrangement.Start) {
         if (!isMine) {
-            Box(
-                modifier = Modifier
-                    .size(32.dp)
-                    .background(Color.Gray, shape = CircleShape)
-            )
-            Spacer(Modifier.width(6.dp))
+          Box(modifier = Modifier.size(32.dp).background(Color.Gray, shape = CircleShape))
+          Spacer(Modifier.width(6.dp))
         }
 
-        Column(
-            horizontalAlignment = if (isMine) Alignment.End else Alignment.Start
-        ) {
-            Box(
-                modifier = Modifier
-                    .shadow(
-                        elevation = 4.dp,
-                        shape = RoundedCornerShape(12.dp),
-                        clip = false
-                    )
-                    .background(
-                        color = Color(0xFFe0e0e0),
-                        shape = RoundedCornerShape(12.dp)
-                    )
-                    .padding(10.dp)
-                    .widthIn(max = 250.dp)
-            ) {
+        Column(horizontalAlignment = if (isMine) Alignment.End else Alignment.Start) {
+          Box(
+              modifier =
+                  Modifier.shadow(elevation = 4.dp, shape = RoundedCornerShape(12.dp), clip = false)
+                      .background(color = Color(0xFFe0e0e0), shape = RoundedCornerShape(12.dp))
+                      .padding(10.dp)
+                      .widthIn(max = 250.dp)) {
                 Column {
-                    if (senderName != null) {
-                        Text(
-                            senderName,
-                            style = MaterialTheme.typography.labelSmall.copy(color = Color.Black)
-                        )
-                        Spacer(Modifier.height(2.dp))
-                    }
+                  if (senderName != null) {
                     Text(
-                        message.content,
-                        style = MaterialTheme.typography.bodyMedium.copy(color = Color.Black)
-                    )
+                        senderName,
+                        style = MaterialTheme.typography.labelSmall.copy(color = Color.Black))
+                    Spacer(Modifier.height(2.dp))
+                  }
+                  Text(
+                      message.content,
+                      style = MaterialTheme.typography.bodyMedium.copy(color = Color.Black))
                 }
-            }
+              }
 
-            Text(
-                text = DateFormat.format("HH:mm", message.createdAt.toDate()).toString(),
-                style = MaterialTheme.typography.labelSmall.copy(color = Color(0xFF888888)),
-                modifier = Modifier
-                    .padding(top = 2.dp)
-                    .align(if (isMine) Alignment.End else Alignment.Start)
-            )
+          Text(
+              text = DateFormat.format("HH:mm", message.createdAt.toDate()).toString(),
+              style = MaterialTheme.typography.labelSmall.copy(color = Color(0xFF888888)),
+              modifier =
+                  Modifier.padding(top = 2.dp)
+                      .align(if (isMine) Alignment.End else Alignment.Start))
         }
 
         if (isMine) {
-            Spacer(Modifier.width(6.dp))
-            Box(
-                modifier = Modifier
-                    .size(32.dp)
-                    .background(Color.Gray, shape = CircleShape)
-            )
+          Spacer(Modifier.width(6.dp))
+          Box(modifier = Modifier.size(32.dp).background(Color.Gray, shape = CircleShape))
         }
-    }
+      }
 }
 
 @Composable
 fun DateSeparator(date: Date) {
-    Box(
-        modifier = Modifier
-            .fillMaxWidth(),
-        contentAlignment = Alignment.Center
-    ) {
-        Text(
-            text = formatDateBubble(date),
-            color = Color.White,
-            modifier = Modifier
-                .background(Color(0xFF9E9E9E), shape = RoundedCornerShape(50))
+  Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+    Text(
+        text = formatDateBubble(date),
+        color = Color.White,
+        modifier =
+            Modifier.background(Color(0xFF9E9E9E), shape = RoundedCornerShape(50))
                 .padding(horizontal = 12.dp, vertical = 4.dp),
-            style = MaterialTheme.typography.labelMedium
-        )
-    }
+        style = MaterialTheme.typography.labelMedium)
+  }
 }
 
 fun formatDateBubble(date: Date): String {
-    val cal = Calendar.getInstance()
-    val today = Calendar.getInstance()
-    cal.time = date
+  val cal = Calendar.getInstance()
+  val today = Calendar.getInstance()
+  cal.time = date
 
-    return when {
-        isSameDay(cal, today) -> "Today"
-        isSameDay(cal, today.apply { add(Calendar.DAY_OF_YEAR, -1) }) -> "Yesterday"
-        else -> DateFormat.format("MMM dd, yyyy", date).toString()
-    }
+  return when {
+    isSameDay(cal, today) -> "Today"
+    isSameDay(cal, today.apply { add(Calendar.DAY_OF_YEAR, -1) }) -> "Yesterday"
+    else -> DateFormat.format("MMM dd, yyyy", date).toString()
+  }
 }
 
 fun shouldShowDateHeader(current: Date, previous: Date?): Boolean {
-    if (previous == null) return true
-    val calCurrent = Calendar.getInstance().apply { time = current }
-    val calPrev = Calendar.getInstance().apply { time = previous }
-    return !(calCurrent.get(Calendar.YEAR) == calPrev.get(Calendar.YEAR)
-            && calCurrent.get(Calendar.DAY_OF_YEAR) == calPrev.get(Calendar.DAY_OF_YEAR))
+  if (previous == null) return true
+  val calCurrent = Calendar.getInstance().apply { time = current }
+  val calPrev = Calendar.getInstance().apply { time = previous }
+  return !(calCurrent.get(Calendar.YEAR) == calPrev.get(Calendar.YEAR) &&
+      calCurrent.get(Calendar.DAY_OF_YEAR) == calPrev.get(Calendar.DAY_OF_YEAR))
 }
 
 fun isSameDay(cal1: Calendar, cal2: Calendar): Boolean {
-    return cal1.get(Calendar.YEAR) == cal2.get(Calendar.YEAR) &&
-            cal1.get(Calendar.DAY_OF_YEAR) == cal2.get(Calendar.DAY_OF_YEAR)
+  return cal1.get(Calendar.YEAR) == cal2.get(Calendar.YEAR) &&
+      cal1.get(Calendar.DAY_OF_YEAR) == cal2.get(Calendar.DAY_OF_YEAR)
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/DiscussionScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/DiscussionScreen.kt
@@ -1,294 +1,231 @@
 package com.github.meeplemeet.ui
 
-import android.text.format.DateFormat
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.automirrored.filled.Send
-import androidx.compose.material.icons.filled.AttachFile
-import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.github.meeplemeet.model.structures.Account
 import com.github.meeplemeet.model.structures.Message
 import com.github.meeplemeet.model.viewmodels.FirestoreViewModel
-import com.github.meeplemeet.ui.navigation.NavigationActions
-import com.github.meeplemeet.ui.theme.AppColors
-import com.github.meeplemeet.ui.theme.appShapes
-import java.util.Calendar
-import java.util.Date
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import android.text.format.DateFormat
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.filled.AttachFile
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Send
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.draw.shadow
 
-/**
- * Composable screen that displays a discussion (chat) and allows sending messages.
- *
- * Messages are collected from [FirestoreViewModel] via a [StateFlow] and displayed in a scrollable
- * list. Users are cached locally for display purposes.
- *
- * @param viewModel FirestoreViewModel for fetching discussion and sending messages
- * @param discussionId ID of the discussion to display
- * @param currentUser The currently logged-in user
- * @param navigation NavigationActions for handling navigation
- */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DiscussionScreen(
     viewModel: FirestoreViewModel,
     discussionId: String,
-    currentUser: Account,
-    navigation: NavigationActions
+    currentUser: Account
 ) {
-  val scope = rememberCoroutineScope()
-  var messageText by remember { mutableStateOf("") }
-  val messages = remember { mutableStateListOf<Message>() }
-  val listState = rememberLazyListState()
-  var isSending by remember { mutableStateOf(false) }
-  var discussionName by remember { mutableStateOf("Loading...") }
-  val userCache = remember { mutableStateMapOf<String, Account>() }
+    val scope = rememberCoroutineScope()
+    var messageText by remember { mutableStateOf("") }
+    val messages = remember { mutableStateListOf<Message>() }
+    val listState = rememberLazyListState()
+    var isSending by remember { mutableStateOf(false) }
+    var discussionName by remember { mutableStateOf("Loading...") }
 
-  /** Collect the discussion StateFlow as Compose state */
-  val discussion by viewModel.discussionFlow(discussionId).collectAsState()
+    val userCache = remember { mutableStateMapOf<String, Account>() }
 
-  /**
-   * Update messages list and user cache whenever the discussion changes.
-   *
-   * Scrolls to the last message automatically.
-   */
-  LaunchedEffect(discussion) {
-    discussion?.let { disc ->
-      messages.clear()
-      messages.addAll(disc.messages)
-      scope.launch { listState.animateScrollToItem(messages.size) }
-
-      disc.messages.forEach { msg ->
-        if (!userCache.containsKey(msg.senderId) && msg.senderId != currentUser.uid) {
-          try {
-            viewModel.getOtherAccount(msg.senderId) { account -> userCache[msg.senderId] = account }
-          } catch (_: Exception) {}
-        }
-      }
-
-      discussionName = disc.name
-    }
-  }
-
-  Column(modifier = Modifier.fillMaxSize().background(AppColors.primary)) {
-    /** Top bar showing discussion name and navigation back button */
-    TopAppBar(
-        title = {
-          Row(verticalAlignment = Alignment.CenterVertically) {
-            Box(
-                modifier =
-                    Modifier.size(40.dp).background(color = Color(0xFF800080), shape = CircleShape))
-            /** TODO: Placeholder for avatar */
-            Spacer(Modifier.width(8.dp))
-            Text(
-                text = discussionName,
-                style = MaterialTheme.typography.bodyMedium.copy(color = AppColors.textIcons))
-          }
-        },
-        navigationIcon = {
-          IconButton(onClick = { navigation.goBack() }) {
-            Icon(
-                Icons.AutoMirrored.Filled.ArrowBack,
-                contentDescription = "Back",
-                tint = AppColors.textIconsFade)
-          }
-        },
-        actions = {
-          IconButton(onClick = {}) { Icon(Icons.Default.Search, contentDescription = "Search") }
-        })
-
-    /** LazyColumn showing all messages with optional date separators */
-    LazyColumn(
-        state = listState,
-        modifier = Modifier.weight(1f).fillMaxWidth(),
-        contentPadding = PaddingValues(8.dp),
-        verticalArrangement = Arrangement.spacedBy(10.dp)) {
-          itemsIndexed(messages) { index, message ->
-            val isMine = message.senderId == currentUser.uid
-            val sender = if (!isMine) userCache[message.senderId]?.name ?: "Unknown" else "You"
-
-            val showDateHeader =
-                shouldShowDateHeader(
-                    current = message.createdAt.toDate(),
-                    previous = messages.getOrNull(index - 1)?.createdAt?.toDate())
-            if (showDateHeader) {
-              DateSeparator(date = message.createdAt.toDate())
-            }
-
-            ChatBubble(message, isMine, sender)
-          }
-        }
-
-    /** Input row at the bottom for typing messages */
-    Row(
-        modifier =
-            Modifier.fillMaxWidth()
-                .padding(8.dp)
-                .background(AppColors.secondary, shape = CircleShape)
-                .padding(horizontal = 12.dp, vertical = 4.dp),
-        verticalAlignment = Alignment.CenterVertically) {
-          IconButton(onClick = {}) {
-            Icon(
-                Icons.Default.AttachFile,
-                contentDescription = "Attach",
-                tint = AppColors.textIconsFade)
-          }
-          Spacer(Modifier.width(8.dp))
-
-          /** Text input field */
-          BasicTextField(
-              value = messageText,
-              onValueChange = { messageText = it },
-              modifier = Modifier.weight(1f),
-              singleLine = true,
-              decorationBox = { innerTextField ->
-                if (messageText.isEmpty()) {
-                  Text("Type something...", color = AppColors.textIconsFade)
+    LaunchedEffect(discussionId) {
+        viewModel.discussionFlow(discussionId).collectLatest { discussion ->
+            discussion?.messages?.let { msgs ->
+                messages.clear()
+                messages.addAll(msgs)
+                scope.launch {
+                    listState.animateScrollToItem(messages.size)
                 }
-                innerTextField()
-              })
-
-          Spacer(Modifier.width(8.dp))
-
-          /** Send button */
-          IconButton(
-              onClick = {
-                discussion?.let { disc ->
-                  if (messageText.isNotBlank() && !isSending) {
-                    scope.launch {
-                      isSending = true
-                      try {
-                        viewModel.sendMessageToDiscussion(disc, currentUser, messageText)
-                        messageText = ""
-                      } finally {
-                        isSending = false
-                      }
+                msgs.forEach { msg ->
+                    if (!userCache.containsKey(msg.senderId) && msg.senderId != currentUser.uid) {
+                        try {
+                            val account = viewModel.getAccount(msg.senderId)
+                            userCache[msg.senderId] = account
+                        } catch (_: Exception) { }
                     }
-                  }
                 }
-              },
-              enabled = !isSending) {
-                Icon(
-                    Icons.AutoMirrored.Filled.Send,
-                    contentDescription = "Send",
-                    tint = AppColors.textIconsFade)
-              }
+                discussionName = discussion?.name ?: "Loading..."
+            }
         }
-  }
+    }
+
+    Column(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        // Top bar with placeholder avatar
+        TopAppBar(
+            title = {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    // TODO Placeholder discussion picture
+                    Box(
+                        modifier = Modifier
+                            .size(40.dp)
+                            .background(Color.Gray, shape = CircleShape)
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text(text = discussionName, style = MaterialTheme.typography.titleMedium)
+                }
+            },
+            navigationIcon = {
+                IconButton(onClick = { /* TODO GO BACK */ }) {
+                    Icon(Icons.Filled.ArrowBack, contentDescription = "Back")
+                }
+            },
+            actions = {
+                IconButton(onClick = { /* TODO search later */ }) {
+                    Icon(Icons.Default.Search, contentDescription = "Search")
+                }
+            }
+        )
+
+        LazyColumn(
+            state = listState,
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth(),
+            contentPadding = PaddingValues(8.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            items(messages) { message ->
+                val isMine = message.senderId == currentUser.uid
+                val sender = if (!isMine) userCache[message.senderId]?.name ?: "Unknown" else  "You"
+                ChatBubble(message, isMine, sender)
+            }
+        }
+
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp)
+                .background(Color(0xFFF0F0F0), shape = CircleShape)
+                .padding(horizontal = 12.dp, vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(
+                onClick = {/*TODO ATTACH FILE*/ }) {
+            Icon(Icons.Default.AttachFile, contentDescription = "Attach")
+            }
+            Spacer(Modifier.width(8.dp))
+            BasicTextField(
+                value = messageText,
+                onValueChange = { messageText = it },
+                modifier = Modifier.weight(1f),
+                singleLine = true,
+                decorationBox = { innerTextField ->
+                    if (messageText.isEmpty()) {
+                        Text("Type something...", color = Color.Gray)
+                    }
+                    innerTextField()
+                }
+            )
+            Spacer(Modifier.width(8.dp))
+            IconButton(
+                onClick = {
+                    if (messageText.isNotBlank() && !isSending) {
+                        scope.launch {
+                            isSending = true
+                            try {
+                                viewModel.sendMessageToDiscussion(
+                                    viewModel.getDiscussion(discussionId),
+                                    currentUser,
+                                    messageText
+                                )
+                                messageText = ""
+                            } finally {
+                                isSending = false
+                            }
+                        }
+                    }
+                },
+                enabled = !isSending
+            ) {
+                Icon(Icons.Default.Send, contentDescription = "Send")
+            }
+        }
+    }
 }
 
-/**
- * A single message bubble in the chat.
- *
- * @param message Message to display
- * @param isMine True if the message belongs to the current user
- * @param senderName Name of the sender
- */
 @Composable
 fun ChatBubble(message: Message, isMine: Boolean, senderName: String?) {
-  Row(
-      modifier = Modifier.fillMaxWidth(),
-      horizontalArrangement = if (isMine) Arrangement.End else Arrangement.Start) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = if (isMine) Arrangement.End else Arrangement.Start
+    ) {
         if (!isMine) {
-          Box(modifier = Modifier.size(32.dp).background(Color(0xFF800080), shape = CircleShape))
-          /** TODO: Placeholder for avatar */
-          Spacer(Modifier.width(6.dp))
+            Box(
+                modifier = Modifier
+                    .size(32.dp)
+                    .background(Color.Gray, shape = CircleShape)
+            )
+            Spacer(Modifier.width(6.dp))
         }
 
-        Column(horizontalAlignment = if (isMine) Alignment.End else Alignment.Start) {
-          Box(
-              modifier =
-                  Modifier.shadow(elevation = 4.dp, shape = appShapes.large, clip = false)
-                      .background(color = AppColors.secondary, shape = appShapes.large)
-                      .padding(10.dp)
-                      .widthIn(max = 250.dp)) {
+        Column(
+            horizontalAlignment = if (isMine) Alignment.End else Alignment.Start
+        ) {
+            // The bubble with shadow
+            Box(
+                modifier = Modifier
+                    .shadow(
+                        elevation = 4.dp, // how “deep” the shadow is
+                        shape = RoundedCornerShape(12.dp),
+                        clip = false // allows shadow to appear outside bounds
+                    )
+                    .background(
+                        color = Color(0xFFe0e0e0),
+                        shape = RoundedCornerShape(12.dp)
+                    )
+                    .padding(10.dp)
+                    .widthIn(max = 250.dp) // optional max width
+            ) {
                 Column {
-                  if (senderName != null) {
+                    if (senderName != null) {
+                        Text(
+                            senderName,
+                            style = MaterialTheme.typography.labelSmall.copy(color = Color.Black)
+                        )
+                        Spacer(Modifier.height(2.dp))
+                    }
                     Text(
-                        senderName,
-                        style =
-                            MaterialTheme.typography.labelSmall.copy(
-                                color = AppColors.textIconsFade))
-                    Spacer(Modifier.height(2.dp))
-                  }
-                  Text(
-                      message.content,
-                      style =
-                          MaterialTheme.typography.bodySmall.copy(color = AppColors.textIconsFade))
+                        message.content,
+                        style = MaterialTheme.typography.bodyMedium.copy(color = Color.Black)
+                    )
                 }
-              }
-          Text(
-              text = DateFormat.format("HH:mm", message.createdAt.toDate()).toString(),
-              style = MaterialTheme.typography.labelSmall.copy(color = AppColors.textIconsFade),
-              modifier =
-                  Modifier.padding(top = 2.dp)
-                      .align(if (isMine) Alignment.End else Alignment.Start))
+            }
+
+            // Timestamp aligned to bubble end
+            Text(
+                text = DateFormat.format("HH:mm", message.createdAt.toDate()).toString(),
+                style = MaterialTheme.typography.labelSmall.copy(color = Color(0xFF888888)),
+                modifier = Modifier
+                    .padding(top = 2.dp)
+                    .align(if (isMine) Alignment.End else Alignment.Start)
+            )
         }
 
         if (isMine) {
-          Spacer(Modifier.width(6.dp))
-          Box(
-              modifier =
-                  Modifier.size(32.dp).background(color = Color(0xFF800080), shape = CircleShape))
-          /** TODO: Placeholder for avatar */
+            Spacer(Modifier.width(6.dp))
+            Box(
+                modifier = Modifier
+                    .size(32.dp)
+                    .background(Color.Gray, shape = CircleShape)
+            )
         }
-      }
-}
-
-/** Shows a date separator between messages. */
-@Composable
-fun DateSeparator(date: Date) {
-  Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-    Text(
-        text = formatDateBubble(date),
-        color = AppColors.textIconsFade,
-        modifier =
-            Modifier.background(AppColors.divider, shape = CircleShape)
-                .padding(horizontal = 12.dp, vertical = 4.dp),
-        style = MaterialTheme.typography.labelSmall)
-  }
-}
-
-/**
- * Formats a date for display in a date separator. Returns "Today", "Yesterday", or formatted date
- * string.
- */
-fun formatDateBubble(date: Date): String {
-  val cal = Calendar.getInstance()
-  val today = Calendar.getInstance()
-  cal.time = date
-
-  return when {
-    isSameDay(cal, today) -> "Today"
-    isSameDay(cal, today.apply { add(Calendar.DAY_OF_YEAR, -1) }) -> "Yesterday"
-    else -> DateFormat.format("MMM dd, yyyy", date).toString()
-  }
-}
-
-/** Determines whether a date header should be displayed between messages. */
-fun shouldShowDateHeader(current: Date, previous: Date?): Boolean {
-  if (previous == null) return true
-  val calCurrent = Calendar.getInstance().apply { time = current }
-  val calPrev = Calendar.getInstance().apply { time = previous }
-  return !(calCurrent.get(Calendar.YEAR) == calPrev.get(Calendar.YEAR) &&
-      calCurrent.get(Calendar.DAY_OF_YEAR) == calPrev.get(Calendar.DAY_OF_YEAR))
-}
-
-/** Checks if two Calendar instances represent the same day. */
-fun isSameDay(cal1: Calendar, cal2: Calendar): Boolean {
-  return cal1.get(Calendar.YEAR) == cal2.get(Calendar.YEAR) &&
-      cal1.get(Calendar.DAY_OF_YEAR) == cal2.get(Calendar.DAY_OF_YEAR)
+    }
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/DiscussionScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/DiscussionScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -25,6 +24,8 @@ import com.github.meeplemeet.model.structures.Account
 import com.github.meeplemeet.model.structures.Message
 import com.github.meeplemeet.model.viewmodels.FirestoreViewModel
 import com.github.meeplemeet.ui.navigation.NavigationActions
+import com.github.meeplemeet.ui.theme.AppColors
+import com.github.meeplemeet.ui.theme.appShapes
 import java.util.Calendar
 import java.util.Date
 import kotlinx.coroutines.launch
@@ -82,19 +83,27 @@ fun DiscussionScreen(
     }
   }
 
-  Column(modifier = Modifier.fillMaxSize()) {
+  Column(modifier = Modifier.fillMaxSize().background(AppColors.primary)) {
     /** Top bar showing discussion name and navigation back button */
     TopAppBar(
         title = {
           Row(verticalAlignment = Alignment.CenterVertically) {
-            Box(modifier = Modifier.size(40.dp).background(Color.Gray, shape = CircleShape))
+            Box(
+                modifier =
+                    Modifier.size(40.dp).background(color = Color(0xFF800080), shape = CircleShape))
+            /** TODO: Placeholder for avatar */
             Spacer(Modifier.width(8.dp))
-            Text(text = discussionName, style = MaterialTheme.typography.titleMedium)
+            Text(
+                text = discussionName,
+                style = MaterialTheme.typography.bodyMedium.copy(color = AppColors.textIcons))
           }
         },
         navigationIcon = {
           IconButton(onClick = { navigation.goBack() }) {
-            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+            Icon(
+                Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = "Back",
+                tint = AppColors.textIconsFade)
           }
         },
         actions = {
@@ -128,10 +137,15 @@ fun DiscussionScreen(
         modifier =
             Modifier.fillMaxWidth()
                 .padding(8.dp)
-                .background(Color(0xFFF0F0F0), shape = CircleShape)
+                .background(AppColors.secondary, shape = CircleShape)
                 .padding(horizontal = 12.dp, vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically) {
-          IconButton(onClick = {}) { Icon(Icons.Default.AttachFile, contentDescription = "Attach") }
+          IconButton(onClick = {}) {
+            Icon(
+                Icons.Default.AttachFile,
+                contentDescription = "Attach",
+                tint = AppColors.textIconsFade)
+          }
           Spacer(Modifier.width(8.dp))
 
           /** Text input field */
@@ -142,7 +156,7 @@ fun DiscussionScreen(
               singleLine = true,
               decorationBox = { innerTextField ->
                 if (messageText.isEmpty()) {
-                  Text("Type something...", color = Color.Gray)
+                  Text("Type something...", color = AppColors.textIconsFade)
                 }
                 innerTextField()
               })
@@ -167,7 +181,10 @@ fun DiscussionScreen(
                 }
               },
               enabled = !isSending) {
-                Icon(Icons.AutoMirrored.Filled.Send, contentDescription = "Send")
+                Icon(
+                    Icons.AutoMirrored.Filled.Send,
+                    contentDescription = "Send",
+                    tint = AppColors.textIconsFade)
               }
         }
   }
@@ -186,33 +203,36 @@ fun ChatBubble(message: Message, isMine: Boolean, senderName: String?) {
       modifier = Modifier.fillMaxWidth(),
       horizontalArrangement = if (isMine) Arrangement.End else Arrangement.Start) {
         if (!isMine) {
-          Box(modifier = Modifier.size(32.dp).background(Color.Gray, shape = CircleShape))
+          Box(modifier = Modifier.size(32.dp).background(Color(0xFF800080), shape = CircleShape))
+          /** TODO: Placeholder for avatar */
           Spacer(Modifier.width(6.dp))
         }
 
         Column(horizontalAlignment = if (isMine) Alignment.End else Alignment.Start) {
           Box(
               modifier =
-                  Modifier.shadow(elevation = 4.dp, shape = RoundedCornerShape(12.dp), clip = false)
-                      .background(color = Color(0xFFe0e0e0), shape = RoundedCornerShape(12.dp))
+                  Modifier.shadow(elevation = 4.dp, shape = appShapes.large, clip = false)
+                      .background(color = AppColors.secondary, shape = appShapes.large)
                       .padding(10.dp)
                       .widthIn(max = 250.dp)) {
                 Column {
                   if (senderName != null) {
                     Text(
                         senderName,
-                        style = MaterialTheme.typography.labelSmall.copy(color = Color.Black))
+                        style =
+                            MaterialTheme.typography.labelSmall.copy(
+                                color = AppColors.textIconsFade))
                     Spacer(Modifier.height(2.dp))
                   }
                   Text(
                       message.content,
-                      style = MaterialTheme.typography.bodyMedium.copy(color = Color.Black))
+                      style =
+                          MaterialTheme.typography.bodySmall.copy(color = AppColors.textIconsFade))
                 }
               }
-
           Text(
               text = DateFormat.format("HH:mm", message.createdAt.toDate()).toString(),
-              style = MaterialTheme.typography.labelSmall.copy(color = Color(0xFF888888)),
+              style = MaterialTheme.typography.labelSmall.copy(color = AppColors.textIconsFade),
               modifier =
                   Modifier.padding(top = 2.dp)
                       .align(if (isMine) Alignment.End else Alignment.Start))
@@ -220,7 +240,10 @@ fun ChatBubble(message: Message, isMine: Boolean, senderName: String?) {
 
         if (isMine) {
           Spacer(Modifier.width(6.dp))
-          Box(modifier = Modifier.size(32.dp).background(Color.Gray, shape = CircleShape))
+          Box(
+              modifier =
+                  Modifier.size(32.dp).background(color = Color(0xFF800080), shape = CircleShape))
+          /** TODO: Placeholder for avatar */
         }
       }
 }
@@ -231,11 +254,11 @@ fun DateSeparator(date: Date) {
   Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
     Text(
         text = formatDateBubble(date),
-        color = Color.White,
+        color = AppColors.textIconsFade,
         modifier =
-            Modifier.background(Color(0xFF9E9E9E), shape = RoundedCornerShape(50))
+            Modifier.background(AppColors.divider, shape = CircleShape)
                 .padding(horizontal = 12.dp, vertical = 4.dp),
-        style = MaterialTheme.typography.labelMedium)
+        style = MaterialTheme.typography.labelSmall)
   }
 }
 

--- a/app/src/main/java/com/github/meeplemeet/ui/DiscussionScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/DiscussionScreen.kt
@@ -1,0 +1,231 @@
+package com.github.meeplemeet.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.github.meeplemeet.model.structures.Account
+import com.github.meeplemeet.model.structures.Message
+import com.github.meeplemeet.model.viewmodels.FirestoreViewModel
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import android.text.format.DateFormat
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.filled.AttachFile
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Send
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.draw.shadow
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DiscussionScreen(
+    viewModel: FirestoreViewModel,
+    discussionId: String,
+    currentUser: Account
+) {
+    val scope = rememberCoroutineScope()
+    var messageText by remember { mutableStateOf("") }
+    val messages = remember { mutableStateListOf<Message>() }
+    val listState = rememberLazyListState()
+    var isSending by remember { mutableStateOf(false) }
+    var discussionName by remember { mutableStateOf("Loading...") }
+
+    val userCache = remember { mutableStateMapOf<String, Account>() }
+
+    LaunchedEffect(discussionId) {
+        viewModel.discussionFlow(discussionId).collectLatest { discussion ->
+            discussion?.messages?.let { msgs ->
+                messages.clear()
+                messages.addAll(msgs)
+                scope.launch {
+                    listState.animateScrollToItem(messages.size)
+                }
+                msgs.forEach { msg ->
+                    if (!userCache.containsKey(msg.senderId) && msg.senderId != currentUser.uid) {
+                        try {
+                            val account = viewModel.getAccount(msg.senderId)
+                            userCache[msg.senderId] = account
+                        } catch (_: Exception) { }
+                    }
+                }
+                discussionName = discussion?.name ?: "Loading..."
+            }
+        }
+    }
+
+    Column(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        // Top bar with placeholder avatar
+        TopAppBar(
+            title = {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    // TODO Placeholder discussion picture
+                    Box(
+                        modifier = Modifier
+                            .size(40.dp)
+                            .background(Color.Gray, shape = CircleShape)
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text(text = discussionName, style = MaterialTheme.typography.titleMedium)
+                }
+            },
+            navigationIcon = {
+                IconButton(onClick = { /* TODO GO BACK */ }) {
+                    Icon(Icons.Filled.ArrowBack, contentDescription = "Back")
+                }
+            },
+            actions = {
+                IconButton(onClick = { /* TODO search later */ }) {
+                    Icon(Icons.Default.Search, contentDescription = "Search")
+                }
+            }
+        )
+
+        LazyColumn(
+            state = listState,
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth(),
+            contentPadding = PaddingValues(8.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            items(messages) { message ->
+                val isMine = message.senderId == currentUser.uid
+                val sender = if (!isMine) userCache[message.senderId]?.name ?: "Unknown" else  "You"
+                ChatBubble(message, isMine, sender)
+            }
+        }
+
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp)
+                .background(Color(0xFFF0F0F0), shape = CircleShape)
+                .padding(horizontal = 12.dp, vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(
+                onClick = {/*TODO ATTACH FILE*/ }) {
+            Icon(Icons.Default.AttachFile, contentDescription = "Attach")
+            }
+            Spacer(Modifier.width(8.dp))
+            BasicTextField(
+                value = messageText,
+                onValueChange = { messageText = it },
+                modifier = Modifier.weight(1f),
+                singleLine = true,
+                decorationBox = { innerTextField ->
+                    if (messageText.isEmpty()) {
+                        Text("Type something...", color = Color.Gray)
+                    }
+                    innerTextField()
+                }
+            )
+            Spacer(Modifier.width(8.dp))
+            IconButton(
+                onClick = {
+                    if (messageText.isNotBlank() && !isSending) {
+                        scope.launch {
+                            isSending = true
+                            try {
+                                viewModel.sendMessageToDiscussion(
+                                    viewModel.getDiscussion(discussionId),
+                                    currentUser,
+                                    messageText
+                                )
+                                messageText = ""
+                            } finally {
+                                isSending = false
+                            }
+                        }
+                    }
+                },
+                enabled = !isSending
+            ) {
+                Icon(Icons.Default.Send, contentDescription = "Send")
+            }
+        }
+    }
+}
+
+@Composable
+fun ChatBubble(message: Message, isMine: Boolean, senderName: String?) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = if (isMine) Arrangement.End else Arrangement.Start
+    ) {
+        if (!isMine) {
+            Box(
+                modifier = Modifier
+                    .size(32.dp)
+                    .background(Color.Gray, shape = CircleShape)
+            )
+            Spacer(Modifier.width(6.dp))
+        }
+
+        Column(
+            horizontalAlignment = if (isMine) Alignment.End else Alignment.Start
+        ) {
+            // The bubble with shadow
+            Box(
+                modifier = Modifier
+                    .shadow(
+                        elevation = 4.dp, // how “deep” the shadow is
+                        shape = RoundedCornerShape(12.dp),
+                        clip = false // allows shadow to appear outside bounds
+                    )
+                    .background(
+                        color = Color(0xFFe0e0e0),
+                        shape = RoundedCornerShape(12.dp)
+                    )
+                    .padding(10.dp)
+                    .widthIn(max = 250.dp) // optional max width
+            ) {
+                Column {
+                    if (senderName != null) {
+                        Text(
+                            senderName,
+                            style = MaterialTheme.typography.labelSmall.copy(color = Color.Black)
+                        )
+                        Spacer(Modifier.height(2.dp))
+                    }
+                    Text(
+                        message.content,
+                        style = MaterialTheme.typography.bodyMedium.copy(color = Color.Black)
+                    )
+                }
+            }
+
+            // Timestamp aligned to bubble end
+            Text(
+                text = DateFormat.format("HH:mm", message.createdAt.toDate()).toString(),
+                style = MaterialTheme.typography.labelSmall.copy(color = Color(0xFF888888)),
+                modifier = Modifier
+                    .padding(top = 2.dp)
+                    .align(if (isMine) Alignment.End else Alignment.Start)
+            )
+        }
+
+        if (isMine) {
+            Spacer(Modifier.width(6.dp))
+            Box(
+                modifier = Modifier
+                    .size(32.dp)
+                    .background(Color.Gray, shape = CircleShape)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/github/meeplemeet/ui/DiscussionScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/DiscussionScreen.kt
@@ -1,271 +1,231 @@
 package com.github.meeplemeet.ui
 
-import android.text.format.DateFormat
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.automirrored.filled.Send
-import androidx.compose.material.icons.filled.AttachFile
-import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.github.meeplemeet.model.structures.Account
 import com.github.meeplemeet.model.structures.Message
 import com.github.meeplemeet.model.viewmodels.FirestoreViewModel
-import com.github.meeplemeet.ui.navigation.NavigationActions
-import java.util.Calendar
-import java.util.Date
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import android.text.format.DateFormat
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.filled.AttachFile
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Send
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.draw.shadow
 
-/**
- * Composable screen that displays a discussion (chat) and allows sending messages.
- *
- * Messages are collected from [FirestoreViewModel] via a [StateFlow] and displayed in a scrollable
- * list. Users are cached locally for display purposes.
- *
- * @param viewModel FirestoreViewModel for fetching discussion and sending messages
- * @param discussionId ID of the discussion to display
- * @param currentUser The currently logged-in user
- * @param navigation NavigationActions for handling navigation
- */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DiscussionScreen(
     viewModel: FirestoreViewModel,
     discussionId: String,
-    currentUser: Account,
-    navigation: NavigationActions
+    currentUser: Account
 ) {
-  val scope = rememberCoroutineScope()
-  var messageText by remember { mutableStateOf("") }
-  val messages = remember { mutableStateListOf<Message>() }
-  val listState = rememberLazyListState()
-  var isSending by remember { mutableStateOf(false) }
-  var discussionName by remember { mutableStateOf("Loading...") }
-  val userCache = remember { mutableStateMapOf<String, Account>() }
+    val scope = rememberCoroutineScope()
+    var messageText by remember { mutableStateOf("") }
+    val messages = remember { mutableStateListOf<Message>() }
+    val listState = rememberLazyListState()
+    var isSending by remember { mutableStateOf(false) }
+    var discussionName by remember { mutableStateOf("Loading...") }
 
-  /** Collect the discussion StateFlow as Compose state */
-  val discussion by viewModel.discussionFlow(discussionId).collectAsState()
+    val userCache = remember { mutableStateMapOf<String, Account>() }
 
-  /**
-   * Update messages list and user cache whenever the discussion changes.
-   *
-   * Scrolls to the last message automatically.
-   */
-  LaunchedEffect(discussion) {
-    discussion?.let { disc ->
-      messages.clear()
-      messages.addAll(disc.messages)
-      scope.launch { listState.animateScrollToItem(messages.size) }
-
-      disc.messages.forEach { msg ->
-        if (!userCache.containsKey(msg.senderId) && msg.senderId != currentUser.uid) {
-          try {
-            viewModel.getOtherAccount(msg.senderId) { account -> userCache[msg.senderId] = account }
-          } catch (_: Exception) {}
-        }
-      }
-
-      discussionName = disc.name
-    }
-  }
-
-  Column(modifier = Modifier.fillMaxSize()) {
-    /** Top bar showing discussion name and navigation back button */
-    TopAppBar(
-        title = {
-          Row(verticalAlignment = Alignment.CenterVertically) {
-            Box(modifier = Modifier.size(40.dp).background(Color.Gray, shape = CircleShape))
-            Spacer(Modifier.width(8.dp))
-            Text(text = discussionName, style = MaterialTheme.typography.titleMedium)
-          }
-        },
-        navigationIcon = {
-          IconButton(onClick = { navigation.goBack() }) {
-            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
-          }
-        },
-        actions = {
-          IconButton(onClick = {}) { Icon(Icons.Default.Search, contentDescription = "Search") }
-        })
-
-    /** LazyColumn showing all messages with optional date separators */
-    LazyColumn(
-        state = listState,
-        modifier = Modifier.weight(1f).fillMaxWidth(),
-        contentPadding = PaddingValues(8.dp),
-        verticalArrangement = Arrangement.spacedBy(10.dp)) {
-          itemsIndexed(messages) { index, message ->
-            val isMine = message.senderId == currentUser.uid
-            val sender = if (!isMine) userCache[message.senderId]?.name ?: "Unknown" else "You"
-
-            val showDateHeader =
-                shouldShowDateHeader(
-                    current = message.createdAt.toDate(),
-                    previous = messages.getOrNull(index - 1)?.createdAt?.toDate())
-            if (showDateHeader) {
-              DateSeparator(date = message.createdAt.toDate())
+    LaunchedEffect(discussionId) {
+        viewModel.discussionFlow(discussionId).collectLatest { discussion ->
+            discussion?.messages?.let { msgs ->
+                messages.clear()
+                messages.addAll(msgs)
+                scope.launch {
+                    listState.animateScrollToItem(messages.size)
+                }
+                msgs.forEach { msg ->
+                    if (!userCache.containsKey(msg.senderId) && msg.senderId != currentUser.uid) {
+                        try {
+                            val account = viewModel.getAccount(msg.senderId)
+                            userCache[msg.senderId] = account
+                        } catch (_: Exception) { }
+                    }
+                }
+                discussionName = discussion?.name ?: "Loading..."
             }
+        }
+    }
 
-            ChatBubble(message, isMine, sender)
-          }
+    Column(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        // Top bar with placeholder avatar
+        TopAppBar(
+            title = {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    // TODO Placeholder discussion picture
+                    Box(
+                        modifier = Modifier
+                            .size(40.dp)
+                            .background(Color.Gray, shape = CircleShape)
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text(text = discussionName, style = MaterialTheme.typography.titleMedium)
+                }
+            },
+            navigationIcon = {
+                IconButton(onClick = { /* TODO GO BACK */ }) {
+                    Icon(Icons.Filled.ArrowBack, contentDescription = "Back")
+                }
+            },
+            actions = {
+                IconButton(onClick = { /* TODO search later */ }) {
+                    Icon(Icons.Default.Search, contentDescription = "Search")
+                }
+            }
+        )
+
+        LazyColumn(
+            state = listState,
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth(),
+            contentPadding = PaddingValues(8.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            items(messages) { message ->
+                val isMine = message.senderId == currentUser.uid
+                val sender = if (!isMine) userCache[message.senderId]?.name ?: "Unknown" else  "You"
+                ChatBubble(message, isMine, sender)
+            }
         }
 
-    /** Input row at the bottom for typing messages */
-    Row(
-        modifier =
-            Modifier.fillMaxWidth()
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
                 .padding(8.dp)
                 .background(Color(0xFFF0F0F0), shape = CircleShape)
                 .padding(horizontal = 12.dp, vertical = 4.dp),
-        verticalAlignment = Alignment.CenterVertically) {
-          IconButton(onClick = {}) { Icon(Icons.Default.AttachFile, contentDescription = "Attach") }
-          Spacer(Modifier.width(8.dp))
-
-          /** Text input field */
-          BasicTextField(
-              value = messageText,
-              onValueChange = { messageText = it },
-              modifier = Modifier.weight(1f),
-              singleLine = true,
-              decorationBox = { innerTextField ->
-                if (messageText.isEmpty()) {
-                  Text("Type something...", color = Color.Gray)
-                }
-                innerTextField()
-              })
-
-          Spacer(Modifier.width(8.dp))
-
-          /** Send button */
-          IconButton(
-              onClick = {
-                discussion?.let { disc ->
-                  if (messageText.isNotBlank() && !isSending) {
-                    scope.launch {
-                      isSending = true
-                      try {
-                        viewModel.sendMessageToDiscussion(disc, currentUser, messageText)
-                        messageText = ""
-                      } finally {
-                        isSending = false
-                      }
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(
+                onClick = {/*TODO ATTACH FILE*/ }) {
+            Icon(Icons.Default.AttachFile, contentDescription = "Attach")
+            }
+            Spacer(Modifier.width(8.dp))
+            BasicTextField(
+                value = messageText,
+                onValueChange = { messageText = it },
+                modifier = Modifier.weight(1f),
+                singleLine = true,
+                decorationBox = { innerTextField ->
+                    if (messageText.isEmpty()) {
+                        Text("Type something...", color = Color.Gray)
                     }
-                  }
+                    innerTextField()
                 }
-              },
-              enabled = !isSending) {
-                Icon(Icons.AutoMirrored.Filled.Send, contentDescription = "Send")
-              }
+            )
+            Spacer(Modifier.width(8.dp))
+            IconButton(
+                onClick = {
+                    if (messageText.isNotBlank() && !isSending) {
+                        scope.launch {
+                            isSending = true
+                            try {
+                                viewModel.sendMessageToDiscussion(
+                                    viewModel.getDiscussion(discussionId),
+                                    currentUser,
+                                    messageText
+                                )
+                                messageText = ""
+                            } finally {
+                                isSending = false
+                            }
+                        }
+                    }
+                },
+                enabled = !isSending
+            ) {
+                Icon(Icons.Default.Send, contentDescription = "Send")
+            }
         }
-  }
+    }
 }
 
-/**
- * A single message bubble in the chat.
- *
- * @param message Message to display
- * @param isMine True if the message belongs to the current user
- * @param senderName Name of the sender
- */
 @Composable
 fun ChatBubble(message: Message, isMine: Boolean, senderName: String?) {
-  Row(
-      modifier = Modifier.fillMaxWidth(),
-      horizontalArrangement = if (isMine) Arrangement.End else Arrangement.Start) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = if (isMine) Arrangement.End else Arrangement.Start
+    ) {
         if (!isMine) {
-          Box(modifier = Modifier.size(32.dp).background(Color.Gray, shape = CircleShape))
-          Spacer(Modifier.width(6.dp))
+            Box(
+                modifier = Modifier
+                    .size(32.dp)
+                    .background(Color.Gray, shape = CircleShape)
+            )
+            Spacer(Modifier.width(6.dp))
         }
 
-        Column(horizontalAlignment = if (isMine) Alignment.End else Alignment.Start) {
-          Box(
-              modifier =
-                  Modifier.shadow(elevation = 4.dp, shape = RoundedCornerShape(12.dp), clip = false)
-                      .background(color = Color(0xFFe0e0e0), shape = RoundedCornerShape(12.dp))
-                      .padding(10.dp)
-                      .widthIn(max = 250.dp)) {
+        Column(
+            horizontalAlignment = if (isMine) Alignment.End else Alignment.Start
+        ) {
+            // The bubble with shadow
+            Box(
+                modifier = Modifier
+                    .shadow(
+                        elevation = 4.dp, // how “deep” the shadow is
+                        shape = RoundedCornerShape(12.dp),
+                        clip = false // allows shadow to appear outside bounds
+                    )
+                    .background(
+                        color = Color(0xFFe0e0e0),
+                        shape = RoundedCornerShape(12.dp)
+                    )
+                    .padding(10.dp)
+                    .widthIn(max = 250.dp) // optional max width
+            ) {
                 Column {
-                  if (senderName != null) {
+                    if (senderName != null) {
+                        Text(
+                            senderName,
+                            style = MaterialTheme.typography.labelSmall.copy(color = Color.Black)
+                        )
+                        Spacer(Modifier.height(2.dp))
+                    }
                     Text(
-                        senderName,
-                        style = MaterialTheme.typography.labelSmall.copy(color = Color.Black))
-                    Spacer(Modifier.height(2.dp))
-                  }
-                  Text(
-                      message.content,
-                      style = MaterialTheme.typography.bodyMedium.copy(color = Color.Black))
+                        message.content,
+                        style = MaterialTheme.typography.bodyMedium.copy(color = Color.Black)
+                    )
                 }
-              }
+            }
 
-          Text(
-              text = DateFormat.format("HH:mm", message.createdAt.toDate()).toString(),
-              style = MaterialTheme.typography.labelSmall.copy(color = Color(0xFF888888)),
-              modifier =
-                  Modifier.padding(top = 2.dp)
-                      .align(if (isMine) Alignment.End else Alignment.Start))
+            // Timestamp aligned to bubble end
+            Text(
+                text = DateFormat.format("HH:mm", message.createdAt.toDate()).toString(),
+                style = MaterialTheme.typography.labelSmall.copy(color = Color(0xFF888888)),
+                modifier = Modifier
+                    .padding(top = 2.dp)
+                    .align(if (isMine) Alignment.End else Alignment.Start)
+            )
         }
 
         if (isMine) {
-          Spacer(Modifier.width(6.dp))
-          Box(modifier = Modifier.size(32.dp).background(Color.Gray, shape = CircleShape))
+            Spacer(Modifier.width(6.dp))
+            Box(
+                modifier = Modifier
+                    .size(32.dp)
+                    .background(Color.Gray, shape = CircleShape)
+            )
         }
-      }
-}
-
-/** Shows a date separator between messages. */
-@Composable
-fun DateSeparator(date: Date) {
-  Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-    Text(
-        text = formatDateBubble(date),
-        color = Color.White,
-        modifier =
-            Modifier.background(Color(0xFF9E9E9E), shape = RoundedCornerShape(50))
-                .padding(horizontal = 12.dp, vertical = 4.dp),
-        style = MaterialTheme.typography.labelMedium)
-  }
-}
-
-/**
- * Formats a date for display in a date separator. Returns "Today", "Yesterday", or formatted date
- * string.
- */
-fun formatDateBubble(date: Date): String {
-  val cal = Calendar.getInstance()
-  val today = Calendar.getInstance()
-  cal.time = date
-
-  return when {
-    isSameDay(cal, today) -> "Today"
-    isSameDay(cal, today.apply { add(Calendar.DAY_OF_YEAR, -1) }) -> "Yesterday"
-    else -> DateFormat.format("MMM dd, yyyy", date).toString()
-  }
-}
-
-/** Determines whether a date header should be displayed between messages. */
-fun shouldShowDateHeader(current: Date, previous: Date?): Boolean {
-  if (previous == null) return true
-  val calCurrent = Calendar.getInstance().apply { time = current }
-  val calPrev = Calendar.getInstance().apply { time = previous }
-  return !(calCurrent.get(Calendar.YEAR) == calPrev.get(Calendar.YEAR) &&
-      calCurrent.get(Calendar.DAY_OF_YEAR) == calPrev.get(Calendar.DAY_OF_YEAR))
-}
-
-/** Checks if two Calendar instances represent the same day. */
-fun isSameDay(cal1: Calendar, cal2: Calendar): Boolean {
-  return cal1.get(Calendar.YEAR) == cal2.get(Calendar.YEAR) &&
-      cal1.get(Calendar.DAY_OF_YEAR) == cal2.get(Calendar.DAY_OF_YEAR)
+    }
 }


### PR DESCRIPTION
# Add DiscussionScreen UI and Tests

## Description
This PR introduces the `DiscussionScreen` UI along with its associated unit and Compose UI tests. It adds two files:

### 1. `DiscussionScreen.kt`
- Implements a chat/discussion screen using Jetpack Compose.
- Features include:
  - Displaying messages with sender info and timestamps.
  - Date separators for "Today", "Yesterday", or older messages.
  - Input field for sending new messages.
  - LazyColumn scrolling with automatic scroll to the latest message.
  - Top bar with discussion name, back navigation, and search icon.
- Uses `FirestoreViewModel` to fetch discussions and send messages.
- Handles user caching to display sender names for other participants.
- TODO placeholders for avatars.

### 2. `DiscussionScreenTest.kt`
- Unit tests for:
  - `isSameDay`
  - `shouldShowDateHeader`
  - `formatDateBubble`
- Compose UI tests for:
  - Rendering discussion title and messages.
  - Send button behavior (clearing input after sending).
  - Back button navigation.
  - `ChatBubble` and `DateSeparator` rendering.
- Uses `mockk` for mocking the repository and navigation in tests.

## Files Added
- `app/src/main/java/com/github/meeplemeet/ui/DiscussionScreen.kt`  
- `app/src/test/java/com/github/meeplemeet/ui/DiscussionScreenTest.kt`

## Testing
- Verified via Compose test rule and unit tests that all UI components render correctly and date formatting logic works as expected.
<img width="362" height="751" alt="image" src="https://github.com/user-attachments/assets/61642529-f73e-4467-8174-25dace427591" />
