### PR TITLE
Implement the Game model, as well as a GameRepository to search for games

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/integration/FirestoreGameTests.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/FirestoreGameTests.kt
@@ -1,0 +1,238 @@
+package com.github.meeplemeet.integration
+
+import com.github.meeplemeet.model.GameNotFoundException
+import com.github.meeplemeet.model.repositories.FirestoreGameRepository
+import com.github.meeplemeet.model.repositories.GAMES_COLLECTION_PATH
+import com.github.meeplemeet.model.structures.Game
+import com.github.meeplemeet.model.structures.GameNoUid
+import com.github.meeplemeet.utils.FirestoreTests
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+class FirestoreGameTests : FirestoreTests() {
+  private lateinit var repository: FirestoreGameRepository
+
+  @Before
+  fun setup() {
+    repository = FirestoreGameRepository(db)
+
+    // Clean collection and insert some baseline documents
+    runBlocking {
+      // Delete existing documents in the collection (defensive)
+      val existing = db.collection(GAMES_COLLECTION_PATH).get().await()
+      existing.documents.forEach { it.reference.delete().await() }
+
+      // Insert baseline games used by multiple tests
+      addGameDoc("g_catan", "Catan", genres = listOf(1, 2))
+      addGameDoc("g_carcassonne", "Carcassonne", genres = listOf(2))
+      addGameDoc("g_chess", "Chess", genres = listOf(3))
+    }
+  }
+
+  @After
+  fun tearDown() {
+    runBlocking {
+      val snapshot = db.collection(GAMES_COLLECTION_PATH).get().await()
+      val batch = db.batch()
+      snapshot.documents.forEach { batch.delete(it.reference) }
+      batch.commit().await()
+    }
+  }
+
+  private fun addGameDoc(id: String, name: String, genres: List<Int> = emptyList()) = runBlocking {
+    db.collection(GAMES_COLLECTION_PATH)
+        .document(id)
+        .set(GameNoUid(name = name, genres = genres))
+        .await()
+  }
+
+  @Test
+  fun getGames_returns_up_to_maxResults() = runTest {
+    runBlocking {
+      for (i in 1..5) {
+        addGameDoc("g_extra_$i", "ExtraGame$i", genres = listOf(1))
+      }
+    }
+
+    val results = repository.getGames(maxResults = 3)
+    assertEquals(3, results.size)
+  }
+
+  @Test
+  fun getGames_returns_all_games_without_exception() = runTest {
+    val results = repository.getGames(maxResults = 10)
+
+    assertTrue(results.size >= 3)
+    assertTrue(results.any { it.name == "Catan" })
+    assertTrue(results.any { it.name == "Carcassonne" })
+    assertTrue(results.any { it.name == "Chess" })
+  }
+
+  @Test
+  fun getGameById_returns_expected_game() = runTest {
+    val game: Game = repository.getGameById("g_catan")
+    assertEquals("Catan", game.name)
+    assertEquals("g_catan", game.uid)
+  }
+
+  @Test(expected = GameNotFoundException::class)
+  fun getGameById_throws_when_missing() = runTest { repository.getGameById("non-existent-id") }
+
+  @Test
+  fun getGameByName_returns_first_matching_game() = runTest {
+    val result = repository.getGameByName("Carcassonne")
+    assertNotNull(result)
+    assertEquals("Carcassonne", result!!.name)
+  }
+
+  @Test
+  fun getGameByName_returns_null_when_none() = runTest {
+    val result = repository.getGameByName("DoesNotExist")
+    assertNull(result)
+  }
+
+  @Test
+  fun getGamesByGenre_returns_only_games_containing_genre() = runTest {
+    val results = repository.getGamesByGenre(2, maxResults = 10)
+    val names = results.map { it.name }
+    assertTrue(names.contains("Catan"))
+    assertTrue(names.contains("Carcassonne"))
+    assertFalse(names.contains("Chess"))
+  }
+
+  @Test
+  fun getGamesByGenre_respects_maxResults() = runTest {
+    // insert 5 games that contain genre 99
+    runBlocking {
+      for (i in 1..5) {
+        addGameDoc("g_gen_99_$i", "Genre99Game$i", genres = listOf(99))
+      }
+    }
+
+    val results = repository.getGamesByGenre(99, maxResults = 2)
+    assertEquals(2, results.size)
+    // ensure all results contain the genre
+    assertTrue(results.all { 99 in it.genres })
+  }
+
+  @Test
+  fun getGamesByGenres_returns_only_games_containing_all_genres() = runTest {
+    // add a document that has genres 1 and 2
+    runBlocking {
+      addGameDoc("g_complex", "ComplexGame", genres = listOf(1, 2, 3))
+      addGameDoc("g_partial", "PartialGame", genres = listOf(1, 2))
+      addGameDoc("g_other", "OtherGame", genres = listOf(2, 3))
+    }
+
+    val results = repository.getGamesByGenres(listOf(1, 2), maxResults = 10)
+    val names = results.map { it.name }
+    assertTrue(names.contains("ComplexGame"))
+    assertTrue(names.contains("PartialGame"))
+    assertFalse(names.contains("OtherGame"))
+  }
+
+  @Test
+  fun getGamesByGenres_respects_maxResults_and_intersection() = runTest {
+    // create several games with genres [10,20], some extra ones that don't match fully
+    runBlocking {
+      addGameDoc("g_both_1", "BothOne", genres = listOf(10, 20))
+      addGameDoc("g_both_2", "BothTwo", genres = listOf(10, 20))
+      addGameDoc("g_both_3", "BothThree", genres = listOf(10, 20))
+      addGameDoc("g_partial", "Only10", genres = listOf(10))
+      addGameDoc("g_other", "Only20", genres = listOf(20))
+    }
+
+    val results = repository.getGamesByGenres(listOf(10, 20), maxResults = 2)
+    // limited by maxResults
+    assertEquals(2, results.size)
+    // all returned games must contain both genres
+    assertTrue(results.all { game -> listOf(10, 20).all { it in game.genres } })
+  }
+
+  @Test
+  fun searchGamesByNameContains_returns_matching_games_ignoreCase_true() = runTest {
+    // baseline already has "Catan" and "Carcassonne"
+    val results =
+        repository.searchGamesByNameContains(query = "cat", maxResults = 10, ignoreCase = true)
+    val resultNames = results.map { it.name.lowercase() }
+    assertTrue(resultNames.any { it.contains("cat") })
+    assertTrue(resultNames.contains("catan"))
+  }
+
+  @Test
+  fun searchGamesByNameContains_respects_maxResults_and_ranking() = runTest {
+    // add more docs to test maxResults and ordering
+    runBlocking {
+      addGameDoc("g_catan_jr", "Catan Junior")
+      addGameDoc("g_concatenate", "Concatenate")
+    }
+
+    val results =
+        repository.searchGamesByNameContains(query = "cat", maxResults = 2, ignoreCase = true)
+
+    assertTrue(results.size <= 2)
+    assertTrue(results.any { it.name == "Catan" } || results.any { it.name == "Catan Junior" })
+  }
+
+  @Test
+  fun searchGamesByNameContains_is_empty_for_blank_query() = runTest {
+    val results =
+        repository.searchGamesByNameContains(query = "", maxResults = 10, ignoreCase = true)
+    assertTrue(results.isEmpty())
+  }
+
+  @Test
+  fun searchGamesByNameContains_caseSensitive_noMatch_when_caseDiffers() = runTest {
+    // baseline: "Catan" exists from setup
+    val resultsCaseSensitive =
+        repository.searchGamesByNameContains(query = "cat", maxResults = 10, ignoreCase = false)
+    // "Catan" starts with 'C' — case-sensitive 'cat' should NOT match "Catan"
+    assertTrue(resultsCaseSensitive.none { it.name == "Catan" })
+  }
+
+  @Test
+  fun searchGamesByNameContains_prioritizes_prefix_and_respects_maxResults() = runTest {
+    // add docs: one that startsWith "cat", one that contains "cat" later, one unrelated
+    runBlocking {
+      addGameDoc("g_catan_jr", "Catan Junior", genres = emptyList())
+      addGameDoc("g_concatenate", "Concatenate", genres = emptyList())
+      addGameDoc("g_catapult", "catapult", genres = emptyList())
+    }
+
+    val results =
+        repository.searchGamesByNameContains(query = "cat", maxResults = 2, ignoreCase = true)
+
+    // respect du maxResults
+    assertTrue(results.size <= 2)
+
+    val first = results.firstOrNull()
+    assertNotNull(first)
+    assertTrue(first!!.name.startsWith("cat", ignoreCase = true))
+  }
+
+  @Test
+  fun searchGamesByNameContains_ignoreCase_variants() = runTest {
+    runBlocking {
+      addGameDoc("g_MyGameAllLower", "mygame", genres = emptyList())
+      addGameDoc("g_MyGameCapital", "MyGame", genres = emptyList())
+    }
+
+    val resIgnoreTrue =
+        repository.searchGamesByNameContains(query = "myg", maxResults = 10, ignoreCase = true)
+    assertTrue(
+        resIgnoreTrue.any {
+          it.name.equals("mygame", ignoreCase = true) || it.name.equals("MyGame", ignoreCase = true)
+        })
+
+    val resIgnoreFalse =
+        repository.searchGamesByNameContains(query = "myg", maxResults = 10, ignoreCase = false)
+    // case-sensitive: "myg" should match "mygame" but not "MyGame"
+    assertTrue(resIgnoreFalse.any { it.name == "mygame" })
+    assertTrue(resIgnoreFalse.none { it.name == "MyGame" })
+  }
+}

