### PR TITLE
Add discussion UI

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/model/ui/AddDiscussionScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/model/ui/AddDiscussionScreenTest.kt
@@ -139,9 +139,7 @@ class AddDiscussionScreenTest {
 
     searchField().performTextInput("ali")
     compose.waitForIdle()
-    compose.onAllNodesWithText("Alice")
-      .filterToOne(hasAnyAncestor(isPopup()))
-      .assertDoesNotExist()
+    compose.onAllNodesWithText("Alice").filterToOne(hasAnyAncestor(isPopup())).assertDoesNotExist()
   }
 
   /** Verifies that clearing the search query closes the dropdown */

--- a/app/src/androidTest/java/com/github/meeplemeet/model/ui/AddDiscussionScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/model/ui/AddDiscussionScreenTest.kt
@@ -47,11 +47,19 @@ class AddDiscussionScreenTest {
   /** Returns the back button node */
   private fun backBtn() = compose.onNodeWithContentDescription("Back")
 
+  private lateinit var onCreate: suspend (String, String, Account, List<Account>) -> Unit
+
   // ---------- Helpers ----------
 
   /** Sets the Compose content for the AddDiscussionScreen */
   private fun setContent() {
-    compose.setContent { AddDiscussionScreen(nav, vm, me) }
+    onCreate = { title: String, desc: String, creator: Account, members: List<Account> ->
+      vm.createDiscussion(title, desc, creator, *members.toTypedArray())
+      nav.goBack()
+    }
+    compose.setContent {
+      AddDiscussionScreen(onBack = { nav.goBack() }, onCreate = onCreate, vm, me)
+    }
   }
 
   // ---------- Tests ----------

--- a/app/src/androidTest/java/com/github/meeplemeet/model/ui/AddDiscussionScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/model/ui/AddDiscussionScreenTest.kt
@@ -1,0 +1,129 @@
+package com.github.meeplemeet.ui
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.github.meeplemeet.model.structures.Account
+import com.github.meeplemeet.model.viewmodels.FirestoreViewModel
+import com.github.meeplemeet.ui.navigation.NavigationActions
+import io.mockk.*
+import kotlinx.coroutines.test.*
+import org.junit.*
+
+class AddDiscussionScreenTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private val nav: NavigationActions = mockk(relaxed = true)
+    private val vm: FirestoreViewModel = mockk(relaxed = true)
+    private val me = Account(uid = "6", name = "Frank")
+
+    /* ---------- semantic matchers ---------- */
+    private fun titleField()   = compose.onNodeWithText("Title", substring = true)
+    private fun descField()    = compose.onNodeWithText("Description", substring = true)
+    private fun searchField()  = compose.onNodeWithText("Add Members", substring = true)
+    private fun createBtn()    = compose.onNodeWithText("Create Discussion")
+    private fun discardBtn()   = compose.onNodeWithText("Discard")
+    private fun backBtn()      = compose.onNodeWithContentDescription("Back")
+
+    /* ---------- helpers ---------- */
+    private fun setContent() {
+        compose.setContent { AddDiscussionScreen(nav, vm, me) }
+    }
+
+    /* ---------- tests ---------- */
+
+    @Test
+    fun initial_state_empty_fields_create_disabled() {
+        setContent()
+        titleField().assertTextContains("")
+        descField().assertTextContains("")
+        createBtn().assertIsNotEnabled()
+    }
+
+    @Test
+    fun typing_title_enables_create() {
+        setContent()
+        titleField().performTextInput("Kotlin")
+        createBtn().assertIsEnabled()
+    }
+
+    @Test
+    fun back_arrow_calls_navigation() {
+        setContent()
+        backBtn().performClick()
+        verify { nav.goBack() }
+    }
+
+    @Test
+    fun discard_button_calls_navigation() {
+        setContent()
+        discardBtn().performClick()
+        verify { nav.goBack() }
+    }
+
+    @Test
+    fun search_shows_results_and_adds_member() {
+        setContent()
+        searchField().performTextInput("bo")
+        compose.waitForIdle()
+        compose.onNodeWithText("Bob").assertExists().performClick()
+        compose.onNodeWithText("Bob").assertExists()
+        searchField().assertTextContains("")
+    }
+
+    @Test
+    fun clear_icon_resets_query() {
+        setContent()
+        searchField().performTextInput("xyz")
+        compose.onNodeWithContentDescription("Clear").performClick()
+        searchField().assertTextContains("")
+    }
+
+    @Test
+    fun remove_member_from_selected_list() {
+        setContent()
+        searchField().performTextInput("ali")
+        compose.waitForIdle()
+        compose.onNodeWithText("Alice").performClick()
+        compose.onNodeWithContentDescription("Remove").performClick()
+        compose.onNodeWithText("Alice").assertDoesNotExist()
+    }
+
+    @Test
+    fun search_filters_out_current_user() {
+        setContent()
+        searchField().performTextInput("Fr")
+        compose.waitForIdle()
+        // Instead of "No results", assert that "Myself" isn't shown
+        compose.onAllNodesWithText("Frank").assertCountEquals(0)
+    }
+
+    @Test
+    fun search_filters_out_already_selected_members() {
+        setContent()
+        searchField().performTextInput("ali")
+        compose.waitForIdle()
+        compose.onNodeWithText("Alice").performClick()
+
+        searchField().performTextInput("ali")
+        compose.waitForIdle()
+        // Instead of "No results", assert that "Alice" is not shown again
+        compose.onAllNodesWithText("Alice").assertCountEquals(0)
+    }
+
+    @Test
+    fun empty_query_closes_dropdown() {
+        setContent()
+        searchField().performTextInput("x")
+        compose.waitForIdle()
+        // Results (if any) should appear temporarily
+        compose.onAllNodesWithText("x", substring = true)
+        searchField().performTextReplacement("")
+        compose.waitForIdle()
+        // After clearing, no names should appear
+        compose.onAllNodesWithText("Alice").assertCountEquals(0)
+        compose.onAllNodesWithText("Bob").assertCountEquals(0)
+        compose.onAllNodesWithText("Eve").assertCountEquals(0)
+    }
+}

--- a/app/src/androidTest/java/com/github/meeplemeet/model/ui/AddDiscussionScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/model/ui/AddDiscussionScreenTest.kt
@@ -139,7 +139,9 @@ class AddDiscussionScreenTest {
 
     searchField().performTextInput("ali")
     compose.waitForIdle()
-    compose.onAllNodesWithText("Alice").assertCountEquals(0)
+    compose.onAllNodesWithText("Alice")
+      .filterToOne(hasAnyAncestor(isPopup()))
+      .assertDoesNotExist()
   }
 
   /** Verifies that clearing the search query closes the dropdown */

--- a/app/src/androidTest/java/com/github/meeplemeet/model/ui/AddDiscussionScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/model/ui/AddDiscussionScreenTest.kt
@@ -9,121 +9,150 @@ import io.mockk.*
 import kotlinx.coroutines.test.*
 import org.junit.*
 
