### PR TITLE
Try a new version of the CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -252,7 +252,7 @@ jobs:
           force-avd-creation: true
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -skin 1080x2400
           disable-animations: true
-          script: ./gradlew connectedDebugAndroidTest --parallel --build-cache
+          script: ./gradlew connectedAndroidTest --parallel --build-cache
 
       - name: Upload android test coverage
         uses: actions/upload-artifact@v4
@@ -344,9 +344,10 @@ jobs:
         run: |
           REPORT_PATH="app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml"
           if [ -f "$REPORT_PATH" ]; then
-            # Extract line coverage from the root report counter (first occurrence)
-            MISSED=$(grep -m 1 '<counter type="LINE"' "$REPORT_PATH" | sed -n 's/.*missed="\([0-9]*\)".*/\1/p')
-            COVERED=$(grep -m 1 '<counter type="LINE"' "$REPORT_PATH" | sed -n 's/.*covered="\([0-9]*\)".*/\1/p')
+            # Extract aggregate line coverage (last <counter type="LINE"> before </report>)
+            LAST_LINE=$(grep -o '<counter[^>]*>' "$REPORT_PATH" | grep 'type="LINE"' | tail -1)
+            MISSED=$(echo "$LAST_LINE" | sed -n 's/.*missed="\([0-9]*\)".*/\1/p')
+            COVERED=$(echo "$LAST_LINE" | sed -n 's/.*covered="\([0-9]*\)".*/\1/p')
             TOTAL=$((MISSED + COVERED))
             if [ $TOTAL -gt 0 ]; then
               PERCENTAGE=$(awk "BEGIN {printf \"%.2f\", ($COVERED / $TOTAL) * 100}")

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,16 +18,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Setup JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: "17"
 
       - name: Retrieve gradle cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
@@ -45,13 +45,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           fetch-depth: 0
 
       - name: Setup JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: "17"
@@ -73,7 +73,7 @@ jobs:
           fi
 
       - name: Retrieve gradle cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
@@ -94,30 +94,24 @@ jobs:
           path: app/build/reports/lint*.xml
           if-no-files-found: warn
 
-  tests-and-coverage-report:
-    name: Tests and Coverage Report
+  unit-tests:
+    name: Unit Tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Enable KVM group perms
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-
       - name: Setup JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: "17"
 
       - name: Retrieve gradle cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
@@ -167,7 +161,85 @@ jobs:
           fi
 
       - name: Run Unit Tests
-        run: ./gradlew check --parallel --build-cache
+        run: ./gradlew testDebugUnitTest --parallel --build-cache
+
+      - name: Upload unit test coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-coverage
+          path: app/build/outputs/unit_test_code_coverage/debugUnitTest/testDebugUnitTest.exec
+
+  android-tests:
+    name: Android Instrumentation Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Setup JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      - name: Retrieve gradle cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+
+      - name: Decode secrets
+        env:
+          GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
+          LOCAL_PROPERTIES: ${{ secrets.LOCAL_PROPERTIES }}
+        run: |
+          if [ -n "$GOOGLE_SERVICES" ]; then
+            echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
+          else
+            echo "::warning::GOOGLE_SERVICES secret is not set."
+          fi
+          if [ -n "$LOCAL_PROPERTIES" ]; then
+            echo "$LOCAL_PROPERTIES" | base64 --decode > ./local.properties
+          else
+            echo "::warning::LOCAL_PROPERTIES secret is not set."
+          fi
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
+
+      - name: Start Firebase emulators
+        run: |
+          if [ -e "firebase.json" ] && jq -e '.emulators' firebase.json >/dev/null; then
+            echo "Starting Firebase emulators..."
+            firebase emulators:start --only auth,firestore --project demo-project > firebase-emulator.log 2>&1 &
+            echo "Waiting for Firebase emulators to be ready..."
+            for i in {1..30}; do
+              if curl -s http://localhost:9099 >/dev/null 2>&1 && curl -s http://localhost:8080 >/dev/null 2>&1; then
+                echo "Firebase emulators are ready!"
+                break
+              fi
+              if [ $i -eq 30 ]; then
+                echo "Error: Firebase emulators failed to start"
+                cat firebase-emulator.log
+                exit 1
+              fi
+              sleep 1
+            done
+          fi
 
       - name: Run instrumentation tests
         timeout-minutes: 25
@@ -180,9 +252,76 @@ jobs:
           force-avd-creation: true
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -skin 1080x2400
           disable-animations: true