--- a/app/src/androidTest/java/com/github/meeplemeet/integration/FirestoreGameTests.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/FirestoreGameTests.kt
@@ -84,19 +84,6 @@ class FirestoreGameTests : FirestoreTests() {
   fun getGameById_throws_when_missing() = runTest { repository.getGameById("non-existent-id") }
 
   @Test
-  fun getGameByName_returns_first_matching_game() = runTest {
-    val result = repository.getGameByName("Carcassonne")
-    assertNotNull(result)
-    assertEquals("Carcassonne", result!!.name)
-  }
-
-  @Test
-  fun getGameByName_returns_null_when_none() = runTest {
-    val result = repository.getGameByName("DoesNotExist")
-    assertNull(result)
-  }
-
-  @Test
   fun getGamesByGenre_returns_only_games_containing_genre() = runTest {
     val results = repository.getGamesByGenre(2, maxResults = 10)
     val names = results.map { it.name }

--- a/app/src/androidTest/java/com/github/meeplemeet/integration/FirestoreSessionTests.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/FirestoreSessionTests.kt
@@ -958,4 +958,44 @@ class FirestoreSessionTests : FirestoreTests() {
 
     vm.setGameQuery(account3, baseDiscussion, "cat")
   }
+
+  @Test
+  fun getGameFromId_updates_state_when_successful() = runTest {
+    val fakeRepo =
+        FakeGameRepo().apply {
+          returnedGame =
+              Game(
+                  uid = "g_123",
+                  name = "Terraforming Mars",
+                  description = "",
+                  imageURL = "",
+                  minPlayers = 1,
+                  maxPlayers = 5,
+                  recommendedPlayers = null,
+                  averagePlayTime = null,
+                  genres = emptyList())
+        }
+    val vm = FirestoreSessionViewModel(baseDiscussion, sessionRepository, fakeRepo)
+
+    vm.getGameFromId("g_123")
+    advanceUntilIdle()
+
+    val state = vm.gameUIState.value
+    assertNotNull(state.fetchedGame)
+    assertEquals("g_123", state.fetchedGame?.uid)
+    assertNull(state.gameFetchError)
+  }
+
+  @Test
+  fun getGameFromId_sets_error_state_on_failure() = runTest {
+    val fakeRepo = FakeGameRepo().apply { shouldThrow = true }
+    val vm = FirestoreSessionViewModel(baseDiscussion, sessionRepository, fakeRepo)
+
+    vm.getGameFromId("g_404")
+    advanceUntilIdle()
+
+    val state = vm.gameUIState.value
+    assertNull(state.fetchedGame)
+    assertEquals("Failed to fetch game details", state.gameFetchError)
+  }
 }

--- a/app/src/androidTest/java/com/github/meeplemeet/integration/FirestoreSessionTests.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/FirestoreSessionTests.kt
@@ -8,9 +8,11 @@ import com.github.meeplemeet.model.repositories.FirestoreRepository
 import com.github.meeplemeet.model.repositories.FirestoreSessionRepository
 import com.github.meeplemeet.model.structures.Account
 import com.github.meeplemeet.model.structures.Discussion
+import com.github.meeplemeet.model.structures.Game
 import com.github.meeplemeet.model.structures.Location
 import com.github.meeplemeet.model.structures.Session
 import com.github.meeplemeet.model.viewmodels.FirestoreSessionViewModel
+import com.github.meeplemeet.utils.FakeGameRepo
 import com.github.meeplemeet.utils.FirestoreTests
 import com.google.firebase.Timestamp
 import io.mockk.coEvery
@@ -18,6 +20,7 @@ import io.mockk.mockk
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNotNull
 import junit.framework.TestCase.assertNull
+import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
@@ -857,5 +860,102 @@ class FirestoreSessionTests : FirestoreTests() {
     assertEquals("Second Session", secondSession.session?.name)
     assertEquals("game222", secondSession.session?.gameId)
     assertEquals(listOf(account2.uid), secondSession.session?.participants)
+  }
+
+  // ------------------------
+  // Tests for setGame / setGameQuery (FirestoreSessionViewModel)
+  // ------------------------
+
+  @Test
+  fun setGame_updates_selectedGameUid_and_query_when_admin() = runTest {
+    val game =
+        Game(
+            uid = "g_1",
+            name = "Catan",
+            description = "",
+            imageURL = "",
+            minPlayers = 1,
+            maxPlayers = 4,
+            recommendedPlayers = null,
+            averagePlayTime = null,
+            genres = emptyList())
+
+    val fakeRepo = FakeGameRepo()
+    val vm = FirestoreSessionViewModel(baseDiscussion, sessionRepository, fakeRepo)
+
+    vm.setGame(account1, baseDiscussion, game)
+
+    val state = vm.gameUIState.value
+    assertEquals(game.uid, state.selectedGameUid)
+    assertEquals(game.name, state.gameQuery)
+  }
+
+  @Test(expected = PermissionDeniedException::class)
+  fun setGame_throws_when_not_admin() = runTest {
+    val game =
+        Game(
+            uid = "g_2",
+            name = "Azul",
+            description = "",
+            imageURL = "",
+            minPlayers = 2,
+            maxPlayers = 4,
+            recommendedPlayers = null,
+            averagePlayTime = null,
+            genres = emptyList())
+
+    val fakeRepo = FakeGameRepo()
+    val vm = FirestoreSessionViewModel(baseDiscussion, sessionRepository, fakeRepo)
+
+    vm.setGame(account3, baseDiscussion, game)
+  }
+
+  @Test
+  fun setGameQuery_updates_suggestions_when_admin() = runTest {
+    val game =
+        Game(
+            uid = "g_3",
+            name = "Catan Junior",
+            description = "",
+            imageURL = "",
+            minPlayers = 2,
+            maxPlayers = 4,
+            recommendedPlayers = null,
+            averagePlayTime = null,
+            genres = emptyList())
+
+    val fakeRepo = FakeGameRepo().apply { returnedGames = listOf(game) }
+    val vm = FirestoreSessionViewModel(baseDiscussion, sessionRepository, fakeRepo)
+
+    vm.setGameQuery(account1, baseDiscussion, "cat")
+    advanceUntilIdle()
+
+    val state = vm.gameUIState.value
+    assertEquals("cat", state.gameQuery)
+    assertEquals(1, state.gameSuggestions.size)
+    assertEquals(game.uid, state.gameSuggestions[0].uid)
+    assertNull(state.gameSearchError)
+  }
+
+  @Test
+  fun setGameQuery_sets_error_on_repository_failure() = runTest {
+    val fakeRepo = FakeGameRepo().apply { shouldThrow = true }
+    val vm = FirestoreSessionViewModel(baseDiscussion, sessionRepository, fakeRepo)
+
+    vm.setGameQuery(account1, baseDiscussion, "cat")
+    advanceUntilIdle()
+
+    val state = vm.gameUIState.value
+    assertEquals("cat", state.gameQuery)
+    assertTrue(state.gameSuggestions.isEmpty())
+    assertNotNull(state.gameSearchError)
+  }
+
+  @Test(expected = PermissionDeniedException::class)
+  fun setGameQuery_throws_when_not_admin() = runTest {
+    val fakeRepo = FakeGameRepo()
+    val vm = FirestoreSessionViewModel(baseDiscussion, sessionRepository, fakeRepo)
+
+    vm.setGameQuery(account3, baseDiscussion, "cat")
   }
 }

