### PR TITLE
Add workflow to build signed APK file

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -334,19 +334,17 @@ jobs:
 
       - name: Upload report to SonarCloud
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          echo "Running Sonar analysis..."
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            ./gradlew clean build --parallel --build-cache
             ./gradlew sonar \
-              -Dsonar.pullrequest.key=${{ github.event.pull_request.number }} \
-              -Dsonar.pullrequest.branch=${{ github.head_ref }} \
-              -Dsonar.pullrequest.base=${{ github.base_ref }} \
-              --stacktrace --info --parallel --build-cache
+            -Dsonar.pullrequest.key=${{ github.event.pull_request.number }} \
+            -Dsonar.pullrequest.branch=${{ github.head_ref }} \
+            -Dsonar.pullrequest.base=${{ github.base_ref }} \
+            --parallel --build-cache
           else
-            ./gradlew clean build --parallel --build-cache
-            ./gradlew sonar --stacktrace --info --parallel --build-cache
+            ./gradlew sonar --parallel --build-cache
           fi
 
       - name: Extract coverage percentage

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -334,17 +334,19 @@ jobs:
 
       - name: Upload report to SonarCloud
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
+          echo "Running Sonar analysis..."
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            ./gradlew clean sonar \
-            -Dsonar.pullrequest.key=${{ github.event.pull_request.number }} \
-            -Dsonar.pullrequest.branch=${{ github.head_ref }} \
-            -Dsonar.pullrequest.base=${{ github.base_ref }} \
-            --parallel --build-cache
+            ./gradlew clean build --parallel --build-cache
+            ./gradlew sonar \
+              -Dsonar.pullrequest.key=${{ github.event.pull_request.number }} \
+              -Dsonar.pullrequest.branch=${{ github.head_ref }} \
+              -Dsonar.pullrequest.base=${{ github.base_ref }} \
+              --stacktrace --info --parallel --build-cache
           else
-            ./gradlew sonar --parallel --build-cache
+            ./gradlew clean build --parallel --build-cache
+            ./gradlew sonar --stacktrace --info --parallel --build-cache
           fi
 
       - name: Extract coverage percentage

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -338,7 +338,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            ./gradlew sonar \
+            ./gradlew clean sonar \
             -Dsonar.pullrequest.key=${{ github.event.pull_request.number }} \
             -Dsonar.pullrequest.branch=${{ github.head_ref }} \
             -Dsonar.pullrequest.base=${{ github.base_ref }} \

--- a/.github/workflows/apk-builder.yml
+++ b/.github/workflows/apk-builder.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   build-apk:

--- a/.github/workflows/apk-builder.yml
+++ b/.github/workflows/apk-builder.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feat/apk-build-workflow
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/apk-builder.yml
+++ b/.github/workflows/apk-builder.yml
@@ -65,4 +65,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: app-release.apk
-          path: app/release/app-release.apk
+          path: app/build/outputs/apk/release/app-release.apk

--- a/.github/workflows/apk-builder.yml
+++ b/.github/workflows/apk-builder.yml
@@ -3,7 +3,8 @@ name: Release Signed APK
 on:
   push:
     branches:
-      - main
+      #- main
+      - feat/apk-build-workflow
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/apk-builder.yml
+++ b/.github/workflows/apk-builder.yml
@@ -50,6 +50,12 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: ./gradlew clean assembleRelease
 
+      - name: List APK output files
+        run: |
+          echo "Listing APK files:"
+          find app -type f -name "*.apk"
+
+
       - name: Upload APK Artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/apk-builder.yml
+++ b/.github/workflows/apk-builder.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Decode Keystore
         run: |
           echo "${{ secrets.KEYSTORE_FILE }}" | base64 --decode > key-store.keystore
+        env:
+          KEYSTORE_PATH: ${{ github.workspace }}/app/key-store.keystore
+
 
       - name: Decode Google Services and Local Properties
         env:

--- a/.github/workflows/apk-builder.yml
+++ b/.github/workflows/apk-builder.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build-apk:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout code
@@ -57,37 +59,32 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: ./gradlew clean assembleRelease
 
-      - name: Get version information
-        id: version
-        run: |
-          VERSION_NAME=$(grep "versionName" app/build.gradle.kts | awk -F'"' '{print $2}')
-          VERSION_CODE=$(grep "versionCode" app/build.gradle.kts | awk '{print $3}')
-          echo "name=$VERSION_NAME" >> $GITHUB_OUTPUT
-          echo "code=$VERSION_CODE" >> $GITHUB_OUTPUT
-          echo "tag=v$VERSION_NAME" >> $GITHUB_OUTPUT
-
-      - name: Rename APK with version
+      - name: Rename APK
         run: |
           mv app/build/outputs/apk/release/app-release.apk \