-          script: ./gradlew connectedCheck --parallel --build-cache
+          script: ./gradlew connectedDebugAndroidTest --parallel --build-cache
 
-      - name: Generate coverage
+      - name: Upload android test coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-test-coverage
+          path: app/build/outputs/code_coverage/debugAndroidTest/connected/**/coverage.ec
+
+  coverage-report:
+    name: Coverage Report
+    needs: [unit-tests, android-tests]
+    runs-on: ubuntu-latest
+    outputs:
+      coverage: ${{ steps.coverage.outputs.percentage }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Setup JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      - name: Retrieve gradle cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+
+      - name: Decode secrets
+        env:
+          GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
+          LOCAL_PROPERTIES: ${{ secrets.LOCAL_PROPERTIES }}
+        run: |
+          if [ -n "$GOOGLE_SERVICES" ]; then
+            echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
+          else
+            echo "::warning::GOOGLE_SERVICES secret is not set."
+          fi
+          if [ -n "$LOCAL_PROPERTIES" ]; then
+            echo "$LOCAL_PROPERTIES" | base64 --decode > ./local.properties
+          else
+            echo "::warning::LOCAL_PROPERTIES secret is not set."
+          fi
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Build debug classes
+        run: ./gradlew compileDebugKotlin --parallel --build-cache
+
+      - name: Download unit test coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: unit-test-coverage
+          path: app/build/outputs/unit_test_code_coverage/debugUnitTest/
+
+      - name: Download android test coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: android-test-coverage
+          path: app/build/outputs/code_coverage/debugAndroidTest/connected/
+
+      - name: Generate coverage report
         run: ./gradlew jacocoTestReport --parallel --build-cache
 
       - name: Upload report to SonarCloud
@@ -200,8 +339,51 @@ jobs:
             ./gradlew sonar --parallel --build-cache
           fi
 
-      - name: Upload coverage artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: Coverage report
-          path: app/build/reports/jacoco/jacocoTestReport
+      - name: Extract coverage percentage
+        id: coverage
+        run: |
+          REPORT_PATH="app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml"
+          if [ -f "$REPORT_PATH" ]; then
+            # Extract line coverage from the root report counter (first occurrence)
+            MISSED=$(grep -m 1 '<counter type="LINE"' "$REPORT_PATH" | sed -n 's/.*missed="\([0-9]*\)".*/\1/p')
+            COVERED=$(grep -m 1 '<counter type="LINE"' "$REPORT_PATH" | sed -n 's/.*covered="\([0-9]*\)".*/\1/p')
+            TOTAL=$((MISSED + COVERED))
+            if [ $TOTAL -gt 0 ]; then
+              PERCENTAGE=$(awk "BEGIN {printf \"%.2f\", ($COVERED / $TOTAL) * 100}")
+            else
+              PERCENTAGE="0.00"
+            fi
+            echo "percentage=$PERCENTAGE" >> $GITHUB_OUTPUT
+            echo "Line coverage: $PERCENTAGE%"
+          else
+            echo "percentage=N/A" >> $GITHUB_OUTPUT
+            echo "Coverage report not found"
+          fi
+
+  coverage-summary:
+    name: "Coverage: ${{ needs.coverage-report.outputs.coverage }}%"
+    needs: coverage-report
+    runs-on: ubuntu-latest
+    steps:
+      - name: Coverage Summary
+        run: |
+          COVERAGE="${{ needs.coverage-report.outputs.coverage }}"
+          THRESHOLD=80.00
+          echo "Line coverage is $COVERAGE%"
+          echo "Minimum required coverage is $THRESHOLD%"
+
+          # Check if coverage meets threshold
+          if [ "$COVERAGE" != "N/A" ]; then
+            # Use awk to compare floating point numbers
+            PASSES=$(awk "BEGIN {print ($COVERAGE >= $THRESHOLD) ? 1 : 0}")
+            if [ "$PASSES" -eq 1 ]; then
+              echo "✓ Coverage check passed!"
+              exit 0
+            else
+              echo "✗ Coverage check failed! Coverage ($COVERAGE%) is below threshold ($THRESHOLD%)"
+              exit 1
+            fi
+          else
+            echo "✗ Coverage report not available"
+            exit 1
+          fi


### PR DESCRIPTION
This PR brings changes to the CI to make it faster by running the unit and android tests on seperate jobs and now explicitly fails if the line coverage is less than 80% by running a new job after the coverage is created and sent to sonar qube.