--- a/app/src/androidTest/java/com/github/meeplemeet/utils/FakeGameRepo.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/utils/FakeGameRepo.kt
@@ -18,10 +18,6 @@ class FakeGameRepo() : GameRepository {
     return returnedGame ?: throw NoSuchElementException("No game found")
   }
 
-  override suspend fun getGameByName(name: String): Game? {
-    throw NotImplementedError("FakeGameRepo: unused method in this test context")
-  }
-
   override suspend fun getGamesByGenre(genreID: Int, maxResults: Int): List<Game> {
     throw NotImplementedError("FakeGameRepo: unused method in this test context")
   }

--- a/app/src/androidTest/java/com/github/meeplemeet/utils/FakeGameRepo.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/utils/FakeGameRepo.kt
@@ -7,13 +7,15 @@ class FakeGameRepo() : GameRepository {
   var returnedGames: List<Game> = emptyList()
   var shouldThrow: Boolean = false
   var lastQuery: String? = null
+  var returnedGame: Game? = null
 
   override suspend fun getGames(maxResults: Int): List<Game> {
     TODO("Not used in tests")
   }
 
   override suspend fun getGameById(gameID: String): Game {
-    TODO("Not used in tests")
+    if (shouldThrow) throw RuntimeException("boom")
+    return returnedGame ?: throw NoSuchElementException("No game found")
   }
 
   override suspend fun getGameByName(name: String): Game? {

--- a/app/src/androidTest/java/com/github/meeplemeet/utils/FakeGameRepo.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/utils/FakeGameRepo.kt
@@ -1,0 +1,40 @@
+package com.github.meeplemeet.utils
+
+import com.github.meeplemeet.model.repositories.GameRepository
+import com.github.meeplemeet.model.structures.Game
+
+class FakeGameRepo() : GameRepository {
+  var returnedGames: List<Game> = emptyList()
+  var shouldThrow: Boolean = false
+  var lastQuery: String? = null
+
+  override suspend fun getGames(maxResults: Int): List<Game> {
+    TODO("Not used in tests")
+  }
+
+  override suspend fun getGameById(gameID: String): Game {
+    TODO("Not used in tests")
+  }
+
+  override suspend fun getGameByName(name: String): Game? {
+    TODO("Not used in tests")
+  }
+
+  override suspend fun getGamesByGenre(genreID: Int, maxResults: Int): List<Game> {
+    TODO("Not used in tests")
+  }
+
+  override suspend fun getGamesByGenres(genreIDs: List<Int>, maxResults: Int): List<Game> {
+    TODO("Not used in tests")
+  }
+
+  override suspend fun searchGamesByNameContains(
+      query: String,
+      maxResults: Int,
+      ignoreCase: Boolean
+  ): List<Game> {
+    lastQuery = query
+    if (shouldThrow) throw RuntimeException("boom")
+    return returnedGames
+  }
+}

--- a/app/src/androidTest/java/com/github/meeplemeet/utils/FakeGameRepo.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/utils/FakeGameRepo.kt
@@ -10,7 +10,7 @@ class FakeGameRepo() : GameRepository {
   var returnedGame: Game? = null
 
   override suspend fun getGames(maxResults: Int): List<Game> {
-    TODO("Not used in tests")
+    throw NotImplementedError("FakeGameRepo: unused method in this test context")
   }
 
   override suspend fun getGameById(gameID: String): Game {
@@ -19,15 +19,15 @@ class FakeGameRepo() : GameRepository {
   }
 
   override suspend fun getGameByName(name: String): Game? {
-    TODO("Not used in tests")
+    throw NotImplementedError("FakeGameRepo: unused method in this test context")
   }
 
   override suspend fun getGamesByGenre(genreID: Int, maxResults: Int): List<Game> {
-    TODO("Not used in tests")
+    throw NotImplementedError("FakeGameRepo: unused method in this test context")
   }
 
   override suspend fun getGamesByGenres(genreIDs: List<Int>, maxResults: Int): List<Game> {
-    TODO("Not used in tests")
+    throw NotImplementedError("FakeGameRepo: unused method in this test context")
   }
 
   override suspend fun searchGamesByNameContains(

--- a/app/src/main/java/com/github/meeplemeet/model/repositories/FirestoreGameRepository.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/repositories/FirestoreGameRepository.kt
@@ -24,7 +24,7 @@ class FirestoreGameRepository(db: FirebaseFirestore = FirebaseProvider.db) : Gam
 
   /** Retrieves all games (within [maxResults]) from Firestore. */
   override suspend fun getGames(maxResults: Int): List<Game> {
-    val snapshot = games.get().await()
+    val snapshot = games.limit(maxResults.toLong()).get().await()
     return mapSnapshotToGames(snapshot.documents)
   }
 

--- a/app/src/main/java/com/github/meeplemeet/model/repositories/FirestoreGameRepository.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/repositories/FirestoreGameRepository.kt
@@ -36,17 +36,6 @@ class FirestoreGameRepository(db: FirebaseFirestore = FirebaseProvider.db) : Gam
   }
 
   /**
-   * Retrieves a single game by its exact name.
-   *
-   * This performs a case-sensitive search in Firestore.
-   */
-  override suspend fun getGameByName(name: String): Game? {
-    val query = games.whereEqualTo("name", name).get().await()
-    val results = mapSnapshotToGames(query.documents)
-    return results.firstOrNull()
-  }
-
-  /**
    * Retrieves all games (within [maxResults]) that include a given genre ID.
    *
    * This uses Firestore's `array-contains` query operator.

--- a/app/src/main/java/com/github/meeplemeet/model/repositories/GameRepository.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/repositories/GameRepository.kt
@@ -33,14 +33,6 @@ interface GameRepository {
   suspend fun getGameById(gameID: String): Game
 
   /**
-   * Retrieves a [Game] by its exact name.
-   *
-   * @param name the exact name of the game to search for.
-   * @return the matching [Game] object, or null if no game with the given name exists.
-   */
-  suspend fun getGameByName(name: String): Game?
-
-  /**
    * Retrieves games that include a specific genre ID.
    *
    * Returns up to [maxResults] items.

--- a/app/src/main/java/com/github/meeplemeet/model/structures/Game.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/structures/Game.kt
@@ -20,10 +20,10 @@ data class Game(
     val name: String,
     val description: String,
     val imageURL: String,
-    val minPlayers: UInt,
-    val maxPlayers: UInt,
-    val recommendedPlayers: UInt?,
-    val averagePlayTime: UInt?,
+    val minPlayers: Int,
+    val maxPlayers: Int,
+    val recommendedPlayers: Int?,
+    val averagePlayTime: Int?,
     val genres: List<Int> = emptyList()
 )
 
@@ -37,10 +37,10 @@ data class GameNoUid(
     val name: String = "",
     val description: String = "",
     val imageURL: String = "",
-    val minPlayers: UInt = 0u,
-    val maxPlayers: UInt = 0u,
-    val recommendedPlayers: UInt? = null,
-    val averagePlayTime: UInt? = null,
+    val minPlayers: Int = 0,
+    val maxPlayers: Int = 0,
+    val recommendedPlayers: Int? = null,
+    val averagePlayTime: Int? = null,
     val genres: List<Int> = emptyList()
 )
 

--- a/app/src/main/java/com/github/meeplemeet/model/viewmodels/FirestoreSessionViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/viewmodels/FirestoreSessionViewModel.kt
@@ -3,14 +3,35 @@ package com.github.meeplemeet.model.viewmodels
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.github.meeplemeet.model.PermissionDeniedException
+import com.github.meeplemeet.model.repositories.FirestoreGameRepository
 import com.github.meeplemeet.model.repositories.FirestoreSessionRepository
+import com.github.meeplemeet.model.repositories.GameRepository
 import com.github.meeplemeet.model.structures.Account
 import com.github.meeplemeet.model.structures.Discussion
+import com.github.meeplemeet.model.structures.Game
 import com.github.meeplemeet.model.structures.Location
 import com.google.firebase.Timestamp
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+
+/**
+ * UI state for the session game picker.
+ *
+ * @property gameQuery Current text in the game search text field (what the user typed).
+ * @property gameSuggestions List of candidate [Game] objects returned by the repository for the
+ *   current query.
+ * @property selectedGameUid If a game has been selected, holds its UID (Firestore document id).
+ *   Empty string when nothing is selected.
+ * @property gameSearchError If a search error occurred, holds the error message. Null otherwise.
+ */
+data class GameUIState(
+    val gameQuery: String = "",
+    val gameSuggestions: List<Game> = emptyList(),
+    val selectedGameUid: String = "",
+    val gameSearchError: String? = null
+)
 
 /**
  * ViewModel for managing gaming sessions within a discussion.
@@ -23,12 +44,16 @@ import kotlinx.coroutines.launch
  */
 class FirestoreSessionViewModel(
     initDiscussion: Discussion,
-    private val repository: FirestoreSessionRepository = FirestoreSessionRepository()
+    private val repository: FirestoreSessionRepository = FirestoreSessionRepository(),
+    private val gameRepository: GameRepository = FirestoreGameRepository()
 ) : ViewModel() {
-  private val _discussion = MutableStateFlow(initDiscussion)
-
   /** Observable discussion state that updates when session operations complete. */
+  private val _discussion = MutableStateFlow(initDiscussion)
   val discussion: StateFlow<Discussion> = _discussion
+
+  /** UI state for game selection within the session. */
+  private val _gameUIState = MutableStateFlow(GameUIState())
+  val gameUIState: StateFlow<GameUIState> = _gameUIState.asStateFlow()
 
   /**
    * Checks if an account has admin privileges for a discussion.
@@ -123,5 +148,56 @@ class FirestoreSessionViewModel(
         throw PermissionDeniedException("Only discussion admins can perform this operation")
 
     viewModelScope.launch { repository.deleteSession(discussion.uid) }
+  }
+
+  /**
+   * Sets the selected game for the session.
+   *
+   * Updates the game UI state with the selected game's UID and name (requires admin privileges).
+   *
+   * @param requester The account requesting to update the session
+   * @param discussion The discussion containing the session
+   * @param game The [Game] object to select
+   */
+  fun setGame(requester: Account, discussion: Discussion, game: Game) {
+    if (!isAdmin(requester, discussion))
+        throw PermissionDeniedException("Only discussion admins can perform this operation")
+    _gameUIState.value = _gameUIState.value.copy(selectedGameUid = game.uid, gameQuery = game.name)
+  }
+
+  /**
+   * Update the game search query and asynchronously fetch suggestions (requires admin privileges).
+   *
+   * The UI should call `setGameQuery` whenever the user types into the game search field. This
+   * method:
+   * - updates the visible `gameQuery` in [GameUIState],
+   * - triggers a background search on the injected [GameRepository],
+   * - updates `gameSuggestions` with the results (or empties the list on error or blank query).
+   * - shows any search related error message in `gameSearchError`.
+   *
+   * @param requester The account requesting to update the session
+   * @param discussion The discussion containing the session
+   * @param query the substring to search for in game names.
+   */
+  fun setGameQuery(requester: Account, discussion: Discussion, query: String) {
+    if (!isAdmin(requester, discussion))
+        throw PermissionDeniedException("Only discussion admins can perform this operation")
+
+    _gameUIState.value = _gameUIState.value.copy(gameQuery = query)
+
+    if (query.isNotBlank()) {
+      viewModelScope.launch {
+        try {
+          val results = gameRepository.searchGamesByNameContains(query)
+          _gameUIState.value = _gameUIState.value.copy(gameSuggestions = results)
+        } catch (_: Exception) {
+          _gameUIState.value =
+              _gameUIState.value.copy(
+                  gameSuggestions = emptyList(), gameSearchError = "Game search failed")
+        }
+      }
+    } else {
+      _gameUIState.value = _gameUIState.value.copy(gameSuggestions = emptyList())
+    }
   }
 }


### PR DESCRIPTION
### Summary

This PR adds comprehensive support for board games within the Meeple-Meet application. Sessions can now have a game assigned, users can search for games by name, and the ViewModel fetches full game details from Firestore. Permission checks ensure that only discussion participants with the right privileges can modify session game information.

The `Game` model, the `GameRepository` interface, and a Firestore implementation provide a clear separation of concerns. A `FakeGameRepo` is included to facilitate reliable testing without relying on Firestore.

The ViewModel integrates seamlessly with the repository, updating the UI state for selected games, search results, and any errors encountered during fetching. The test suite covers admin and non-admin scenarios, game search functionality, and fetching games by ID, ensuring that the system behaves correctly in all expected cases.

This setup enables the UI to interact with session games naturally, providing a solid foundation for future features such as session editing and game suggestions.
