### PR TITLE
 Add CreateAccountScreen UI and Integration Tests

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/ui/CreateAccountScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/CreateAccountScreenTest.kt
@@ -1,3 +1,4 @@
+/** Sections of this file were generated using ChatGPT */
 package com.github.meeplemeet.ui
 
 import androidx.compose.material3.MaterialTheme
@@ -23,148 +24,147 @@ import org.junit.runner.RunWith
 
 /**
  * UI tests for [CreateAccountScreen] using a real [FirestoreHandlesViewModel].
- * These tests validate UI field behaviour, validation logic, and integration with the ViewModel.
+ *
+ * Validates:
+ * - Initial field states.
+ * - Input validation for empty username and handle conflicts.
+ * - Integration with [FirestoreHandlesViewModel] and [FirestoreHandlesRepository].
+ * - Successful handle creation triggers [onCreate] callback.
  */
 @RunWith(AndroidJUnit4::class)
 class CreateAccountScreenTest {
 
-    /* ---------- Test rule ---------- */
+  @get:Rule val compose = createComposeRule()
 
-    @get:Rule
-    val compose = createComposeRule()
+  /** Repository used by the ViewModel and for test verification. */
+  private lateinit var handlesRepo: FirestoreHandlesRepository
 
-    /* ---------- Dependencies ---------- */
+  /** ViewModel under test. */
+  private lateinit var viewModel: FirestoreHandlesViewModel
 
-    /** Single repository instance shared by ViewModel and test verification. */
-    private lateinit var handlesRepo: FirestoreHandlesRepository
+  /** Account representing the current user. */
+  private lateinit var me: Account
 
-    /** ViewModel under test. */
-    private lateinit var viewModel: FirestoreHandlesViewModel
+  /** Existing account used to test handle collisions. */
+  private lateinit var existing: Account
 
-    /* ---------- Test data ---------- */
+  /** Flag to verify that onCreate was called. */
+  private var onCreateCalled = false
 
-    /** Account representing the current user. */
-    private lateinit var me: Account
+  /** Returns the handle input field node. */
+  private fun handleField() = compose.onNodeWithText("Handle", substring = true)
 
-    /** Another existing account used to test handle collisions. */
-    private lateinit var existing: Account
+  /** Returns the username input field node. */
+  private fun usernameField() = compose.onNodeWithText("Username", substring = true)
 
-    /** Flag to verify that onCreate was called. */
-    private var onCreateCalled = false
+  /** Returns the create button node. */
+  private fun createBtn() = compose.onNodeWithText("Let's go!", substring = true)
 
-    /* ---------- Semantic helpers ---------- */
+  /** Cleans up seeded handles after each test to ensure a fresh start. */
+  @After
+  fun tearDown() = runBlocking {
+    handlesRepo.deleteAccountHandle("bobhandle")
+    handlesRepo.deleteAccountHandle("uniqueHandle")
+    handlesRepo.deleteAccountHandle("newHandle")
+  }
 
-    private fun handleField() = compose.onNodeWithText("Handle", substring = true)
-    private fun usernameField() = compose.onNodeWithText("Username", substring = true)
-    private fun createBtn() = compose.onNodeWithText("Let's go!", substring = true)
+  /**
+   * Sets up test dependencies and seeds initial accounts.
+   *
+   * Initializes a ViewModel, repositories, and Compose content for testing.
+   */
+  @Before
+  fun setup() = runBlocking {
+    val bootstrapRepo = FirestoreRepository()
+    me = bootstrapRepo.createAccount("111", "frank", "frank@email.com", null)
 
-    /* ---------- Setup ---------- */
+    handlesRepo = FirestoreHandlesRepository()
+    viewModel = FirestoreHandlesViewModel(handlesRepo)
 
-    @After
-    fun tearDown() = runBlocking {
-        // clean up the seeded handle so the next test starts fresh
-        handlesRepo.deleteAccountHandle("bobhandle")
-        handlesRepo.deleteAccountHandle("uniqueHandle")
-        handlesRepo.deleteAccountHandle("newHandle")
+    existing = bootstrapRepo.createAccount("222", "bob", "bob@email.com", null)
 
+    compose.setContent {
+      MaterialTheme {
+        CreateAccountScreen(
+            viewModel = viewModel, currentAccount = me, onCreate = { onCreateCalled = true })
+      }
+    }
+  }
+
+  /** Verifies that all input fields are initially empty. */
+  @Test
+  fun initial_state_all_fields_empty() {
+    handleField().assertTextContains("")
+    usernameField().assertTextContains("")
+  }
+
+  /** Verifies that clicking the create button with empty username disables the button. */
+  @Test
+  fun clicking_button_with_empty_username_shows_error() {
+    handleField().performTextInput("newHandle")
+    createBtn().performClick()
+    createBtn().assertIsNotEnabled()
+  }
+
+  /**
+   * Tests that entering a handle already taken by another account displays the appropriate error
+   * message.
+   */
+  @Test
+  fun entering_existing_handle_shows_error_message() {
+    runBlocking { handlesRepo.createAccountHandle(existing.uid, "bobhandle") }
+
+    handleField().performTextInput("bobhandle")
+    usernameField().performTextInput("Frank")
+    createBtn().performClick()
+
+    compose.waitUntil(timeoutMillis = 3_000) {
+      viewModel.errorMessage.value == HandleAlreadyTakenException.DEFAULT_MESSAGE
     }
 
-    @Before
-    fun setup() = runBlocking {
-        val bootstrapRepo = FirestoreRepository()
-        me = bootstrapRepo.createAccount("111","frank","frank@email.com",null)
+    compose
+        .onNodeWithText(HandleAlreadyTakenException.DEFAULT_MESSAGE, substring = true)
+        .assertExists()
+  }
 
-        handlesRepo = FirestoreHandlesRepository()
-        viewModel = FirestoreHandlesViewModel(handlesRepo)
+  /** Tests that valid input creates the handle and triggers onCreate. */
+  @Test
+  fun valid_input_creates_handle_and_calls_onCreate() = runBlocking {
+    handleField().performTextInput("uniqueHandle")
+    usernameField().performTextInput("Frank")
+    createBtn().performClick()
 
-        existing = bootstrapRepo.createAccount("222","bob","bob@email.com",null)
-
-        compose.setContent {
-            MaterialTheme {
-                CreateAccountScreen(
-                    viewModel = viewModel,
-                    currentAccount = me,
-                    onCreate = { onCreateCalled = true }
-                )
-            }
-        }
+    compose.waitUntil(timeoutMillis = 5_000) {
+      runBlocking { handlesRepo.getAccount(me.uid).handle == "uniqueHandle" }
     }
 
-    /* ---------- Tests ---------- */
+    val updated = handlesRepo.getAccount(me.uid)
+    assert(updated.handle == "uniqueHandle")
+    assert(onCreateCalled)
+  }
 
-    @Test
-    fun initial_state_all_fields_empty() {
-        handleField().assertTextContains("")
-        usernameField().assertTextContains("")
-    }
+  /** Verifies that empty handle input does not create a handle or call onCreate. */
+  @Test
+  fun empty_handle_does_not_trigger_creation() {
+    usernameField().performTextInput("Frank")
+    createBtn().performClick()
+    compose.waitForIdle()
 
-    @Test
-    fun clicking_button_with_empty_username_shows_error() {
-        handleField().performTextInput("newHandle")
-        createBtn().performClick()
-
-        createBtn().assertIsNotEnabled()
-    }
-
-    @Test
-    fun entering_existing_handle_shows_error_message() {
-        // seed the conflict
-        runBlocking { handlesRepo.createAccountHandle(existing.uid, "bobhandle") }
-
-        // type the conflicting handle
-        handleField().performTextInput("bobhandle")
-        usernameField().performTextInput("Frank")
-        createBtn().performClick()
-
-        // WAIT until the ViewModel posts the error
-        compose.waitUntil(timeoutMillis = 3_000) {
-            // read the same flow the screen observes
-            viewModel.errorMessage.value == HandleAlreadyTakenException.DEFAULT_MESSAGE
-        }
-
-        // now the node is on screen
-        compose
-            .onNodeWithText(HandleAlreadyTakenException.DEFAULT_MESSAGE, substring = true)
-            .assertExists()
-    }
-
-    @Test
-    fun valid_input_creates_handle_and_calls_onCreate() = runBlocking {
-        // Act
-        handleField().performTextInput("uniqueHandle")
-        usernameField().performTextInput("Frank")
-        createBtn().performClick()
-
-        // Wait until the handle is visible in the same repo the ViewModel wrote to
-        compose.waitUntil(timeoutMillis = 5_000) {
-            runBlocking {
-                handlesRepo.getAccount(me.uid).handle == "uniqueHandle"
-            }
-        }
-
-        // Assert
-        val updated = handlesRepo.getAccount(me.uid)
-        assert(updated.handle == "uniqueHandle")
-        assert(onCreateCalled)
-    }
-
-    @Test
-    fun empty_handle_does_not_trigger_creation() {
-        usernameField().performTextInput("Frank")
-        createBtn().performClick()
-        compose.waitForIdle()
-
-        // Should not call onCreate nor create a handle
-        val updated = runBlocking { handlesRepo.getAccount(me.uid) }
-        assert(updated.handle == me.handle) // still null / empty
-        assert(!onCreateCalled)
-    }
+    val updated = runBlocking { handlesRepo.getAccount(me.uid) }
+    assert(updated.handle == me.handle)
+    assert(!onCreateCalled)
+  }
 }
 
-/* ---------- test-only helper ---------- */
-
+/**
+ * Test-only helper to retrieve an [Account] from [FirestoreHandlesRepository].
+ *
+ * @param uid The UID of the account to retrieve.
+ * @return The [Account] object corresponding to the UID.
+ * @throws AccountNotFoundException If no account exists with the given UID.
+ */
 private suspend fun FirestoreHandlesRepository.getAccount(uid: String): Account {
-    val snap = db.collection(ACCOUNT_COLLECTION_PATH).document(uid).get().await()
-    val noUid = snap.toObject(AccountNoUid::class.java) ?: throw AccountNotFoundException()
-    return fromNoUid(uid, noUid)
+  val snap = db.collection(ACCOUNT_COLLECTION_PATH).document(uid).get().await()
+  val noUid = snap.toObject(AccountNoUid::class.java) ?: throw AccountNotFoundException()
+  return fromNoUid(uid, noUid)
 }

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/CreateAccountScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/CreateAccountScreenTest.kt
@@ -1,7 +1,6 @@
 /** Sections of this file were generated using ChatGPT */
 package com.github.meeplemeet.ui
 
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -158,8 +157,8 @@ class CreateAccountScreenTest {
     assert(!onCreateCalled)
   }
   /**
-   * Tests that typing something in the username field and then deleting it
-   * shows the "Username cannot be empty" error message.
+   * Tests that typing something in the username field and then deleting it shows the "Username
+   * cannot be empty" error message.
    */
   @Test
   fun deleting_username_shows_empty_error_message() {

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/CreateAccountScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/CreateAccountScreenTest.kt
@@ -14,6 +14,8 @@ import com.github.meeplemeet.model.structures.Account
 import com.github.meeplemeet.model.structures.AccountNoUid
 import com.github.meeplemeet.model.structures.fromNoUid
 import com.github.meeplemeet.model.viewmodels.FirestoreHandlesViewModel
+import com.github.meeplemeet.ui.theme.AppTheme
+import com.github.meeplemeet.ui.theme.ThemeMode
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.tasks.await
 import org.junit.After
@@ -84,7 +86,7 @@ class CreateAccountScreenTest {
     existing = bootstrapRepo.createAccount("222", "bob", "bob@email.com", null)
 
     compose.setContent {
-      MaterialTheme {
+      AppTheme(themeMode = ThemeMode.DARK) {
         CreateAccountScreen(
             viewModel = viewModel, currentAccount = me, onCreate = { onCreateCalled = true })
       }
@@ -141,6 +143,7 @@ class CreateAccountScreenTest {
     val updated = handlesRepo.getAccount(me.uid)
     assert(updated.handle == "uniqueHandle")
     assert(onCreateCalled)
+    Thread.sleep(5000) // For observing the result during test runs
   }
 
   /** Verifies that empty handle input does not create a handle or call onCreate. */
@@ -153,6 +156,18 @@ class CreateAccountScreenTest {
     val updated = runBlocking { handlesRepo.getAccount(me.uid) }
     assert(updated.handle == me.handle)
     assert(!onCreateCalled)
+  }
+  /**
+   * Tests that typing something in the username field and then deleting it
+   * shows the "Username cannot be empty" error message.
+   */
+  @Test
+  fun deleting_username_shows_empty_error_message() {
+    usernameField().performTextInput("Frank")
+    compose.waitForIdle()
+    usernameField().performTextClearance()
+    compose.waitForIdle()
+    compose.onNodeWithText("Username cannot be empty", substring = true).assertExists()
   }
 }
 

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/CreateAccountScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/CreateAccountScreenTest.kt
@@ -142,7 +142,7 @@ class CreateAccountScreenTest {
     val updated = handlesRepo.getAccount(me.uid)
     assert(updated.handle == "uniqueHandle")
     assert(onCreateCalled)
-    Thread.sleep(5000) // For observing the result during test runs
+    Thread.sleep(5000)
   }
 
   /** Verifies that empty handle input does not create a handle or call onCreate. */

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/CreateAccountScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/CreateAccountScreenTest.kt
@@ -1,0 +1,170 @@
+package com.github.meeplemeet.ui
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.meeplemeet.model.AccountNotFoundException
+import com.github.meeplemeet.model.HandleAlreadyTakenException
+import com.github.meeplemeet.model.repositories.ACCOUNT_COLLECTION_PATH
+import com.github.meeplemeet.model.repositories.FirestoreHandlesRepository
+import com.github.meeplemeet.model.repositories.FirestoreRepository
+import com.github.meeplemeet.model.structures.Account
+import com.github.meeplemeet.model.structures.AccountNoUid
+import com.github.meeplemeet.model.structures.fromNoUid
+import com.github.meeplemeet.model.viewmodels.FirestoreHandlesViewModel
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.tasks.await
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * UI tests for [CreateAccountScreen] using a real [FirestoreHandlesViewModel].
+ * These tests validate UI field behaviour, validation logic, and integration with the ViewModel.
+ */
+@RunWith(AndroidJUnit4::class)
+class CreateAccountScreenTest {
+
+    /* ---------- Test rule ---------- */
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    /* ---------- Dependencies ---------- */
+
+    /** Single repository instance shared by ViewModel and test verification. */
+    private lateinit var handlesRepo: FirestoreHandlesRepository
+
+    /** ViewModel under test. */
+    private lateinit var viewModel: FirestoreHandlesViewModel
+
+    /* ---------- Test data ---------- */
+
+    /** Account representing the current user. */
+    private lateinit var me: Account
+
+    /** Another existing account used to test handle collisions. */
+    private lateinit var existing: Account
+
+    /** Flag to verify that onCreate was called. */
+    private var onCreateCalled = false
+
+    /* ---------- Semantic helpers ---------- */
+
+    private fun handleField() = compose.onNodeWithText("Handle", substring = true)
+    private fun usernameField() = compose.onNodeWithText("Username", substring = true)
+    private fun createBtn() = compose.onNodeWithText("Let's go!", substring = true)
+
+    /* ---------- Setup ---------- */
+
+    @After
+    fun tearDown() = runBlocking {
+        // clean up the seeded handle so the next test starts fresh
+        handlesRepo.deleteAccountHandle("bobhandle")
+        handlesRepo.deleteAccountHandle("uniqueHandle")
+        handlesRepo.deleteAccountHandle("newHandle")
+
+    }
+
+    @Before
+    fun setup() = runBlocking {
+        val bootstrapRepo = FirestoreRepository()
+        me = bootstrapRepo.createAccount("111","frank","frank@email.com",null)
+
+        handlesRepo = FirestoreHandlesRepository()
+        viewModel = FirestoreHandlesViewModel(handlesRepo)
+
+        existing = bootstrapRepo.createAccount("222","bob","bob@email.com",null)
+
+        compose.setContent {
+            MaterialTheme {
+                CreateAccountScreen(
+                    viewModel = viewModel,
+                    currentAccount = me,
+                    onCreate = { onCreateCalled = true }
+                )
+            }
+        }
+    }
+
+    /* ---------- Tests ---------- */
+
+    @Test
+    fun initial_state_all_fields_empty() {
+        handleField().assertTextContains("")
+        usernameField().assertTextContains("")
+    }
+
+    @Test
+    fun clicking_button_with_empty_username_shows_error() {
+        handleField().performTextInput("newHandle")
+        createBtn().performClick()
+
+        createBtn().assertIsNotEnabled()
+    }
+
+    @Test
+    fun entering_existing_handle_shows_error_message() {
+        // seed the conflict
+        runBlocking { handlesRepo.createAccountHandle(existing.uid, "bobhandle") }
+
+        // type the conflicting handle
+        handleField().performTextInput("bobhandle")
+        usernameField().performTextInput("Frank")
+        createBtn().performClick()
+
+        // WAIT until the ViewModel posts the error
+        compose.waitUntil(timeoutMillis = 3_000) {
+            // read the same flow the screen observes
+            viewModel.errorMessage.value == HandleAlreadyTakenException.DEFAULT_MESSAGE
+        }
+
+        // now the node is on screen
+        compose
+            .onNodeWithText(HandleAlreadyTakenException.DEFAULT_MESSAGE, substring = true)
+            .assertExists()
+    }
+
+    @Test
+    fun valid_input_creates_handle_and_calls_onCreate() = runBlocking {
+        // Act
+        handleField().performTextInput("uniqueHandle")
+        usernameField().performTextInput("Frank")
+        createBtn().performClick()
+
+        // Wait until the handle is visible in the same repo the ViewModel wrote to
+        compose.waitUntil(timeoutMillis = 5_000) {
+            runBlocking {
+                handlesRepo.getAccount(me.uid).handle == "uniqueHandle"
+            }
+        }
+
+        // Assert
+        val updated = handlesRepo.getAccount(me.uid)
+        assert(updated.handle == "uniqueHandle")
+        assert(onCreateCalled)
+    }
+
+    @Test
+    fun empty_handle_does_not_trigger_creation() {
+        usernameField().performTextInput("Frank")
+        createBtn().performClick()
+        compose.waitForIdle()
+
+        // Should not call onCreate nor create a handle
+        val updated = runBlocking { handlesRepo.getAccount(me.uid) }
+        assert(updated.handle == me.handle) // still null / empty
+        assert(!onCreateCalled)
+    }
+}
+
+/* ---------- test-only helper ---------- */
+
+private suspend fun FirestoreHandlesRepository.getAccount(uid: String): Account {
+    val snap = db.collection(ACCOUNT_COLLECTION_PATH).document(uid).get().await()
+    val noUid = snap.toObject(AccountNoUid::class.java) ?: throw AccountNotFoundException()
+    return fromNoUid(uid, noUid)
+}

--- a/app/src/main/java/com/github/meeplemeet/ui/CreateAccountScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/CreateAccountScreen.kt
@@ -1,0 +1,145 @@
+package com.github.meeplemeet.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.github.meeplemeet.model.structures.Account
+import com.github.meeplemeet.model.viewmodels.FirestoreHandlesViewModel
+import com.github.meeplemeet.ui.theme.AppColors
+import com.github.meeplemeet.ui.theme.appShapes
+
+@Composable
+fun CreateAccountScreen(
+    viewModel: FirestoreHandlesViewModel,
+    currentAccount: Account,
+    modifier: Modifier = Modifier,
+    onCreate: () -> Unit = {},
+) {
+    var handle by remember { mutableStateOf("") }
+    var username by remember { mutableStateOf("") }
+    var usernameError by remember { mutableStateOf<String?>(null) }
+
+    val errorMessage by viewModel.errorMessage.collectAsState()
+    var showErrors by remember { mutableStateOf(false) }
+
+    fun validateHandle(handle: String) {
+        showErrors = true
+        viewModel.checkHandleAvailable(handle)
+    }
+
+    fun validateUsername(username: String): String? {
+        return when {
+            username.isBlank() -> "Username cannot be empty"
+            else -> null
+        }
+    }
+
+    // Main column centered vertically
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(24.dp)
+            .background(AppColors.primary),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        // Spacer above square to push content into center
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Square box placeholder (colored properly)
+        Box(
+            modifier = Modifier
+                .size(120.dp)
+                .background(Color(0xFFe0e0e0))
+        )
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        // "You're almost there!" text
+        Text(
+            "You're almost there!",
+            style = TextStyle(fontSize = 36.sp, color = AppColors.neutral),
+            modifier = Modifier.padding(bottom = 16.dp)
+        )
+
+        // Handle input field
+        OutlinedTextField(
+            value = handle,
+            onValueChange = { handle = it },
+            label = { Text("Handle") },
+            singleLine = true,
+            textStyle = TextStyle(color = AppColors.textIcons),
+            isError = showErrors && errorMessage.isNotBlank(),
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        if (showErrors && errorMessage.isNotBlank()) {
+            Text(
+                text = errorMessage,
+                color = AppColors.textIconsFade,
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 16.dp, top = 4.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // Username input field
+        OutlinedTextField(
+            value = username,
+            onValueChange = {
+                username = it
+                usernameError = validateUsername(username)
+            },
+            label = { Text("Username") },
+            singleLine = true,
+            isError = usernameError != null,
+            textStyle = TextStyle(color = AppColors.textIcons),
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        if (usernameError != null) {
+            Text(
+                text = usernameError!!,
+                color = AppColors.textIconsFade,
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 16.dp, top = 4.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Action button
+        Button(
+            enabled = handle.isNotBlank() && username.isNotBlank(),
+            colors = ButtonDefaults.buttonColors(containerColor = AppColors.affirmative),
+            shape = appShapes.medium,
+            elevation = ButtonDefaults.buttonElevation(defaultElevation = 4.dp, pressedElevation = 0.dp),
+            onClick = {
+                showErrors = true
+                validateHandle(handle)
+                val usernameValidation = validateUsername(username)
+                usernameError = usernameValidation
+
+                if ((errorMessage.isBlank()) && usernameValidation == null) {
+                    viewModel.createAccountHandle(account = currentAccount, handle = handle)
+                    if (errorMessage.isBlank()) onCreate()
+                }
+            },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Let's go!")
+        }
+    }
+}

--- a/app/src/main/java/com/github/meeplemeet/ui/CreateAccountScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/CreateAccountScreen.kt
@@ -85,8 +85,8 @@ fun CreateAccountScreen(
             textStyle = TextStyle(color = AppColors.textIcons),
             colors =
                 TextFieldDefaults.colors(
-                    focusedIndicatorColor = AppColors.textIcons, // border when selected
-                    unfocusedIndicatorColor = AppColors.textIconsFade, // border when deselected
+                    focusedIndicatorColor = AppColors.textIcons,
+                    unfocusedIndicatorColor = AppColors.textIconsFade,
                     cursorColor = AppColors.textIcons,
                     focusedLabelColor = AppColors.textIcons,
                     unfocusedLabelColor = AppColors.textIconsFade,
@@ -115,8 +115,8 @@ fun CreateAccountScreen(
             singleLine = true,
             colors =
                 TextFieldDefaults.colors(
-                    focusedIndicatorColor = AppColors.textIcons, // border when selected
-                    unfocusedIndicatorColor = AppColors.textIconsFade, // border when deselected
+                    focusedIndicatorColor = AppColors.textIcons,
+                    unfocusedIndicatorColor = AppColors.textIconsFade,
                     cursorColor = AppColors.textIcons,
                     focusedLabelColor = AppColors.textIcons,
                     unfocusedLabelColor = AppColors.textIconsFade,

--- a/app/src/main/java/com/github/meeplemeet/ui/CreateAccountScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/CreateAccountScreen.kt
@@ -62,21 +62,25 @@ fun CreateAccountScreen(
     }
   }
 
+  /** Root layout column for aligning all UI components vertically. */
   Column(
       modifier = modifier.fillMaxSize().background(AppColors.primary).padding(24.dp),
       horizontalAlignment = Alignment.CenterHorizontally,
       verticalArrangement = Arrangement.Center) {
         Spacer(modifier = Modifier.height(24.dp))
 
+        /** Placeholder image box displayed at the top of the screen. */
         Box(modifier = Modifier.size(120.dp).background(Color(0xFFe0e0e0)))
 
         Spacer(modifier = Modifier.height(32.dp))
 
+        /** Title text shown below the image placeholder. */
         Text(
             "You're almost there!",
             style = TextStyle(fontSize = 36.sp, color = AppColors.neutral),
             modifier = Modifier.padding(bottom = 16.dp))
 
+        /** Input field for entering the user's unique handle. */
         OutlinedTextField(
             value = handle,
             onValueChange = { handle = it },
@@ -95,6 +99,7 @@ fun CreateAccountScreen(
             isError = showErrors && errorMessage.isNotBlank(),
             modifier = Modifier.fillMaxWidth())
 
+        /** Error message displayed if handle validation fails. */
         if (showErrors && errorMessage.isNotBlank()) {
           Text(
               text = errorMessage,
@@ -105,6 +110,7 @@ fun CreateAccountScreen(
 
         Spacer(modifier = Modifier.height(8.dp))
 
+        /** Input field for entering the user's display username. */
         OutlinedTextField(
             value = username,
             onValueChange = {
@@ -126,6 +132,7 @@ fun CreateAccountScreen(
             textStyle = TextStyle(color = AppColors.textIcons),
             modifier = Modifier.fillMaxWidth())
 
+        /** Error message displayed if username validation fails. */
         if (usernameError != null) {
           Text(
               text = usernameError!!,
@@ -136,6 +143,7 @@ fun CreateAccountScreen(
 
         Spacer(modifier = Modifier.height(16.dp))
 
+        /** Submit button to create the account once inputs are valid. */
         Button(
             enabled = handle.isNotBlank() && username.isNotBlank(),
             colors = ButtonDefaults.buttonColors(containerColor = AppColors.affirmative),

--- a/app/src/main/java/com/github/meeplemeet/ui/CreateAccountScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/CreateAccountScreen.kt
@@ -1,3 +1,4 @@
+/** Documentation was written with the help of ChatGPT */
 package com.github.meeplemeet.ui
 
 import androidx.compose.foundation.background
@@ -15,6 +16,18 @@ import com.github.meeplemeet.model.viewmodels.FirestoreHandlesViewModel
 import com.github.meeplemeet.ui.theme.AppColors
 import com.github.meeplemeet.ui.theme.appShapes
 
+/**
+ * Composable screen for completing account creation by selecting a handle and username.
+ *
+ * This screen collects a handle and username from the user, validates them, and interacts with the
+ * [FirestoreHandlesViewModel] to ensure the handle is available. Once valid, it triggers [onCreate]
+ * to continue the account creation flow.
+ *
+ * @param viewModel The ViewModel responsible for handling Firestore handle validation.
+ * @param currentAccount The [Account] object representing the user creating an account.
+ * @param modifier Optional [Modifier] for styling and layout.
+ * @param onCreate Lambda to be executed when account creation is successfully validated.
+ */
 @Composable
 fun CreateAccountScreen(
     viewModel: FirestoreHandlesViewModel,
@@ -22,54 +35,47 @@ fun CreateAccountScreen(
     modifier: Modifier = Modifier,
     onCreate: () -> Unit = {},
 ) {
-    var handle by remember { mutableStateOf("") }
-    var username by remember { mutableStateOf("") }
-    var usernameError by remember { mutableStateOf<String?>(null) }
+  var handle by remember { mutableStateOf("") }
+  var username by remember { mutableStateOf("") }
+  var usernameError by remember { mutableStateOf<String?>(null) }
 
-    val errorMessage by viewModel.errorMessage.collectAsState()
-    var showErrors by remember { mutableStateOf(false) }
+  val errorMessage by viewModel.errorMessage.collectAsState()
+  var showErrors by remember { mutableStateOf(false) }
 
-    fun validateHandle(handle: String) {
-        showErrors = true
-        viewModel.checkHandleAvailable(handle)
+  /** Checks the handle availability and updates the ViewModel state. */
+  fun validateHandle(handle: String) {
+    showErrors = true
+    viewModel.checkHandleAvailable(handle)
+  }
+
+  /**
+   * Validates the username for non-emptiness.
+   *
+   * @param username The input username string.
+   * @return Error message if username is empty; null if valid.
+   */
+  fun validateUsername(username: String): String? {
+    return when {
+      username.isBlank() -> "Username cannot be empty"
+      else -> null
     }
+  }
 
-    fun validateUsername(username: String): String? {
-        return when {
-            username.isBlank() -> "Username cannot be empty"
-            else -> null
-        }
-    }
-
-    // Main column centered vertically
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .padding(24.dp)
-            .background(AppColors.primary),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
-    ) {
-        // Spacer above square to push content into center
+  Column(
+      modifier = modifier.fillMaxSize().padding(24.dp).background(AppColors.primary),
+      horizontalAlignment = Alignment.CenterHorizontally,
+      verticalArrangement = Arrangement.Center) {
         Spacer(modifier = Modifier.height(24.dp))
 
-        // Square box placeholder (colored properly)
-        Box(
-            modifier = Modifier
-                .size(120.dp)
-                .background(Color(0xFFe0e0e0))
-        )
+        Box(modifier = Modifier.size(120.dp).background(Color(0xFFe0e0e0)))
 
         Spacer(modifier = Modifier.height(32.dp))
 
-        // "You're almost there!" text
         Text(
             "You're almost there!",
             style = TextStyle(fontSize = 36.sp, color = AppColors.neutral),
-            modifier = Modifier.padding(bottom = 16.dp)
-        )
+            modifier = Modifier.padding(bottom = 16.dp))
 
-        // Handle input field
         OutlinedTextField(
             value = handle,
             onValueChange = { handle = it },
@@ -77,69 +83,59 @@ fun CreateAccountScreen(
             singleLine = true,
             textStyle = TextStyle(color = AppColors.textIcons),
             isError = showErrors && errorMessage.isNotBlank(),
-            modifier = Modifier.fillMaxWidth()
-        )
+            modifier = Modifier.fillMaxWidth())
 
         if (showErrors && errorMessage.isNotBlank()) {
-            Text(
-                text = errorMessage,
-                color = AppColors.textIconsFade,
-                style = MaterialTheme.typography.bodySmall,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(start = 16.dp, top = 4.dp)
-            )
+          Text(
+              text = errorMessage,
+              color = AppColors.textIconsFade,
+              style = MaterialTheme.typography.bodySmall,
+              modifier = Modifier.fillMaxWidth().padding(start = 16.dp, top = 4.dp))
         }
 
         Spacer(modifier = Modifier.height(8.dp))
 
-        // Username input field
         OutlinedTextField(
             value = username,
             onValueChange = {
-                username = it
-                usernameError = validateUsername(username)
+              username = it
+              usernameError = validateUsername(username)
             },
             label = { Text("Username") },
             singleLine = true,
             isError = usernameError != null,
             textStyle = TextStyle(color = AppColors.textIcons),
-            modifier = Modifier.fillMaxWidth()
-        )
+            modifier = Modifier.fillMaxWidth())
 
         if (usernameError != null) {
-            Text(
-                text = usernameError!!,
-                color = AppColors.textIconsFade,
-                style = MaterialTheme.typography.bodySmall,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(start = 16.dp, top = 4.dp)
-            )
+          Text(
+              text = usernameError!!,
+              color = AppColors.textIconsFade,
+              style = MaterialTheme.typography.bodySmall,
+              modifier = Modifier.fillMaxWidth().padding(start = 16.dp, top = 4.dp))
         }
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        // Action button
         Button(
             enabled = handle.isNotBlank() && username.isNotBlank(),
             colors = ButtonDefaults.buttonColors(containerColor = AppColors.affirmative),
             shape = appShapes.medium,
-            elevation = ButtonDefaults.buttonElevation(defaultElevation = 4.dp, pressedElevation = 0.dp),
+            elevation =
+                ButtonDefaults.buttonElevation(defaultElevation = 4.dp, pressedElevation = 0.dp),
             onClick = {
-                showErrors = true
-                validateHandle(handle)
-                val usernameValidation = validateUsername(username)
-                usernameError = usernameValidation
+              showErrors = true
+              validateHandle(handle)
+              val usernameValidation = validateUsername(username)
+              usernameError = usernameValidation
 
-                if ((errorMessage.isBlank()) && usernameValidation == null) {
-                    viewModel.createAccountHandle(account = currentAccount, handle = handle)
-                    if (errorMessage.isBlank()) onCreate()
-                }
+              if ((errorMessage.isBlank()) && usernameValidation == null) {
+                viewModel.createAccountHandle(account = currentAccount, handle = handle)
+                if (errorMessage.isBlank()) onCreate()
+              }
             },
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Text("Let's go!")
-        }
-    }
+            modifier = Modifier.fillMaxWidth()) {
+              Text("Let's go!")
+            }
+      }
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/CreateAccountScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/CreateAccountScreen.kt
@@ -3,7 +3,9 @@ package com.github.meeplemeet.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.*
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -14,7 +16,6 @@ import androidx.compose.ui.unit.sp
 import com.github.meeplemeet.model.structures.Account
 import com.github.meeplemeet.model.viewmodels.FirestoreHandlesViewModel
 import com.github.meeplemeet.ui.theme.AppColors
-import com.github.meeplemeet.ui.theme.appShapes
 
 /**
  * Composable screen for completing account creation by selecting a handle and username.
@@ -62,7 +63,7 @@ fun CreateAccountScreen(
   }
 
   Column(
-      modifier = modifier.fillMaxSize().padding(24.dp).background(AppColors.primary),
+      modifier = modifier.fillMaxSize().background(AppColors.primary).padding(24.dp),
       horizontalAlignment = Alignment.CenterHorizontally,
       verticalArrangement = Arrangement.Center) {
         Spacer(modifier = Modifier.height(24.dp))
@@ -82,6 +83,15 @@ fun CreateAccountScreen(
             label = { Text("Handle") },
             singleLine = true,
             textStyle = TextStyle(color = AppColors.textIcons),
+            colors =
+                TextFieldDefaults.colors(
+                    focusedIndicatorColor = AppColors.textIcons, // border when selected
+                    unfocusedIndicatorColor = AppColors.textIconsFade, // border when deselected
+                    cursorColor = AppColors.textIcons,
+                    focusedLabelColor = AppColors.textIcons,
+                    unfocusedLabelColor = AppColors.textIconsFade,
+                    focusedTextColor = AppColors.textIcons,
+                    unfocusedTextColor = AppColors.textIconsFade),
             isError = showErrors && errorMessage.isNotBlank(),
             modifier = Modifier.fillMaxWidth())
 
@@ -103,6 +113,15 @@ fun CreateAccountScreen(
             },
             label = { Text("Username") },
             singleLine = true,
+            colors =
+                TextFieldDefaults.colors(
+                    focusedIndicatorColor = AppColors.textIcons, // border when selected
+                    unfocusedIndicatorColor = AppColors.textIconsFade, // border when deselected
+                    cursorColor = AppColors.textIcons,
+                    focusedLabelColor = AppColors.textIcons,
+                    unfocusedLabelColor = AppColors.textIconsFade,
+                    focusedTextColor = AppColors.textIcons,
+                    unfocusedTextColor = AppColors.textIconsFade),
             isError = usernameError != null,
             textStyle = TextStyle(color = AppColors.textIcons),
             modifier = Modifier.fillMaxWidth())
@@ -120,7 +139,7 @@ fun CreateAccountScreen(
         Button(
             enabled = handle.isNotBlank() && username.isNotBlank(),
             colors = ButtonDefaults.buttonColors(containerColor = AppColors.affirmative),
-            shape = appShapes.medium,
+            shape = CircleShape,
             elevation =
                 ButtonDefaults.buttonElevation(defaultElevation = 4.dp, pressedElevation = 0.dp),
             onClick = {
@@ -134,7 +153,7 @@ fun CreateAccountScreen(
                 if (errorMessage.isBlank()) onCreate()
               }
             },
-            modifier = Modifier.fillMaxWidth()) {
+            modifier = Modifier.fillMaxWidth(0.3f)) {
               Text("Let's go!")
             }
       }

--- a/app/src/main/java/com/github/meeplemeet/ui/CreateAccountScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/CreateAccountScreen.kt
@@ -156,6 +156,7 @@ fun CreateAccountScreen(
               val usernameValidation = validateUsername(username)
               usernameError = usernameValidation
 
+              /** Create the handle and call onCreate if there are no errors */
               if ((errorMessage.isBlank()) && usernameValidation == null) {
                 viewModel.createAccountHandle(account = currentAccount, handle = handle)
                 if (errorMessage.isBlank()) onCreate()


### PR DESCRIPTION
# PR: Add CreateAccountScreen UI and Integration Tests

## Overview

This PR introduces the `CreateAccountScreen` composable and its associated instrumented UI tests using `Compose` and `FirestoreHandlesViewModel`.  

The purpose is to provide a complete account creation flow where users can select a unique handle and a username, with client-side validation and Firestore integration.

## Changes

### `CreateAccountScreen.kt`

- Adds a composable screen for selecting handle and username during account creation.
- Includes:
  - Input fields for handle and username with validation.
  - Real-time handle availability check via `FirestoreHandlesViewModel`.
  - Disabled/enable state for the action button based on validation.
  - Callback `onCreate` triggered when handle and username are valid.
- Fully styled using app theme colors and shapes.

### `CreateAccountScreenTest.kt`

- Adds integration/UI tests for `CreateAccountScreen`:
  - Verifies initial state of input fields.
  - Validates behavior for empty username or handle.
  - Ensures proper error messages for handle conflicts (`HandleAlreadyTakenException`).
  - Confirms successful handle creation triggers `onCreate`.
- Uses a real `FirestoreHandlesViewModel` and seeded test accounts for realistic integration testing.
<img width="413" height="836" alt="image" src="https://github.com/user-attachments/assets/52d6d1a1-4428-4f4b-9b25-3c7fc4c61323" />