+/**
+ * Tests for the AddDiscussionScreen UI. Verifies initial state, input behavior, member search, and
+ * navigation actions.
+ */
 class AddDiscussionScreenTest {
 
-    @get:Rule
-    val compose = createComposeRule()
+  /** Compose test rule for running Compose UI tests */
+  @get:Rule val compose = createComposeRule()
 
-    private val nav: NavigationActions = mockk(relaxed = true)
-    private val vm: FirestoreViewModel = mockk(relaxed = true)
-    private val me = Account(uid = "6", name = "Frank")
+  /** Mocked navigation actions */
+  private val nav: NavigationActions = mockk(relaxed = true)
 
-    /* ---------- semantic matchers ---------- */
-    private fun titleField()   = compose.onNodeWithText("Title", substring = true)
-    private fun descField()    = compose.onNodeWithText("Description", substring = true)
-    private fun searchField()  = compose.onNodeWithText("Add Members", substring = true)
-    private fun createBtn()    = compose.onNodeWithText("Create Discussion")
-    private fun discardBtn()   = compose.onNodeWithText("Discard")
-    private fun backBtn()      = compose.onNodeWithContentDescription("Back")
+  /** Mocked ViewModel for testing */
+  private val vm: FirestoreViewModel = mockk(relaxed = true)
 
-    /* ---------- helpers ---------- */
-    private fun setContent() {
-        compose.setContent { AddDiscussionScreen(nav, vm, me) }
-    }
+  /** Current user for the screen */
+  private val me = Account(uid = "6", name = "Frank")
 
-    /* ---------- tests ---------- */
+  // ---------- Semantic matchers ----------
 
-    @Test
-    fun initial_state_empty_fields_create_disabled() {
-        setContent()
-        titleField().assertTextContains("")
-        descField().assertTextContains("")
-        createBtn().assertIsNotEnabled()
-    }
+  /** Returns the title input field node */
+  private fun titleField() = compose.onNodeWithText("Title", substring = true)
 
-    @Test
-    fun typing_title_enables_create() {
-        setContent()
-        titleField().performTextInput("Kotlin")
-        createBtn().assertIsEnabled()
-    }
+  /** Returns the description input field node */
+  private fun descField() = compose.onNodeWithText("Description", substring = true)
 
-    @Test
-    fun back_arrow_calls_navigation() {
-        setContent()
-        backBtn().performClick()
-        verify { nav.goBack() }
-    }
+  /** Returns the add members search field node */
+  private fun searchField() = compose.onNodeWithText("Add Members", substring = true)
 
-    @Test
-    fun discard_button_calls_navigation() {
-        setContent()
-        discardBtn().performClick()
-        verify { nav.goBack() }
-    }
+  /** Returns the create discussion button node */
+  private fun createBtn() = compose.onNodeWithText("Create Discussion")
 
-    @Test
-    fun search_shows_results_and_adds_member() {
-        setContent()
-        searchField().performTextInput("bo")
-        compose.waitForIdle()
-        compose.onNodeWithText("Bob").assertExists().performClick()
-        compose.onNodeWithText("Bob").assertExists()
-        searchField().assertTextContains("")
-    }
+  /** Returns the discard button node */
+  private fun discardBtn() = compose.onNodeWithText("Discard")
 
-    @Test
-    fun clear_icon_resets_query() {
-        setContent()
-        searchField().performTextInput("xyz")
-        compose.onNodeWithContentDescription("Clear").performClick()
-        searchField().assertTextContains("")
-    }
+  /** Returns the back button node */
+  private fun backBtn() = compose.onNodeWithContentDescription("Back")
 
-    @Test
-    fun remove_member_from_selected_list() {
-        setContent()
-        searchField().performTextInput("ali")
-        compose.waitForIdle()
-        compose.onNodeWithText("Alice").performClick()
-        compose.onNodeWithContentDescription("Remove").performClick()
-        compose.onNodeWithText("Alice").assertDoesNotExist()
-    }
+  // ---------- Helpers ----------
 
-    @Test
-    fun search_filters_out_current_user() {
-        setContent()
-        searchField().performTextInput("Fr")
-        compose.waitForIdle()
-        // Instead of "No results", assert that "Myself" isn't shown
-        compose.onAllNodesWithText("Frank").assertCountEquals(0)
-    }
+  /** Sets the Compose content for the AddDiscussionScreen */
+  private fun setContent() {
+    compose.setContent { AddDiscussionScreen(nav, vm, me) }
+  }
 
-    @Test
-    fun search_filters_out_already_selected_members() {
-        setContent()
-        searchField().performTextInput("ali")
-        compose.waitForIdle()
-        compose.onNodeWithText("Alice").performClick()
+  // ---------- Tests ----------
 
-        searchField().performTextInput("ali")
-        compose.waitForIdle()
-        // Instead of "No results", assert that "Alice" is not shown again
-        compose.onAllNodesWithText("Alice").assertCountEquals(0)
-    }
+  /** Verifies initial state: empty fields and disabled create button */
+  @Test
+  fun initial_state_empty_fields_create_disabled() {
+    setContent()
+    titleField().assertTextContains("")
+    descField().assertTextContains("")
+    createBtn().assertIsNotEnabled()
+  }
 
-    @Test
-    fun empty_query_closes_dropdown() {
-        setContent()
-        searchField().performTextInput("x")
-        compose.waitForIdle()
-        // Results (if any) should appear temporarily
-        compose.onAllNodesWithText("x", substring = true)
-        searchField().performTextReplacement("")
-        compose.waitForIdle()
-        // After clearing, no names should appear
-        compose.onAllNodesWithText("Alice").assertCountEquals(0)
-        compose.onAllNodesWithText("Bob").assertCountEquals(0)
-        compose.onAllNodesWithText("Eve").assertCountEquals(0)
-    }
+  /** Verifies typing a title enables the create button */
+  @Test
+  fun typing_title_enables_create() {
+    setContent()
+    titleField().performTextInput("Kotlin")
+    createBtn().assertIsEnabled()
+  }
+
+  /** Verifies back arrow calls navigation.goBack() */
+  @Test
+  fun back_arrow_calls_navigation() {
+    setContent()
+    backBtn().performClick()
+    verify { nav.goBack() }
+  }
+
+  /** Verifies discard button calls navigation.goBack() */
+  @Test
+  fun discard_button_calls_navigation() {
+    setContent()
+    discardBtn().performClick()
+    verify { nav.goBack() }
+  }
+
+  /** Verifies member search displays results and adds a member */
+  @Test
+  fun search_shows_results_and_adds_member() {
+    setContent()
+    searchField().performTextInput("bo")
+    compose.waitForIdle()
+    compose.onNodeWithText("Bob").assertExists().performClick()
+    compose.onNodeWithText("Bob").assertExists()
+    searchField().assertTextContains("")
+  }
+
+  /** Verifies that the clear icon resets the search query */
+  @Test
+  fun clear_icon_resets_query() {
+    setContent()
+    searchField().performTextInput("xyz")
+    compose.onNodeWithContentDescription("Clear").performClick()
+    searchField().assertTextContains("")
+  }
+
+  /** Verifies removing a member from the selected list works correctly */
+  @Test
+  fun remove_member_from_selected_list() {
+    setContent()
+    searchField().performTextInput("ali")
+    compose.waitForIdle()
+    compose.onNodeWithText("Alice").performClick()
+    compose.onNodeWithContentDescription("Remove").performClick()
+    compose.onNodeWithText("Alice").assertDoesNotExist()
+  }
+
+  /** Verifies that the current user is filtered out of search results */
+  @Test
+  fun search_filters_out_current_user() {
+    setContent()
+    searchField().performTextInput("Fr")
+    compose.waitForIdle()
+    compose.onAllNodesWithText("Frank").assertCountEquals(0)
+  }
+
+  /** Verifies that already selected members are filtered out of search results */
+  @Test
+  fun search_filters_out_already_selected_members() {
+    setContent()
+    searchField().performTextInput("ali")
+    compose.waitForIdle()
+    compose.onNodeWithText("Alice").performClick()
+
+    searchField().performTextInput("ali")
+    compose.waitForIdle()
+    compose.onAllNodesWithText("Alice").assertCountEquals(0)
+  }
+
+  /** Verifies that clearing the search query closes the dropdown */
+  @Test
+  fun empty_query_closes_dropdown() {
+    setContent()
+    searchField().performTextInput("x")
+    compose.waitForIdle()
+    compose.onAllNodesWithText("x", substring = true)
+    searchField().performTextReplacement("")
+    compose.waitForIdle()
+    compose.onAllNodesWithText("Alice").assertCountEquals(0)
+    compose.onAllNodesWithText("Bob").assertCountEquals(0)
+    compose.onAllNodesWithText("Eve").assertCountEquals(0)
+  }
 }

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/AddDiscussionScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/AddDiscussionScreenTest.kt
@@ -65,18 +65,12 @@ class AddDiscussionScreenTest {
   /** Returns the back button node */
   private fun backBtn() = compose.onNodeWithContentDescription("Back")
 
-  private lateinit var onCreate: suspend (String, String, Account, List<Account>) -> Unit
-
   // ---------- Helpers ----------
 
   /** Sets the Compose content for the AddDiscussionScreen */
   private fun setContent() {
-    onCreate = { title: String, desc: String, creator: Account, members: List<Account> ->
-      vm.createDiscussion(title, desc, creator, *members.toTypedArray())
-      nav.goBack()
-    }
     compose.setContent {
-      AddDiscussionScreen(onBack = { nav.goBack() }, onCreate = onCreate, vm, me)
+      AddDiscussionScreen(onBack = { nav.goBack() }, onCreate = { nav.goBack() }, vm, me)
     }
   }
 
@@ -193,28 +187,5 @@ class AddDiscussionScreenTest {
     titleField().performTextInput("New Discussion")
     createBtn().performClick()
     coVerify(exactly = 1) { vm.createDiscussion(any(), any(), any()) }
-  }
-
-  /**
-   * Verifies that when the createDiscussion lambda throws an exception, the error snackbar with the
-   * message "Failed to create discussion" is displayed.
-   */
-  @Test
-  fun createButton_shows_error_snackbar_on_failure() = runTest {
-    val failingOnCreate: suspend (String, String, Account, List<Account>) -> Unit = { _, _, _, _ ->
-      throw Exception("Simulated failure")
-    }
-
-    compose.setContent {
-      AddDiscussionScreen(onBack = {}, onCreate = failingOnCreate, viewModel = vm, currentUser = me)
-    }
-
-    compose.onNodeWithText("Title", substring = true).performTextInput("Test Discussion")
-
-    compose.onNodeWithText("Create Discussion").performClick()
-
-    compose.waitForIdle()
-
-    compose.onNodeWithText("Failed to create discussion").assertExists()
   }
 }

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/AddDiscussionScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/AddDiscussionScreenTest.kt
@@ -34,8 +34,7 @@ import org.junit.Test
 class AddDiscussionScreenTest {
 
   /** Compose test rule for running Compose UI tests */
-  @get:Rule
-  val compose = createComposeRule()
+  @get:Rule val compose = createComposeRule()
 
   /** Mocked navigation actions */
   private val nav: NavigationActions = mockk(relaxed = true)
@@ -105,7 +104,7 @@ class AddDiscussionScreenTest {
   fun back_arrow_calls_navigation() {
     setContent()
     backBtn().performClick()
-      verify { nav.goBack() }
+    verify { nav.goBack() }
   }
 
   /** Verifies discard button calls navigation.goBack() */
@@ -113,7 +112,7 @@ class AddDiscussionScreenTest {
   fun discard_button_calls_navigation() {
     setContent()
     discardBtn().performClick()
-      verify { nav.goBack() }
+    verify { nav.goBack() }
   }
 
   /** Verifies member search displays results and adds a member */
@@ -189,11 +188,11 @@ class AddDiscussionScreenTest {
    */
   @Test
   fun create_button_calls_viewmodel_createDiscussion() = runTest {
-      coEvery { vm.createDiscussion(any(), any(), any()) } just runs
-      setContent()
-      titleField().performTextInput("New Discussion")
-      createBtn().performClick()
-      coVerify(exactly = 1) { vm.createDiscussion(any(), any(), any()) }
+    coEvery { vm.createDiscussion(any(), any(), any()) } just runs
+    setContent()
+    titleField().performTextInput("New Discussion")
+    createBtn().performClick()
+    coVerify(exactly = 1) { vm.createDiscussion(any(), any(), any()) }
   }
 
   /**
@@ -202,26 +201,20 @@ class AddDiscussionScreenTest {
    */
   @Test
   fun createButton_shows_error_snackbar_on_failure() = runTest {
-      val failingOnCreate: suspend (String, String, Account, List<Account>) -> Unit =
-          { _, _, _, _ ->
-              throw Exception("Simulated failure")
-          }
+    val failingOnCreate: suspend (String, String, Account, List<Account>) -> Unit = { _, _, _, _ ->
+      throw Exception("Simulated failure")
+    }
 
-      compose.setContent {
-          AddDiscussionScreen(
-              onBack = {},
-              onCreate = failingOnCreate,
-              viewModel = vm,
-              currentUser = me
-          )
-      }
+    compose.setContent {
+      AddDiscussionScreen(onBack = {}, onCreate = failingOnCreate, viewModel = vm, currentUser = me)
+    }
 
-      compose.onNodeWithText("Title", substring = true).performTextInput("Test Discussion")
+    compose.onNodeWithText("Title", substring = true).performTextInput("Test Discussion")
 
-      compose.onNodeWithText("Create Discussion").performClick()
+    compose.onNodeWithText("Create Discussion").performClick()
 
-      compose.waitForIdle()
+    compose.waitForIdle()
 
-      compose.onNodeWithText("Failed to create discussion").assertExists()
+    compose.onNodeWithText("Failed to create discussion").assertExists()
   }
 }

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/AddDiscussionScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/AddDiscussionScreenTest.kt
@@ -1,13 +1,31 @@
 package com.github.meeplemeet.ui
 
-import androidx.compose.ui.test.*
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.filterToOne
+import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.isPopup
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.performTextReplacement
 import com.github.meeplemeet.model.structures.Account
 import com.github.meeplemeet.model.viewmodels.FirestoreViewModel
 import com.github.meeplemeet.ui.navigation.NavigationActions
-import io.mockk.*
-import kotlinx.coroutines.test.*
-import org.junit.*
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
 
 /**
  * Tests for the AddDiscussionScreen UI. Verifies initial state, input behavior, member search, and
@@ -16,7 +34,8 @@ import org.junit.*
 class AddDiscussionScreenTest {
 
   /** Compose test rule for running Compose UI tests */
-  @get:Rule val compose = createComposeRule()
+  @get:Rule
+  val compose = createComposeRule()
 
   /** Mocked navigation actions */
   private val nav: NavigationActions = mockk(relaxed = true)
@@ -86,7 +105,7 @@ class AddDiscussionScreenTest {
   fun back_arrow_calls_navigation() {
     setContent()
     backBtn().performClick()
-    verify { nav.goBack() }
+      verify { nav.goBack() }
   }
 
   /** Verifies discard button calls navigation.goBack() */
@@ -94,7 +113,7 @@ class AddDiscussionScreenTest {
   fun discard_button_calls_navigation() {
     setContent()
     discardBtn().performClick()
-    verify { nav.goBack() }
+      verify { nav.goBack() }
   }
 
   /** Verifies member search displays results and adds a member */
@@ -170,11 +189,11 @@ class AddDiscussionScreenTest {
    */
   @Test
   fun create_button_calls_viewmodel_createDiscussion() = runTest {
-    coEvery { vm.createDiscussion(any(), any(), any()) } just runs
-    setContent()
-    titleField().performTextInput("New Discussion")
-    createBtn().performClick()
-    coVerify(exactly = 1) { vm.createDiscussion(any(), any(), any()) }
+      coEvery { vm.createDiscussion(any(), any(), any()) } just runs
+      setContent()
+      titleField().performTextInput("New Discussion")
+      createBtn().performClick()
+      coVerify(exactly = 1) { vm.createDiscussion(any(), any(), any()) }
   }
 
   /**
@@ -183,20 +202,26 @@ class AddDiscussionScreenTest {
    */
   @Test
   fun createButton_shows_error_snackbar_on_failure() = runTest {
-    val failingOnCreate: suspend (String, String, Account, List<Account>) -> Unit = { _, _, _, _ ->
-      throw Exception("Simulated failure")
-    }
+      val failingOnCreate: suspend (String, String, Account, List<Account>) -> Unit =
+          { _, _, _, _ ->
+              throw Exception("Simulated failure")
+          }
 
-    compose.setContent {
-      AddDiscussionScreen(onBack = {}, onCreate = failingOnCreate, viewModel = vm, currentUser = me)
-    }
+      compose.setContent {
+          AddDiscussionScreen(
+              onBack = {},
+              onCreate = failingOnCreate,
+              viewModel = vm,
+              currentUser = me
+          )
+      }
 
-    compose.onNodeWithText("Title", substring = true).performTextInput("Test Discussion")
+      compose.onNodeWithText("Title", substring = true).performTextInput("Test Discussion")
 
-    compose.onNodeWithText("Create Discussion").performClick()
+      compose.onNodeWithText("Create Discussion").performClick()
 
-    compose.waitForIdle()
+      compose.waitForIdle()
 
-    compose.onNodeWithText("Failed to create discussion").assertExists()
+      compose.onNodeWithText("Failed to create discussion").assertExists()
   }
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/AddDiscussionScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/AddDiscussionScreen.kt
@@ -1,13 +1,11 @@
 package com.github.meeplemeet.ui
 
-import android.R
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Cancel
@@ -18,10 +16,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.max
 import com.github.meeplemeet.model.structures.Account
 import com.github.meeplemeet.model.viewmodels.FirestoreViewModel
 import com.github.meeplemeet.ui.navigation.NavigationActions

--- a/app/src/main/java/com/github/meeplemeet/ui/AddDiscussionScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/AddDiscussionScreen.kt
@@ -41,296 +41,291 @@ fun AddDiscussionScreen(
     viewModel: FirestoreViewModel,
     currentUser: Account
 ) {
-    val scope = rememberCoroutineScope()
+  val scope = rememberCoroutineScope()
 
-    /** State for discussion title and description */
-    var title by remember { mutableStateOf("") }
-    var description by remember { mutableStateOf("") }
+  /** State for discussion title and description */
+  var title by remember { mutableStateOf("") }
+  var description by remember { mutableStateOf("") }
 
-    /** Live search state for adding members */
-    var searchQuery by remember { mutableStateOf("") }
-    var searchResults by remember { mutableStateOf<List<Account>>(emptyList()) }
-    var isSearching by remember { mutableStateOf(false) }
-    var dropdownExpanded by remember { mutableStateOf(false) }
+  /** Live search state for adding members */
+  var searchQuery by remember { mutableStateOf("") }
+  var searchResults by remember { mutableStateOf<List<Account>>(emptyList()) }
+  var isSearching by remember { mutableStateOf(false) }
+  var dropdownExpanded by remember { mutableStateOf(false) }
 
-    /** List of members selected for the new discussion */
-    val selectedMembers = remember { mutableStateListOf<Account>() }
+  /** List of members selected for the new discussion */
+  val selectedMembers = remember { mutableStateListOf<Account>() }
 
-    /**
-     * Handles live search whenever [searchQuery] changes. Filters out the current user and
-     * already-selected members.
-     */
-    LaunchedEffect(searchQuery) {
-        if (searchQuery.isBlank()) {
-            searchResults = emptyList()
-            dropdownExpanded = false
-            return@LaunchedEffect
-        }
-
-        isSearching = true
-        /** Simulated backend search */
-        searchResults =
-            fakeSearchAccounts(searchQuery).filter {
-                it.uid != currentUser.uid && it !in selectedMembers
-            }
-
-        dropdownExpanded = searchResults.isNotEmpty()
-        isSearching = false
+  /**
+   * Handles live search whenever [searchQuery] changes. Filters out the current user and
+   * already-selected members.
+   */
+  LaunchedEffect(searchQuery) {
+    if (searchQuery.isBlank()) {
+      searchResults = emptyList()
+      dropdownExpanded = false
+      return@LaunchedEffect
     }
 
-    /** Main layout scaffold */
-    Scaffold(
-        containerColor = AppColors.primary,
-        topBar = {
-            Column {
-                /** App bar with title and back button */
-                CenterAlignedTopAppBar(
-                    colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
-                        containerColor = AppColors.primary,
-                        titleContentColor = AppColors.textIcons,
-                        navigationIconContentColor = AppColors.textIcons
-                    ),
-                    title = { Text(text = "Add Discussion") },
-                    navigationIcon = {
-                        IconButton(onClick = { navigation.goBack() }) {
-                            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
-                        }
-                    }
-                )
-                /** Decorative divider under the top bar */
-                HorizontalDivider(
-                    modifier = Modifier.fillMaxWidth(0.7f)
-                        .padding(horizontal = 0.dp)
-                        .align(Alignment.CenterHorizontally),
-                    thickness = 1.dp,
-                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.2f)
-                )
-            }
+    isSearching = true
+    /** Simulated backend search */
+    searchResults =
+        fakeSearchAccounts(searchQuery).filter {
+          it.uid != currentUser.uid && it !in selectedMembers
         }
-    ) { padding ->
+
+    dropdownExpanded = searchResults.isNotEmpty()
+    isSearching = false
+  }
+
+  /** Main layout scaffold */
+  Scaffold(
+      containerColor = AppColors.primary,
+      topBar = {
+        Column {
+          /** App bar with title and back button */
+          CenterAlignedTopAppBar(
+              colors =
+                  TopAppBarDefaults.centerAlignedTopAppBarColors(
+                      containerColor = AppColors.primary,
+                      titleContentColor = AppColors.textIcons,
+                      navigationIconContentColor = AppColors.textIcons),
+              title = { Text(text = "Add Discussion") },
+              navigationIcon = {
+                IconButton(onClick = { navigation.goBack() }) {
+                  Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                }
+              })
+          /** Decorative divider under the top bar */
+          HorizontalDivider(
+              modifier =
+                  Modifier.fillMaxWidth(0.7f)
+                      .padding(horizontal = 0.dp)
+                      .align(Alignment.CenterHorizontally),
+              thickness = 1.dp,
+              color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.2f))
+        }
+      }) { padding ->
         Column(
-            modifier = Modifier
-                .padding(padding)
-                .padding(16.dp)
-                .fillMaxSize(),
-            verticalArrangement = Arrangement.Top
-        ) {
-            /** Title input field */
-            OutlinedTextField(
-                value = title,
-                colors = TextFieldDefaults.colors().copy(
-                    focusedTextColor = AppColors.textIcons,
-                    unfocusedTextColor = AppColors.textIcons,
-                    unfocusedIndicatorColor = AppColors.textIcons,
-                    focusedIndicatorColor = AppColors.textIcons,
-                    unfocusedLabelColor = AppColors.textIconsFade,
-                    focusedLabelColor = AppColors.textIconsFade,
-                    unfocusedContainerColor = Color.Transparent,
-                    focusedContainerColor = Color.Transparent
-                ),
-                textStyle = MaterialTheme.typography.bodySmall,
-                onValueChange = { title = it },
-                label = { Text("Title") },
-                modifier = Modifier.fillMaxWidth()
-            )
+            modifier = Modifier.padding(padding).padding(16.dp).fillMaxSize(),
+            verticalArrangement = Arrangement.Top) {
+              /** Title input field */
+              OutlinedTextField(
+                  value = title,
+                  colors =
+                      TextFieldDefaults.colors()
+                          .copy(
+                              focusedTextColor = AppColors.textIcons,
+                              unfocusedTextColor = AppColors.textIcons,
+                              unfocusedIndicatorColor = AppColors.textIcons,
+                              focusedIndicatorColor = AppColors.textIcons,
+                              unfocusedLabelColor = AppColors.textIconsFade,
+                              focusedLabelColor = AppColors.textIconsFade,
+                              unfocusedContainerColor = Color.Transparent,
+                              focusedContainerColor = Color.Transparent),
+                  textStyle = MaterialTheme.typography.bodySmall,
+                  onValueChange = { title = it },
+                  label = { Text("Title") },
+                  modifier = Modifier.fillMaxWidth())
 
-            Spacer(modifier = Modifier.height(12.dp))
+              Spacer(modifier = Modifier.height(12.dp))
 
-            /** Description input field */
-            OutlinedTextField(
-                value = description,
-                colors = TextFieldDefaults.colors().copy(
-                    focusedTextColor = AppColors.textIcons,
-                    unfocusedTextColor = AppColors.textIcons,
-                    unfocusedIndicatorColor = AppColors.textIcons,
-                    focusedIndicatorColor = AppColors.textIcons,
-                    unfocusedLabelColor = AppColors.textIconsFade,
-                    focusedLabelColor = AppColors.textIconsFade,
-                    unfocusedContainerColor = Color.Transparent,
-                    focusedContainerColor = Color.Transparent
-                ),
-                textStyle = MaterialTheme.typography.bodySmall,
-                onValueChange = { description = it },
-                label = { Text("Description (optional)") },
-                modifier = Modifier.fillMaxWidth().height(150.dp)
-            )
+              /** Description input field */
+              OutlinedTextField(
+                  value = description,
+                  colors =
+                      TextFieldDefaults.colors()
+                          .copy(
+                              focusedTextColor = AppColors.textIcons,
+                              unfocusedTextColor = AppColors.textIcons,
+                              unfocusedIndicatorColor = AppColors.textIcons,
+                              focusedIndicatorColor = AppColors.textIcons,
+                              unfocusedLabelColor = AppColors.textIconsFade,
+                              focusedLabelColor = AppColors.textIconsFade,
+                              unfocusedContainerColor = Color.Transparent,
+                              focusedContainerColor = Color.Transparent),
+                  textStyle = MaterialTheme.typography.bodySmall,
+                  onValueChange = { description = it },
+                  label = { Text("Description (optional)") },
+                  modifier = Modifier.fillMaxWidth().height(150.dp))
 
-            Spacer(modifier = Modifier.height(16.dp))
+              Spacer(modifier = Modifier.height(16.dp))
 
-            /** Row for search and member selection */
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = "Members:",
-                    style = MaterialTheme.typography.bodySmall,
-                    fontWeight = FontWeight.Bold
-                )
+              /** Row for search and member selection */
+              Row(
+                  modifier = Modifier.fillMaxWidth(),
+                  verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = "Members:",
+                        style = MaterialTheme.typography.bodySmall,
+                        fontWeight = FontWeight.Bold)
 
-                /** Autocomplete search field */
-                Box(modifier = Modifier.fillMaxWidth().padding(start = 8.dp)) {
-                    OutlinedTextField(
-                        value = searchQuery,
-                        colors = TextFieldDefaults.colors().copy(
-                            focusedTextColor = AppColors.textIcons,
-                            unfocusedTextColor = AppColors.textIcons,
-                            unfocusedIndicatorColor = AppColors.textIcons,
-                            focusedIndicatorColor = AppColors.textIcons,
-                            unfocusedLabelColor = AppColors.textIconsFade,
-                            focusedLabelColor = AppColors.textIconsFade,
-                            unfocusedContainerColor = Color.Transparent,
-                            focusedContainerColor = Color.Transparent
-                        ),
-                        textStyle = MaterialTheme.typography.bodySmall,
-                        shape = CircleShape,
-                        onValueChange = { searchQuery = it },
-                        label = { Text("Add Members") },
-                        modifier = Modifier.fillMaxWidth(),
-                        trailingIcon = {
+                    /** Autocomplete search field */
+                    Box(modifier = Modifier.fillMaxWidth().padding(start = 8.dp)) {
+                      OutlinedTextField(
+                          value = searchQuery,
+                          colors =
+                              TextFieldDefaults.colors()
+                                  .copy(
+                                      focusedTextColor = AppColors.textIcons,
+                                      unfocusedTextColor = AppColors.textIcons,
+                                      unfocusedIndicatorColor = AppColors.textIcons,
+                                      focusedIndicatorColor = AppColors.textIcons,
+                                      unfocusedLabelColor = AppColors.textIconsFade,
+                                      focusedLabelColor = AppColors.textIconsFade,
+                                      unfocusedContainerColor = Color.Transparent,
+                                      focusedContainerColor = Color.Transparent),
+                          textStyle = MaterialTheme.typography.bodySmall,
+                          shape = CircleShape,
+                          onValueChange = { searchQuery = it },
+                          label = { Text("Add Members") },
+                          modifier = Modifier.fillMaxWidth(),
+                          trailingIcon = {
                             if (searchQuery.isNotBlank()) {
-                                Icon(
-                                    Icons.Default.Close,
-                                    contentDescription = "Clear",
-                                    modifier = Modifier.clickable {
+                              Icon(
+                                  Icons.Default.Close,
+                                  contentDescription = "Clear",
+                                  modifier =
+                                      Modifier.clickable {
                                         searchQuery = ""
                                         dropdownExpanded = false
-                                    }
-                                )
+                                      })
                             }
-                        }
-                    )
+                          })
 
-                    /** Dropdown menu showing search results */
-                    DropdownMenu(
-                        expanded = dropdownExpanded,
-                        onDismissRequest = { dropdownExpanded = false },
-                        modifier = Modifier.fillMaxWidth().background(AppColors.divider)
-                    ) {
-                        when {
-                            isSearching -> {
+                      /** Dropdown menu showing search results */
+                      DropdownMenu(
+                          expanded = dropdownExpanded,
+                          onDismissRequest = { dropdownExpanded = false },
+                          modifier = Modifier.fillMaxWidth().background(AppColors.divider)) {
+                            when {
+                              isSearching -> {
                                 DropdownMenuItem(text = { Text("Searching...") }, onClick = {})
-                            }
-                            searchResults.isEmpty() -> {
+                              }
+                              searchResults.isEmpty() -> {
                                 DropdownMenuItem(text = { Text("No results") }, onClick = {})
-                            }
-                            else -> {
+                              }
+                              else -> {
                                 searchResults.forEach { account ->
-                                    DropdownMenuItem(
-                                        text = { Text(account.name) },
-                                        onClick = {
-                                            selectedMembers.add(account)
-                                            searchQuery = ""
-                                            dropdownExpanded = false
-                                        },
-                                        leadingIcon = {
-                                            Box(
-                                                modifier = Modifier.size(32.dp)
+                                  DropdownMenuItem(
+                                      text = { Text(account.name) },
+                                      onClick = {
+                                        selectedMembers.add(account)
+                                        searchQuery = ""
+                                        dropdownExpanded = false
+                                      },
+                                      leadingIcon = {
+                                        Box(
+                                            modifier =
+                                                Modifier.size(32.dp)
                                                     .clip(CircleShape)
                                                     .background(Color.LightGray),
-                                                contentAlignment = Alignment.Center
-                                            ) {
-                                                Text(
-                                                    text = account.name.firstOrNull()?.toString() ?: "A",
-                                                    color = Color(0xFFFFA000),
-                                                    fontWeight = FontWeight.Bold
-                                                )
+                                            contentAlignment = Alignment.Center) {
+                                              Text(
+                                                  text =
+                                                      account.name.firstOrNull()?.toString() ?: "A",
+                                                  color = Color(0xFFFFA000),
+                                                  fontWeight = FontWeight.Bold)
                                             }
-                                        }
-                                    )
+                                      })
                                 }
+                              }
                             }
-                        }
+                          }
                     }
-                }
-            }
+                  }
 
-            Spacer(modifier = Modifier.height(20.dp))
+              Spacer(modifier = Modifier.height(20.dp))
 
-            /** Divider between search and selected members */
-            HorizontalDivider(
-                modifier = Modifier.fillMaxWidth(0.9f)
-                    .padding(horizontal = 0.dp)
-                    .align(Alignment.CenterHorizontally),
-                thickness = 1.dp,
-                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.2f)
-            )
+              /** Divider between search and selected members */
+              HorizontalDivider(
+                  modifier =
+                      Modifier.fillMaxWidth(0.9f)
+                          .padding(horizontal = 0.dp)
+                          .align(Alignment.CenterHorizontally),
+                  thickness = 1.dp,
+                  color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.2f))
 
-            /** Display list of selected members */
-            if (selectedMembers.isNotEmpty()) {
+              /** Display list of selected members */
+              if (selectedMembers.isNotEmpty()) {
                 Spacer(modifier = Modifier.height(12.dp))
-                LazyColumn ( modifier = Modifier.heightIn(max = 200.dp)) {
-                    items(selectedMembers) { member ->
-                        Row(
-                            modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            /** Member avatar */
-                            Box(
-                                modifier = Modifier.size(36.dp)
-                                    .clip(CircleShape)
-                                    .background(Color.LightGray),
-                                contentAlignment = Alignment.Center
-                            ) {
+                LazyColumn(modifier = Modifier.heightIn(max = 200.dp)) {
+                  items(selectedMembers) { member ->
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically) {
+                          /** Member avatar */
+                          Box(
+                              modifier =
+                                  Modifier.size(36.dp)
+                                      .clip(CircleShape)
+                                      .background(Color.LightGray),
+                              contentAlignment = Alignment.Center) {
                                 Text(
                                     text = member.name.firstOrNull()?.toString() ?: "A",
                                     color = Color(0xFFFFA000),
-                                    fontWeight = FontWeight.Bold
-                                )
-                            }
-                            Spacer(modifier = Modifier.width(12.dp))
+                                    fontWeight = FontWeight.Bold)
+                              }
+                          Spacer(modifier = Modifier.width(12.dp))
 
-                            /** Member name */
-                            Text(text = member.name, modifier = Modifier.weight(1f), maxLines = 1, color = AppColors.textIcons,
-                                fontStyle = MaterialTheme.typography.bodySmall.fontStyle)
+                          /** Member name */
+                          Text(
+                              text = member.name,
+                              modifier = Modifier.weight(1f),
+                              maxLines = 1,
+                              color = AppColors.textIcons,
+                              fontStyle = MaterialTheme.typography.bodySmall.fontStyle)
 
-                            /** Remove member button */
-                            Icon(
-                                Icons.Default.Cancel,
-                                contentDescription = "Remove",
-                                tint = AppColors.negative,
-                                modifier = Modifier.clickable { selectedMembers.remove(member) }
-                            )
+                          /** Remove member button */
+                          Icon(
+                              Icons.Default.Cancel,
+                              contentDescription = "Remove",
+                              tint = AppColors.negative,
+                              modifier = Modifier.clickable { selectedMembers.remove(member) })
                         }
-                    }
+                  }
                 }
-            }
+              }
 
-            /** Spacer to move buttons higher */
-            Spacer(modifier = Modifier.height(24.dp))
+              /** Spacer to move buttons higher */
+              Spacer(modifier = Modifier.height(24.dp))
 
-            /** Buttons section */
-            Column(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                Button(
-                    onClick = {
-                        scope.launch {
+              /** Buttons section */
+              Column(
+                  modifier = Modifier.fillMaxWidth(),
+                  horizontalAlignment = Alignment.CenterHorizontally) {
+                    Button(
+                        onClick = {
+                          scope.launch {
                             viewModel.createDiscussion(
-                                title, description, currentUser, *selectedMembers.toTypedArray()
-                            )
+                                title, description, currentUser, *selectedMembers.toTypedArray())
                             navigation.goBack() // TODO: navigate to new discussion screen
+                          }
+                        },
+                        enabled = title.isNotBlank(),
+                        modifier = Modifier.fillMaxWidth(0.5f),
+                        shape = CircleShape,
+                        colors =
+                            ButtonDefaults.buttonColors(containerColor = AppColors.affirmative)) {
+                          Text(
+                              text = "Create Discussion",
+                              style = MaterialTheme.typography.bodySmall)
                         }
-                    },
-                    enabled = title.isNotBlank(),
-                    modifier = Modifier.fillMaxWidth(0.5f),
-                    shape = CircleShape,
-                    colors = ButtonDefaults.buttonColors(containerColor = AppColors.affirmative)
-                ) { Text(text = "Create Discussion", style = MaterialTheme.typography.bodySmall) }
 
-                Spacer(modifier = Modifier.height(8.dp))
+                    Spacer(modifier = Modifier.height(8.dp))
 
-                OutlinedButton(
-                    onClick = { navigation.goBack() },
-                    modifier = Modifier.fillMaxWidth(0.3f),
-                    shape = CircleShape,
-                    colors = ButtonDefaults.outlinedButtonColors(contentColor = AppColors.negative)
-                ) { Text(text = "Discard",
-                    style = MaterialTheme.typography.bodySmall) }
+                    OutlinedButton(
+                        onClick = { navigation.goBack() },
+                        modifier = Modifier.fillMaxWidth(0.3f),
+                        shape = CircleShape,
+                        colors =
+                            ButtonDefaults.outlinedButtonColors(
+                                contentColor = AppColors.negative)) {
+                          Text(text = "Discard", style = MaterialTheme.typography.bodySmall)
+                        }
+                  }
             }
-        }
-    }
+      }
 }
 
 /**
@@ -341,16 +336,15 @@ fun AddDiscussionScreen(
  * @return List of matching [Account] objects
  */
 fun fakeSearchAccounts(query: String): List<Account> {
-    val allAccounts =
-        listOf(
-            Account("1", "Alice"),
-            Account("2", "Bob"),
-            Account("3", "Charlie"),
-            Account("4", "David"),
-            Account("5", "Eve"),
-            Account("6", "Frank"),
-            Account("7", "Grace"),
-            Account("8", "Heidi")
-        )
-    return allAccounts.filter { it.name.contains(query, ignoreCase = true) }
+  val allAccounts =
+      listOf(
+          Account("1", "Alice"),
+          Account("2", "Bob"),
+          Account("3", "Charlie"),
+          Account("4", "David"),
+          Account("5", "Eve"),
+          Account("6", "Frank"),
+          Account("7", "Grace"),
+          Account("8", "Heidi"))
+  return allAccounts.filter { it.name.contains(query, ignoreCase = true) }
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/AddDiscussionScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/AddDiscussionScreen.kt
@@ -1,0 +1,297 @@
+package com.github.meeplemeet.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Cancel
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.github.meeplemeet.model.structures.Account
+import com.github.meeplemeet.model.viewmodels.FirestoreViewModel
+import com.github.meeplemeet.ui.navigation.NavigationActions
+import kotlinx.coroutines.launch
+
+/**
+ * Screen for creating a new discussion with title, description, and selected members.
+ *
+ * Supports live search for adding members, displays selected members, and allows creating or
+ * discarding the discussion.
+ *
+ * @param navigation NavigationActions to handle navigation events
+ * @param viewModel FirestoreViewModel for creating discussions and accessing accounts
+ * @param currentUser The currently logged-in user
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddDiscussionScreen(
+    navigation: NavigationActions,
+    viewModel: FirestoreViewModel,
+    currentUser: Account
+) {
+  val scope = rememberCoroutineScope()
+
+  /** State for discussion title and description */
+  var title by remember { mutableStateOf("") }
+  var description by remember { mutableStateOf("") }
+
+  /** Live search state for adding members */
+  var searchQuery by remember { mutableStateOf("") }
+  var searchResults by remember { mutableStateOf<List<Account>>(emptyList()) }
+  var isSearching by remember { mutableStateOf(false) }
+  var dropdownExpanded by remember { mutableStateOf(false) }
+
+  /** List of members selected for the new discussion */
+  val selectedMembers = remember { mutableStateListOf<Account>() }
+
+  /**
+   * Handles live search whenever [searchQuery] changes. Filters out the current user and
+   * already-selected members.
+   */
+  LaunchedEffect(searchQuery) {
+    if (searchQuery.isBlank()) {
+      searchResults = emptyList()
+      dropdownExpanded = false
+      return@LaunchedEffect
+    }
+
+    isSearching = true
+    // Simulated backend search
+    searchResults =
+        fakeSearchAccounts(searchQuery).filter {
+          it.uid != currentUser.uid && it !in selectedMembers
+        }
+
+    dropdownExpanded = searchResults.isNotEmpty()
+    isSearching = false
+  }
+
+  /** Main layout scaffold */
+  Scaffold(
+      topBar = {
+        Column {
+          /** App bar with title and back button */
+          CenterAlignedTopAppBar(
+              title = { Text("Add Discussion") },
+              navigationIcon = {
+                IconButton(onClick = { navigation.goBack() }) {
+                  Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                }
+              })
+          /** Decorative divider under the top bar */
+          HorizontalDivider(
+              modifier =
+                  Modifier.fillMaxWidth(0.7f)
+                      .padding(horizontal = 0.dp)
+                      .align(Alignment.CenterHorizontally),
+              thickness = 1.dp,
+              color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.2f))
+        }
+      },
+      bottomBar = {
+        Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+          /** Button to create the discussion */
+          Button(
+              onClick = {
+                scope.launch {
+                  viewModel.createDiscussion(
+                      title, description, currentUser, *selectedMembers.toTypedArray())
+                  navigation.goBack() // TODO: navigate to new discussion screen
+                }
+              },
+              enabled = title.isNotBlank(),
+              elevation =
+                  ButtonDefaults.buttonElevation(defaultElevation = 4.dp, pressedElevation = 0.dp),
+              modifier = Modifier.fillMaxWidth(0.5f).align(Alignment.CenterHorizontally),
+              shape = RoundedCornerShape(30.dp),
+              colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF6DBA56))) {
+                Text("Create Discussion")
+              }
+
+          Spacer(modifier = Modifier.height(8.dp))
+
+          /** Button to discard and go back */
+          OutlinedButton(
+              onClick = { navigation.goBack() },
+              modifier = Modifier.fillMaxWidth(0.3f).align(Alignment.CenterHorizontally),
+              shape = RoundedCornerShape(30.dp),
+              colors = ButtonDefaults.outlinedButtonColors(contentColor = Color.Red)) {
+                Text("Discard")
+              }
+        }
+      }) { padding ->
+        Column(
+            modifier = Modifier.padding(padding).padding(16.dp).fillMaxSize(),
+            verticalArrangement = Arrangement.Top) {
+              /** Title input field */
+              OutlinedTextField(
+                  value = title,
+                  onValueChange = { title = it },
+                  label = { Text("Title") },
+                  modifier = Modifier.fillMaxWidth())
+
+              Spacer(modifier = Modifier.height(12.dp))
+
+              /** Description input field */
+              OutlinedTextField(
+                  value = description,
+                  onValueChange = { description = it },
+                  label = { Text("Description (optional)") },
+                  modifier = Modifier.fillMaxWidth().height(150.dp))
+
+              Spacer(modifier = Modifier.height(16.dp))
+
+              /** Row for search and member selection */
+              Row(
+                  modifier = Modifier.fillMaxWidth(),
+                  verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = "Members:",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold)
+
+                    /** Autocomplete search field */
+                    Box(modifier = Modifier.fillMaxWidth().padding(start = 8.dp)) {
+                      OutlinedTextField(
+                          value = searchQuery,
+                          shape = RoundedCornerShape(28.dp),
+                          onValueChange = { searchQuery = it },
+                          label = { Text("Add Members") },
+                          modifier = Modifier.fillMaxWidth(),
+                          trailingIcon = {
+                            if (searchQuery.isNotBlank()) {
+                              Icon(
+                                  Icons.Default.Close,
+                                  contentDescription = "Clear",
+                                  modifier =
+                                      Modifier.clickable {
+                                        searchQuery = ""
+                                        dropdownExpanded = false
+                                      })
+                            }
+                          })
+
+                      /** Dropdown menu showing search results */
+                      DropdownMenu(
+                          expanded = dropdownExpanded,
+                          onDismissRequest = { dropdownExpanded = false },
+                          modifier = Modifier.fillMaxWidth().background(Color.White)) {
+                            when {
+                              isSearching -> {
+                                DropdownMenuItem(text = { Text("Searching...") }, onClick = {})
+                              }
+                              searchResults.isEmpty() -> {
+                                DropdownMenuItem(text = { Text("No results") }, onClick = {})
+                              }
+                              else -> {
+                                searchResults.forEach { account ->
+                                  DropdownMenuItem(
+                                      text = { Text(account.name) },
+                                      onClick = {
+                                        selectedMembers.add(account)
+                                        searchQuery = ""
+                                        dropdownExpanded = false
+                                      },
+                                      leadingIcon = {
+                                        Box(
+                                            modifier =
+                                                Modifier.size(32.dp)
+                                                    .clip(CircleShape)
+                                                    .background(Color.LightGray),
+                                            contentAlignment = Alignment.Center) {
+                                              Text(
+                                                  text =
+                                                      account.name.firstOrNull()?.toString() ?: "A",
+                                                  color = Color(0xFFFFA000),
+                                                  fontWeight = FontWeight.Bold)
+                                            }
+                                      })
+                                }
+                              }
+                            }
+                          }
+                    }
+                  }
+
+              Spacer(modifier = Modifier.height(20.dp))
+
+              /** Divider between search and selected members */
+              HorizontalDivider(
+                  modifier =
+                      Modifier.fillMaxWidth(0.9f)
+                          .padding(horizontal = 0.dp)
+                          .align(Alignment.CenterHorizontally),
+                  thickness = 1.dp,
+                  color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.2f))
+
+              /** Display list of selected members */
+              if (selectedMembers.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(12.dp))
+                LazyColumn {
+                  items(selectedMembers) { member ->
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically) {
+                          /** Member avatar */
+                          Box(
+                              modifier =
+                                  Modifier.size(36.dp)
+                                      .clip(CircleShape)
+                                      .background(Color.LightGray),
+                              contentAlignment = Alignment.Center) {
+                                Text(
+                                    text = member.name.firstOrNull()?.toString() ?: "A",
+                                    color = Color(0xFFFFA000),
+                                    fontWeight = FontWeight.Bold)
+                              }
+                          Spacer(modifier = Modifier.width(12.dp))
+
+                          /** Member name */
+                          Text(text = member.name, modifier = Modifier.weight(1f), maxLines = 1)
+
+                          /** Remove member button */
+                          Icon(
+                              Icons.Default.Cancel,
+                              contentDescription = "Remove",
+                              tint = Color.Red,
+                              modifier = Modifier.clickable { selectedMembers.remove(member) })
+                        }
+                  }
+                }
+              }
+            }
+      }
+}
+
+/**
+ * Fake search function to simulate backend account search. Filters a hard-coded list of accounts by
+ * the query string.
+ *
+ * @param query The search query
+ * @return List of matching [Account] objects
+ */
+fun fakeSearchAccounts(query: String): List<Account> {
+  val allAccounts =
+      listOf(
+          Account("1", "Alice"),
+          Account("2", "Bob"),
+          Account("3", "Charlie"),
+          Account("4", "David"),
+          Account("5", "Eve"),
+          Account("6", "Frank"),
+          Account("7", "Grace"),
+          Account("8", "Heidi"))
+  return allAccounts.filter { it.name.contains(query, ignoreCase = true) }
+}