-             app/build/outputs/apk/release/meeple-meet-v${{ steps.version.outputs.name }}.apk
+             app/build/outputs/apk/release/meeple-meet.apk
 
       - name: Upload APK Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: app-release.apk
-          path: app/build/outputs/apk/release/meeple-meet-v${{ steps.version.outputs.name }}.apk
+          name: meeple-meet-apk
+          path: app/build/outputs/apk/release/meeple-meet.apk
+
+      - name: Get short SHA
+        id: sha
+        run: echo "short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.version.outputs.tag }}
-          name: Meeple Meet ${{ steps.version.outputs.tag }}
+          tag_name: build-${{ github.run_number }}
+          name: Meeple Meet Build #${{ github.run_number }}
           body: |
-            ## Meeple Meet Release ${{ steps.version.outputs.tag }}
+            ## Meeple Meet APK
             
-            **Version Code:** ${{ steps.version.outputs.code }}
+            **Build Number:** ${{ github.run_number }}
             **Build Date:** ${{ github.event.head_commit.timestamp }}
-            **Commit:** ${{ github.sha }}
+            **Commit:** ${{ steps.sha.outputs.short }}
             
             ### Changes
             ${{ github.event.head_commit.message }}
@@ -97,7 +94,7 @@ jobs:
             
             **Note:** You may need to enable "Install from Unknown Sources" in your device settings.
           files: |
-            app/build/outputs/apk/release/meeple-meet-v${{ steps.version.outputs.name }}.apk
+            app/build/outputs/apk/release/meeple-meet.apk
           draft: false
           prerelease: false
           generate_release_notes: true

--- a/.github/workflows/apk-builder.yml
+++ b/.github/workflows/apk-builder.yml
@@ -54,4 +54,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: app-release.apk
-          path: app/build/outputs/apk/release/app-release.apk
+          path: app/release/app-release.apk

--- a/.github/workflows/apk-builder.yml
+++ b/.github/workflows/apk-builder.yml
@@ -55,12 +55,6 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: ./gradlew clean assembleRelease
 
-      - name: List APK output files
-        run: |
-          echo "Listing APK files:"
-          find app -type f -name "*.apk"
-
-
       - name: Upload APK Artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/apk-builder.yml
+++ b/.github/workflows/apk-builder.yml
@@ -25,6 +25,23 @@ jobs:
         run: |
           echo "${{ secrets.KEYSTORE_FILE }}" | base64 --decode > key-store.keystore
 
+      - name: Decode Google Services and Local Properties
+        env:
+          GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
+          LOCAL_PROPERTIES: ${{ secrets.LOCAL_PROPERTIES }}
+        run: |
+          if [ -n "$GOOGLE_SERVICES" ]; then
+            echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
+          else
+            echo "::warning::GOOGLE_SERVICES secret is not set."
+          fi
+          if [ -n "$LOCAL_PROPERTIES" ]; then
+            echo "$LOCAL_PROPERTIES" | base64 --decode > ./local.properties
+          else
+            echo "::warning::LOCAL_PROPERTIES secret is not set."
+          fi
+
+
       - name: Build Signed Release APK
         env:
           KEYSTORE_PATH: key-store.keystore

--- a/.github/workflows/apk-builder.yml
+++ b/.github/workflows/apk-builder.yml
@@ -23,7 +23,9 @@ jobs:
 
       - name: Decode Keystore
         run: |
-          echo "${{ secrets.KEYSTORE_FILE }}" | base64 --decode > key-store.keystore
+          mkdir -p app
+          echo "${{ secrets.KEYSTORE_FILE }}" | base64 --decode > app/key-store.keystore
+          echo "KEYSTORE_PATH=$PWD/app/key-store.keystore" >> $GITHUB_ENV
         env:
           KEYSTORE_PATH: ${{ github.workspace }}/app/key-store.keystore
 

--- a/.github/workflows/apk-builder.yml
+++ b/.github/workflows/apk-builder.yml
@@ -34,7 +34,7 @@ jobs:
         run: ./gradlew clean assembleRelease
 
       - name: Upload APK Artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v3
         with:
           name: app-release.apk
           path: app/build/outputs/apk/release/app-release.apk

--- a/.github/workflows/apk-builder.yml
+++ b/.github/workflows/apk-builder.yml
@@ -1,0 +1,38 @@
+name: Release Signed APK
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-apk:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Decode Keystore
+        run: |
+          echo "${{ secrets.KEYSTORE_FILE }}" | base64 --decode > key-store.keystore
+
+      - name: Build Signed Release APK
+        env:
+          KEYSTORE_PATH: key-store.keystore
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        run: ./gradlew clean assembleRelease
+
+      - name: Upload APK Artifact
+        uses: actions/upload-artifact@v5
+        with:
+          name: app-release.apk
+          path: app/build/outputs/apk/release/app-release.apk

--- a/.github/workflows/apk-builder.yml
+++ b/.github/workflows/apk-builder.yml
@@ -3,8 +3,7 @@ name: Release Signed APK
 on:
   push:
     branches:
-      #- main
-      - feat/apk-build-workflow
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/apk-builder.yml
+++ b/.github/workflows/apk-builder.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - feat/apk-build-workflow
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/apk-builder.yml
+++ b/.github/workflows/apk-builder.yml
@@ -34,7 +34,7 @@ jobs:
         run: ./gradlew clean assembleRelease
 
       - name: Upload APK Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: app-release.apk
           path: app/build/outputs/apk/release/app-release.apk

--- a/.github/workflows/apk-builder.yml
+++ b/.github/workflows/apk-builder.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - feat/apk-build-workflow
   workflow_dispatch:
 
 jobs:
@@ -45,6 +46,8 @@ jobs:
             echo "::warning::LOCAL_PROPERTIES secret is not set."
           fi
 
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
 
       - name: Build Signed Release APK
         env:
@@ -54,8 +57,49 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: ./gradlew clean assembleRelease
 
+      - name: Get version information
+        id: version
+        run: |
+          VERSION_NAME=$(grep "versionName" app/build.gradle.kts | awk -F'"' '{print $2}')
+          VERSION_CODE=$(grep "versionCode" app/build.gradle.kts | awk '{print $3}')
+          echo "name=$VERSION_NAME" >> $GITHUB_OUTPUT
+          echo "code=$VERSION_CODE" >> $GITHUB_OUTPUT
+          echo "tag=v$VERSION_NAME" >> $GITHUB_OUTPUT
+
+      - name: Rename APK with version
+        run: |
+          mv app/build/outputs/apk/release/app-release.apk \
+             app/build/outputs/apk/release/meeple-meet-v${{ steps.version.outputs.name }}.apk
+
       - name: Upload APK Artifact
         uses: actions/upload-artifact@v4
         with:
           name: app-release.apk
-          path: app/build/outputs/apk/release/app-release.apk
+          path: app/build/outputs/apk/release/meeple-meet-v${{ steps.version.outputs.name }}.apk
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: Meeple Meet ${{ steps.version.outputs.tag }}
+          body: |
+            ## Meeple Meet Release ${{ steps.version.outputs.tag }}
+            
+            **Version Code:** ${{ steps.version.outputs.code }}
+            **Build Date:** ${{ github.event.head_commit.timestamp }}
+            **Commit:** ${{ github.sha }}
+            
+            ### Changes
+            ${{ github.event.head_commit.message }}
+            
+            ### Installation
+            Download the APK file below and install it on your Android device.
+            
+            **Note:** You may need to enable "Install from Unknown Sources" in your device settings.
+          files: |
+            app/build/outputs/apk/release/meeple-meet-v${{ steps.version.outputs.name }}.apk
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,7 +76,7 @@ android {
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
             )