--- a/app/src/main/java/com/github/meeplemeet/ui/AddDiscussionScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/AddDiscussionScreen.kt
@@ -1,5 +1,6 @@
 package com.github.meeplemeet.ui
 
+import android.R
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -17,11 +18,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.max
 import com.github.meeplemeet.model.structures.Account
 import com.github.meeplemeet.model.viewmodels.FirestoreViewModel
 import com.github.meeplemeet.ui.navigation.NavigationActions
+import com.github.meeplemeet.ui.theme.AppColors
 import kotlinx.coroutines.launch
 
 /**
@@ -41,238 +45,296 @@ fun AddDiscussionScreen(
     viewModel: FirestoreViewModel,
     currentUser: Account
 ) {
-  val scope = rememberCoroutineScope()
+    val scope = rememberCoroutineScope()
 
-  /** State for discussion title and description */
-  var title by remember { mutableStateOf("") }
-  var description by remember { mutableStateOf("") }
+    /** State for discussion title and description */
+    var title by remember { mutableStateOf("") }
+    var description by remember { mutableStateOf("") }
 
-  /** Live search state for adding members */
-  var searchQuery by remember { mutableStateOf("") }
-  var searchResults by remember { mutableStateOf<List<Account>>(emptyList()) }
-  var isSearching by remember { mutableStateOf(false) }
-  var dropdownExpanded by remember { mutableStateOf(false) }
+    /** Live search state for adding members */
+    var searchQuery by remember { mutableStateOf("") }
+    var searchResults by remember { mutableStateOf<List<Account>>(emptyList()) }
+    var isSearching by remember { mutableStateOf(false) }
+    var dropdownExpanded by remember { mutableStateOf(false) }
 
-  /** List of members selected for the new discussion */
-  val selectedMembers = remember { mutableStateListOf<Account>() }
+    /** List of members selected for the new discussion */
+    val selectedMembers = remember { mutableStateListOf<Account>() }
 
-  /**
-   * Handles live search whenever [searchQuery] changes. Filters out the current user and
-   * already-selected members.
-   */
-  LaunchedEffect(searchQuery) {
-    if (searchQuery.isBlank()) {
-      searchResults = emptyList()
-      dropdownExpanded = false
-      return@LaunchedEffect
+    /**
+     * Handles live search whenever [searchQuery] changes. Filters out the current user and
+     * already-selected members.
+     */
+    LaunchedEffect(searchQuery) {
+        if (searchQuery.isBlank()) {
+            searchResults = emptyList()
+            dropdownExpanded = false
+            return@LaunchedEffect
+        }
+
+        isSearching = true
+        /** Simulated backend search */
+        searchResults =
+            fakeSearchAccounts(searchQuery).filter {
+                it.uid != currentUser.uid && it !in selectedMembers
+            }
+
+        dropdownExpanded = searchResults.isNotEmpty()
+        isSearching = false
     }
 
-    isSearching = true
-    /** Simulated backend search */
-    searchResults =
-        fakeSearchAccounts(searchQuery).filter {
-          it.uid != currentUser.uid && it !in selectedMembers
+    /** Main layout scaffold */
+    Scaffold(
+        containerColor = AppColors.primary,
+        topBar = {
+            Column {
+                /** App bar with title and back button */
+                CenterAlignedTopAppBar(
+                    colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                        containerColor = AppColors.primary,
+                        titleContentColor = AppColors.textIcons,
+                        navigationIconContentColor = AppColors.textIcons
+                    ),
+                    title = { Text(text = "Add Discussion") },
+                    navigationIcon = {
+                        IconButton(onClick = { navigation.goBack() }) {
+                            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        }
+                    }
+                )
+                /** Decorative divider under the top bar */
+                HorizontalDivider(
+                    modifier = Modifier.fillMaxWidth(0.7f)
+                        .padding(horizontal = 0.dp)
+                        .align(Alignment.CenterHorizontally),
+                    thickness = 1.dp,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.2f)
+                )
+            }
         }
-
-    dropdownExpanded = searchResults.isNotEmpty()
-    isSearching = false
-  }
-
-  /** Main layout scaffold */
-  Scaffold(
-      topBar = {
-        Column {
-          /** App bar with title and back button */
-          CenterAlignedTopAppBar(
-              title = { Text("Add Discussion") },
-              navigationIcon = {
-                IconButton(onClick = { navigation.goBack() }) {
-                  Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
-                }
-              })
-          /** Decorative divider under the top bar */
-          HorizontalDivider(
-              modifier =
-                  Modifier.fillMaxWidth(0.7f)
-                      .padding(horizontal = 0.dp)
-                      .align(Alignment.CenterHorizontally),
-              thickness = 1.dp,
-              color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.2f))
-        }
-      },
-      bottomBar = {
-        Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
-          /** Button to create the discussion */
-          Button(
-              onClick = {
-                scope.launch {
-                  viewModel.createDiscussion(
-                      title, description, currentUser, *selectedMembers.toTypedArray())
-                  navigation.goBack() // TODO: navigate to new discussion screen
-                }
-              },
-              enabled = title.isNotBlank(),
-              elevation =
-                  ButtonDefaults.buttonElevation(defaultElevation = 4.dp, pressedElevation = 0.dp),
-              modifier = Modifier.fillMaxWidth(0.5f).align(Alignment.CenterHorizontally),
-              shape = RoundedCornerShape(30.dp),
-              colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF6DBA56))) {
-                Text("Create Discussion")
-              }
-
-          Spacer(modifier = Modifier.height(8.dp))
-
-          /** Button to discard and go back */
-          OutlinedButton(
-              onClick = { navigation.goBack() },
-              modifier = Modifier.fillMaxWidth(0.3f).align(Alignment.CenterHorizontally),
-              shape = RoundedCornerShape(30.dp),
-              colors = ButtonDefaults.outlinedButtonColors(contentColor = Color.Red)) {
-                Text("Discard")
-              }
-        }
-      }) { padding ->
+    ) { padding ->
         Column(
-            modifier = Modifier.padding(padding).padding(16.dp).fillMaxSize(),
-            verticalArrangement = Arrangement.Top) {
-              /** Title input field */
-              OutlinedTextField(
-                  value = title,
-                  onValueChange = { title = it },
-                  label = { Text("Title") },
-                  modifier = Modifier.fillMaxWidth())
+            modifier = Modifier
+                .padding(padding)
+                .padding(16.dp)
+                .fillMaxSize(),
+            verticalArrangement = Arrangement.Top
+        ) {
+            /** Title input field */
+            OutlinedTextField(
+                value = title,
+                colors = TextFieldDefaults.colors().copy(
+                    focusedTextColor = AppColors.textIcons,
+                    unfocusedTextColor = AppColors.textIcons,
+                    unfocusedIndicatorColor = AppColors.textIcons,
+                    focusedIndicatorColor = AppColors.textIcons,
+                    unfocusedLabelColor = AppColors.textIconsFade,
+                    focusedLabelColor = AppColors.textIconsFade,
+                    unfocusedContainerColor = Color.Transparent,
+                    focusedContainerColor = Color.Transparent
+                ),
+                textStyle = MaterialTheme.typography.bodySmall,
+                onValueChange = { title = it },
+                label = { Text("Title") },
+                modifier = Modifier.fillMaxWidth()
+            )
 
-              Spacer(modifier = Modifier.height(12.dp))
+            Spacer(modifier = Modifier.height(12.dp))
 
-              /** Description input field */
-              OutlinedTextField(
-                  value = description,
-                  onValueChange = { description = it },
-                  label = { Text("Description (optional)") },
-                  modifier = Modifier.fillMaxWidth().height(150.dp))
+            /** Description input field */
+            OutlinedTextField(
+                value = description,
+                colors = TextFieldDefaults.colors().copy(
+                    focusedTextColor = AppColors.textIcons,
+                    unfocusedTextColor = AppColors.textIcons,
+                    unfocusedIndicatorColor = AppColors.textIcons,
+                    focusedIndicatorColor = AppColors.textIcons,
+                    unfocusedLabelColor = AppColors.textIconsFade,
+                    focusedLabelColor = AppColors.textIconsFade,
+                    unfocusedContainerColor = Color.Transparent,
+                    focusedContainerColor = Color.Transparent
+                ),
+                textStyle = MaterialTheme.typography.bodySmall,
+                onValueChange = { description = it },
+                label = { Text("Description (optional)") },
+                modifier = Modifier.fillMaxWidth().height(150.dp)
+            )
 
-              Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(16.dp))
 
-              /** Row for search and member selection */
-              Row(
-                  modifier = Modifier.fillMaxWidth(),
-                  verticalAlignment = Alignment.CenterVertically) {
-                    Text(
-                        text = "Members:",
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.Bold)
+            /** Row for search and member selection */
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "Members:",
+                    style = MaterialTheme.typography.bodySmall,
+                    fontWeight = FontWeight.Bold
+                )
 
-                    /** Autocomplete search field */
-                    Box(modifier = Modifier.fillMaxWidth().padding(start = 8.dp)) {
-                      OutlinedTextField(
-                          value = searchQuery,
-                          shape = RoundedCornerShape(28.dp),
-                          onValueChange = { searchQuery = it },
-                          label = { Text("Add Members") },
-                          modifier = Modifier.fillMaxWidth(),
-                          trailingIcon = {
+                /** Autocomplete search field */
+                Box(modifier = Modifier.fillMaxWidth().padding(start = 8.dp)) {
+                    OutlinedTextField(
+                        value = searchQuery,
+                        colors = TextFieldDefaults.colors().copy(
+                            focusedTextColor = AppColors.textIcons,
+                            unfocusedTextColor = AppColors.textIcons,
+                            unfocusedIndicatorColor = AppColors.textIcons,
+                            focusedIndicatorColor = AppColors.textIcons,
+                            unfocusedLabelColor = AppColors.textIconsFade,
+                            focusedLabelColor = AppColors.textIconsFade,
+                            unfocusedContainerColor = Color.Transparent,
+                            focusedContainerColor = Color.Transparent
+                        ),
+                        textStyle = MaterialTheme.typography.bodySmall,
+                        shape = CircleShape,
+                        onValueChange = { searchQuery = it },
+                        label = { Text("Add Members") },
+                        modifier = Modifier.fillMaxWidth(),
+                        trailingIcon = {
                             if (searchQuery.isNotBlank()) {
-                              Icon(
-                                  Icons.Default.Close,
-                                  contentDescription = "Clear",
-                                  modifier =
-                                      Modifier.clickable {
+                                Icon(
+                                    Icons.Default.Close,
+                                    contentDescription = "Clear",
+                                    modifier = Modifier.clickable {
                                         searchQuery = ""
                                         dropdownExpanded = false
-                                      })
+                                    }
+                                )
                             }
-                          })
+                        }
+                    )
 
-                      /** Dropdown menu showing search results */
-                      DropdownMenu(
-                          expanded = dropdownExpanded,
-                          onDismissRequest = { dropdownExpanded = false },
-                          modifier = Modifier.fillMaxWidth().background(Color.White)) {
-                            when {
-                              isSearching -> {
+                    /** Dropdown menu showing search results */
+                    DropdownMenu(
+                        expanded = dropdownExpanded,
+                        onDismissRequest = { dropdownExpanded = false },
+                        modifier = Modifier.fillMaxWidth().background(AppColors.divider)
+                    ) {
+                        when {
+                            isSearching -> {
                                 DropdownMenuItem(text = { Text("Searching...") }, onClick = {})
-                              }
-                              searchResults.isEmpty() -> {
+                            }
+                            searchResults.isEmpty() -> {
                                 DropdownMenuItem(text = { Text("No results") }, onClick = {})
-                              }
-                              else -> {
+                            }
+                            else -> {
                                 searchResults.forEach { account ->
-                                  DropdownMenuItem(
-                                      text = { Text(account.name) },
-                                      onClick = {
-                                        selectedMembers.add(account)
-                                        searchQuery = ""
-                                        dropdownExpanded = false
-                                      },
-                                      leadingIcon = {
-                                        Box(
-                                            modifier =
-                                                Modifier.size(32.dp)
+                                    DropdownMenuItem(
+                                        text = { Text(account.name) },
+                                        onClick = {
+                                            selectedMembers.add(account)
+                                            searchQuery = ""
+                                            dropdownExpanded = false
+                                        },
+                                        leadingIcon = {
+                                            Box(
+                                                modifier = Modifier.size(32.dp)
                                                     .clip(CircleShape)
                                                     .background(Color.LightGray),
-                                            contentAlignment = Alignment.Center) {
-                                              Text(
-                                                  text =
-                                                      account.name.firstOrNull()?.toString() ?: "A",
-                                                  color = Color(0xFFFFA000),
-                                                  fontWeight = FontWeight.Bold)
+                                                contentAlignment = Alignment.Center
+                                            ) {
+                                                Text(
+                                                    text = account.name.firstOrNull()?.toString() ?: "A",
+                                                    color = Color(0xFFFFA000),
+                                                    fontWeight = FontWeight.Bold
+                                                )
                                             }
-                                      })
+                                        }
+                                    )
                                 }
-                              }
                             }
-                          }
+                        }
                     }
-                  }
+                }
+            }
 
-              Spacer(modifier = Modifier.height(20.dp))
+            Spacer(modifier = Modifier.height(20.dp))
 
-              /** Divider between search and selected members */
-              HorizontalDivider(
-                  modifier =
-                      Modifier.fillMaxWidth(0.9f)
-                          .padding(horizontal = 0.dp)
-                          .align(Alignment.CenterHorizontally),
-                  thickness = 1.dp,
-                  color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.2f))
+            /** Divider between search and selected members */
+            HorizontalDivider(
+                modifier = Modifier.fillMaxWidth(0.9f)
+                    .padding(horizontal = 0.dp)
+                    .align(Alignment.CenterHorizontally),
+                thickness = 1.dp,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.2f)
+            )
 