-            signingConfig = signingConfigs.release
+            signingConfig = signingConfigs.getByName("release")
         }
         debug {
             enableUnitTestCoverage = true

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,7 +62,7 @@ android {
     }
 
     signingConfigs {
-        release {
+        create("release") {
             storeFile = file(System.getenv("KEYSTORE_PATH"))
             storePassword = System.getenv("KEYSTORE_PASSWORD")
             keyAlias = System.getenv("KEY_ALIAS")
@@ -71,7 +71,7 @@ android {
     }
 
     buildTypes {
-        release {
+        getByName("release") {
             isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,6 +11,16 @@ plugins {
     alias(libs.plugins.sonar)
 }
 
+// Force newer version of commons-compress for all configurations including sonar
+configurations.all {
+    resolutionStrategy.eachDependency {
+        if (requested.group == "org.apache.commons" && requested.name == "commons-compress") {
+            useVersion("1.26.1")
+            because("Fixes compatibility issue with Gradle and SonarQube plugin")
+        }
+    }
+}
+
 sonar {
     //disable automatic analysis
     properties {
@@ -285,12 +295,4 @@ configurations.forEach { configuration ->
     // Exclude protobuf-lite from all configurations
     // This fixes a fatal exception for tests interacting with Cloud Firestore
     configuration.exclude("com.google.protobuf", "protobuf-lite")
-}
-
-configurations.all {
-    resolutionStrategy.eachDependency {
-        if (requested.group == "org.apache.commons" && requested.name == "commons-compress") {
-            useVersion("1.26.1")
-        }
-    }
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,10 +63,17 @@ android {
 
     signingConfigs {
         create("release") {
-            storeFile = file(System.getenv("KEYSTORE_PATH"))
-            storePassword = System.getenv("KEYSTORE_PASSWORD")
-            keyAlias = System.getenv("KEY_ALIAS")
-            keyPassword = System.getenv("KEY_PASSWORD")
+            val keystorePath = System.getenv("KEYSTORE_PATH")
+            val keystorePassword = System.getenv("KEYSTORE_PASSWORD")
+            val keystoreKeyAlias = System.getenv("KEY_ALIAS")
+            val keystoreKeyPassword = System.getenv("KEY_PASSWORD")
+
+            if (keystorePath != null) {
+                storeFile = file(keystorePath)
+                storePassword = keystorePassword
+                keyAlias = keystoreKeyAlias
+                keyPassword = keystoreKeyPassword
+            }
         }
     }
 
@@ -76,7 +83,10 @@ android {
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
             )
-            signingConfig = signingConfigs.getByName("release")
+            // Only apply signing config if keystore is configured
+            if (System.getenv("KEYSTORE_PATH") != null) {
+                signingConfig = signingConfigs.getByName("release")
+            }
         }
         debug {
             enableUnitTestCoverage = true

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -61,12 +61,22 @@ android {
         manifestPlaceholders["MAPS_API_KEY"] = mapsApiKey
     }
 
+    signingConfigs {
+        release {
+            storeFile = file(System.getenv("KEYSTORE_PATH"))
+            storePassword = System.getenv("KEYSTORE_PASSWORD")
+            keyAlias = System.getenv("KEY_ALIAS")
+            keyPassword = System.getenv("KEY_PASSWORD")
+        }
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
             )
+            signingConfig = signingConfigs.release
         }
         debug {
             enableUnitTestCoverage = true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,16 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+
+buildscript {
+    configurations.all {
+        resolutionStrategy.eachDependency {
+            if (requested.group == "org.apache.commons" && requested.name == "commons-compress") {
+                useVersion("1.26.1")
+                because("Fixes TarArchiveInputStream.getNextEntry() compatibility issue with Gradle 8.7+")
+            }
+        }
+    }
+}
+
 plugins {
     alias(libs.plugins.androidApplication) apply false
     alias(libs.plugins.jetbrainsKotlinAndroid) apply false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,3 +5,11 @@ plugins {
     alias(libs.plugins.ktfmt) apply false
     alias(libs.plugins.gms) apply false
 }
+
+configurations.all {
+    resolutionStrategy.eachDependency {
+        if (requested.group == "org.apache.commons" && requested.name == "commons-compress") {
+            useVersion("1.26.1")
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -125,4 +125,4 @@ androidApplication = { id = "com.android.application", version.ref = "agp" }
 jetbrainsKotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 ktfmt = { id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt" }
 gms = { id = "com.google.gms.google-services", version.ref = "gms" }
-sonar = { id = "org.sonarqube", version = "6.3.1.5724" }
+sonar = { id = "org.sonarqube", version = "5.1.0.4882" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -125,4 +125,4 @@ androidApplication = { id = "com.android.application", version.ref = "agp" }
 jetbrainsKotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 ktfmt = { id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt" }
 gms = { id = "com.google.gms.google-services", version.ref = "gms" }
-sonar = { id = "org.sonarqube", version = "7.0.0.6105" }
+sonar = { id = "org.sonarqube", version = "6.3.1.5724" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -125,4 +125,4 @@ androidApplication = { id = "com.android.application", version.ref = "agp" }
 jetbrainsKotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 ktfmt = { id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt" }
 gms = { id = "com.google.gms.google-services", version.ref = "gms" }
-sonar = { id = "org.sonarqube", version = "4.4.1.3373" }
+sonar = { id = "org.sonarqube", version = "7.0.0.6105" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,8 +17,8 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
     }
+
 }
 
 rootProject.name = "Meeple Meet"
 include(":app")
- 


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that builds a signed APK. 
- The workflow is triggered on pushes to the main branch.  
- It can also be triggered manually via the Actions tab.  
- The workflow securely uses secrets for the keystore file.