-              /** Display list of selected members */
-              if (selectedMembers.isNotEmpty()) {
+            /** Display list of selected members */
+            if (selectedMembers.isNotEmpty()) {
                 Spacer(modifier = Modifier.height(12.dp))
-                LazyColumn {
-                  items(selectedMembers) { member ->
-                    Row(
-                        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
-                        verticalAlignment = Alignment.CenterVertically) {
-                          /** Member avatar */
-                          Box(
-                              modifier =
-                                  Modifier.size(36.dp)
-                                      .clip(CircleShape)
-                                      .background(Color.LightGray),
-                              contentAlignment = Alignment.Center) {
+                LazyColumn ( modifier = Modifier.heightIn(max = 200.dp)) {
+                    items(selectedMembers) { member ->
+                        Row(
+                            modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            /** Member avatar */
+                            Box(
+                                modifier = Modifier.size(36.dp)
+                                    .clip(CircleShape)
+                                    .background(Color.LightGray),
+                                contentAlignment = Alignment.Center
+                            ) {
                                 Text(
                                     text = member.name.firstOrNull()?.toString() ?: "A",
                                     color = Color(0xFFFFA000),
-                                    fontWeight = FontWeight.Bold)
-                              }
-                          Spacer(modifier = Modifier.width(12.dp))
+                                    fontWeight = FontWeight.Bold
+                                )
+                            }
+                            Spacer(modifier = Modifier.width(12.dp))
 
-                          /** Member name */
-                          Text(text = member.name, modifier = Modifier.weight(1f), maxLines = 1)
+                            /** Member name */
+                            Text(text = member.name, modifier = Modifier.weight(1f), maxLines = 1, color = AppColors.textIcons,
+                                fontStyle = MaterialTheme.typography.bodySmall.fontStyle)
 
-                          /** Remove member button */
-                          Icon(
-                              Icons.Default.Cancel,
-                              contentDescription = "Remove",
-                              tint = Color.Red,
-                              modifier = Modifier.clickable { selectedMembers.remove(member) })
+                            /** Remove member button */
+                            Icon(
+                                Icons.Default.Cancel,
+                                contentDescription = "Remove",
+                                tint = AppColors.negative,
+                                modifier = Modifier.clickable { selectedMembers.remove(member) }
+                            )
                         }
-                  }
+                    }
                 }
-              }
             }
-      }
+
+            /** Spacer to move buttons higher */
+            Spacer(modifier = Modifier.height(24.dp))
+
+            /** Buttons section */
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Button(
+                    onClick = {
+                        scope.launch {
+                            viewModel.createDiscussion(
+                                title, description, currentUser, *selectedMembers.toTypedArray()
+                            )
+                            navigation.goBack() // TODO: navigate to new discussion screen
+                        }
+                    },
+                    enabled = title.isNotBlank(),
+                    modifier = Modifier.fillMaxWidth(0.5f),
+                    shape = CircleShape,
+                    colors = ButtonDefaults.buttonColors(containerColor = AppColors.affirmative)
+                ) { Text(text = "Create Discussion", style = MaterialTheme.typography.bodySmall) }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                OutlinedButton(
+                    onClick = { navigation.goBack() },
+                    modifier = Modifier.fillMaxWidth(0.3f),
+                    shape = CircleShape,
+                    colors = ButtonDefaults.outlinedButtonColors(contentColor = AppColors.negative)
+                ) { Text(text = "Discard",
+                    style = MaterialTheme.typography.bodySmall) }
+            }
+        }
+    }
 }
 
 /**
@@ -283,15 +345,16 @@ fun AddDiscussionScreen(
  * @return List of matching [Account] objects
  */
 fun fakeSearchAccounts(query: String): List<Account> {
-  val allAccounts =
-      listOf(
-          Account("1", "Alice"),
-          Account("2", "Bob"),
-          Account("3", "Charlie"),
-          Account("4", "David"),
-          Account("5", "Eve"),
-          Account("6", "Frank"),
-          Account("7", "Grace"),
-          Account("8", "Heidi"))
-  return allAccounts.filter { it.name.contains(query, ignoreCase = true) }
+    val allAccounts =
+        listOf(
+            Account("1", "Alice"),
+            Account("2", "Bob"),
+            Account("3", "Charlie"),
+            Account("4", "David"),
+            Account("5", "Eve"),
+            Account("6", "Frank"),
+            Account("7", "Grace"),
+            Account("8", "Heidi")
+        )
+    return allAccounts.filter { it.name.contains(query, ignoreCase = true) }
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/AddDiscussionScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/AddDiscussionScreen.kt
@@ -31,7 +31,7 @@ import kotlinx.coroutines.launch
  * Navigation is now decoupled using callbacks: [onBack] and [onCreate].
  *
  * @param onBack Lambda called when back/discard is pressed
- * @param onCreate Lambda called with title, description, and members when creating a discussion
+ * @param onCreate Lambda called when creation is successful
  * @param viewModel FirestoreViewModel for creating discussions
  * @param currentUser The currently logged-in user
  */
@@ -39,9 +39,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun AddDiscussionScreen(
     onBack: () -> Unit,
-    onCreate:
-        suspend (
-            title: String, description: String, creator: Account, members: List<Account>) -> Unit,
+    onCreate: () -> Unit,
     viewModel: FirestoreViewModel,
     currentUser: Account
 ) {
@@ -306,8 +304,10 @@ fun AddDiscussionScreen(
                           scope.launch {
                             try {
                               isCreating = true
-                              onCreate(title, description, currentUser, selectedMembers.toList())
+                              viewModel.createDiscussion(
+                                  title, description, currentUser, *selectedMembers.toTypedArray())
                               isCreating = false
+                              onCreate()
                             } catch (e: Exception) {
                               isCreating = false
                               creationError = "Failed to create discussion"

--- a/app/src/main/java/com/github/meeplemeet/ui/AddDiscussionScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/AddDiscussionScreen.kt
@@ -68,7 +68,7 @@ fun AddDiscussionScreen(
     }
 
     isSearching = true
-    // Simulated backend search
+    /** Simulated backend search */
     searchResults =
         fakeSearchAccounts(searchQuery).filter {
           it.uid != currentUser.uid && it !in selectedMembers


### PR DESCRIPTION
# Add Discussion Screen and UI Tests

## Overview
This PR introduces a new `AddDiscussionScreen` in the `ui` module, allowing users to create a discussion by specifying a title, optional description, and selecting members. It also includes a comprehensive suite of UI tests to ensure proper behavior and navigation.

---

## Changes

### 1. `AddDiscussionScreen.kt`
- **Purpose**: Provides a Compose UI screen for creating discussions.
- **Features**:
  - Input fields for **title** and **description**.
  - **Live search** for adding members (excluding the current user and already-selected members).
  - **Dropdown menu** for displaying search results with avatars.
  - **Selected members list** with removal functionality.
  - **Create Discussion** button (enabled only when a title is entered).
  - **Discard** button and back navigation handling.
- **UI Elements**:
  - `OutlinedTextField` for text inputs.
  - `LazyColumn` for displaying selected members.
  - `Button` and `OutlinedButton` for actions.
- **Helpers**:
  - `fakeSearchAccounts(query: String)` simulates backend account search.

---

### 2. `AddDiscussionScreenTest.kt`
- **Purpose**: Ensures the `AddDiscussionScreen` UI behaves as expected.
- **Tests included**:
  - **Initial state**: empty fields and disabled create button.
  - **Title input**: enabling create button.
  - **Navigation**: back button and discard button call `goBack()`.
  - **Member search**:
    - Displaying search results.
    - Adding members.
    - Clearing search input.
    - Removing selected members.
    - Filtering out current user and already-selected members.
  - **Dropdown behavior**: closes when search query is empty.

- **Tools**:
  - Compose Test Rule (`createComposeRule`).
  - MockK for mocking `NavigationActions` and `FirestoreViewModel`.
  - Coroutine test support for async operations.

---

## Notes
- The current implementation uses a **fake search** for demonstration. This should later be replaced with a proper backend query.
- Navigation after creating a discussion currently calls `goBack()`. Consider navigating directly to the newly created discussion in a future iteration.
- UI follows the app's theme with `AppColors` and `Material3` components.

---

## Testing
- All tests pass on the Compose Test Rule environment.
- Verified:
  - Input fields behave correctly.
  - Search and member selection work as intended.
  - Navigation actions are correctly triggered.

<img width="361" height="731" alt="image" src="https://github.com/user-attachments/assets/42418542-5c27-4a02-8b05-a47953184884" />

