### PR TITLE
Restore PR #69 ("Feed/Post backend") by reverting its previous revert (#104).

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/integration/FirestorePostTests.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/FirestorePostTests.kt
@@ -1,0 +1,313 @@
+package com.github.meeplemeet.integration
+
+import com.github.meeplemeet.model.PermissionDeniedException
+import com.github.meeplemeet.model.repositories.FirestorePostRepository
+import com.github.meeplemeet.model.structures.Account
+import com.github.meeplemeet.model.viewmodels.CreatePostViewModel
+import com.github.meeplemeet.model.viewmodels.PostOverviewViewModel
+import com.github.meeplemeet.model.viewmodels.PostViewModel
+import com.github.meeplemeet.utils.FirestoreTests
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FirestorePostTests : FirestoreTests() {
+  private lateinit var repository: FirestorePostRepository
+  private lateinit var createVM: CreatePostViewModel
+  private lateinit var postVM: PostViewModel
+  private lateinit var overviewVM: PostOverviewViewModel
+
+  private val testAccount1 =
+      Account(uid = "user1", handle = "alice", name = "Alice", email = "alice@test.com")
+  private val testAccount2 =
+      Account(uid = "user2", handle = "bob", name = "Bob", email = "bob@test.com")
+
+  @Before
+  fun setup() {
+    repository = FirestorePostRepository()
+    createVM = CreatePostViewModel(repository)
+    postVM = PostViewModel(repository)
+    overviewVM = PostOverviewViewModel(repository)
+  }
+
+  @Test
+  fun testCreatePost() = runTest {
+    val post =
+        repository.createPost(
+            "Test Title", "Test Content", testAccount1.uid, listOf("tag1", "tag2"))
+
+    assertNotNull(post.id)
+    assertEquals("Test Title", post.title)
+    assertEquals("Test Content", post.body)
+    assertEquals(testAccount1.uid, post.authorId)
+    assertEquals(listOf("tag1", "tag2"), post.tags)
+    assertTrue(post.comments.isEmpty())
+  }
+
+  @Test
+  fun testCreatePostWithoutTags() = runTest {
+    val post = repository.createPost("No Tags", "Content", testAccount1.uid)
+
+    assertNotNull(post.id)
+    assertEquals("No Tags", post.title)
+    assertEquals("Content", post.body)
+    assertEquals(testAccount1.uid, post.authorId)
+    assertTrue(post.tags.isEmpty())
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun testDeletePost() = runTest {
+    val post = repository.createPost("To Delete", "Content", testAccount1.uid)
+    repository.deletePost(post.id)
+
+    runBlocking { repository.getPost(post.id) }
+  }
+
+  @Test
+  fun testAddTopLevelComment() = runTest {
+    val post = repository.createPost("Post with Comment", "Content", testAccount1.uid)
+    val commentId = repository.addComment(post.id, "Top level comment", testAccount2.uid, post.id)
+
+    assertNotNull(commentId)
+
+    // Verify comment was added by getting the post
+    val updatedPost = repository.getPost(post.id)
+
+    assertEquals(1, updatedPost.comments.size)
+    assertEquals("Top level comment", updatedPost.comments[0].text)
+    assertEquals(testAccount2.uid, updatedPost.comments[0].authorId)
+  }
+
+  @Test
+  fun testAddReplyToComment() = runTest {
+    val post = repository.createPost("Post with Reply", "Content", testAccount1.uid)
+    val parentCommentId =
+        repository.addComment(post.id, "Parent comment", testAccount2.uid, post.id)
+    val replyId =
+        repository.addComment(post.id, "Reply to comment", testAccount1.uid, parentCommentId)
+
+    assertNotNull(replyId)
+
+    // Verify nested comment structure
+    val updatedPost = repository.getPost(post.id)
+
+    assertEquals(1, updatedPost.comments.size)
+    val parentComment = updatedPost.comments[0]
+    assertEquals("Parent comment", parentComment.text)
+    assertEquals(1, parentComment.children.size)
+    assertEquals("Reply to comment", parentComment.children[0].text)
+    assertEquals(testAccount1.uid, parentComment.children[0].authorId)
+  }
+
+  @Test
+  fun testRemoveComment() = runTest {
+    val post = repository.createPost("Post", "Content", testAccount1.uid)
+    val commentId = repository.addComment(post.id, "To remove", testAccount2.uid, post.id)
+
+    repository.removeComment(post.id, commentId)
+
+    // Verify comment was removed
+    val updatedPost = repository.getPost(post.id)
+    assertTrue(updatedPost.comments.isEmpty())
+  }
+
+  @Test
+  fun testRemoveCommentWithReplies() = runTest {
+    val post = repository.createPost("Post", "Content", testAccount1.uid)
+    val parentCommentId = repository.addComment(post.id, "Parent", testAccount2.uid, post.id)
+    repository.addComment(post.id, "Reply 1", testAccount1.uid, parentCommentId)
+    repository.addComment(post.id, "Reply 2", testAccount2.uid, parentCommentId)
+
+    // Remove parent comment should also remove all replies
+    repository.removeComment(post.id, parentCommentId)
+
+    val updatedPost = repository.getPost(post.id)
+    assertTrue(updatedPost.comments.isEmpty())
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun testRemoveNonExistentComment() = runTest {
+    val post = repository.createPost("Post", "Content", testAccount1.uid)
+
+    runBlocking { repository.removeComment(post.id, "nonexistent") }
+  }
+
+  @Test
+  fun testGetPostReturnsCompletePostWithComments() = runBlocking {
+    val post = repository.createPost("Get Test", "Content", testAccount1.uid, listOf("test"))
+    val commentId1 = repository.addComment(post.id, "Comment 1", testAccount2.uid, post.id)
+    repository.addComment(post.id, "Reply to Comment 1", testAccount1.uid, commentId1)
+    repository.addComment(post.id, "Comment 2", testAccount2.uid, post.id)
+
+    val retrievedPost = repository.getPost(post.id)
+
+    assertEquals(post.id, retrievedPost.id)
+    assertEquals("Get Test", retrievedPost.title)
+    assertEquals("Content", retrievedPost.body)
+    assertEquals(testAccount1.uid, retrievedPost.authorId)
+    assertEquals(listOf("test"), retrievedPost.tags)
+    assertEquals(2, retrievedPost.comments.size)
+
+    val commentWithChild = retrievedPost.comments.find { it.children.isNotEmpty() }
+    assertNotNull(commentWithChild)
+    assertEquals(1, commentWithChild!!.children.size)
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun testDeletePostWithComments() = runTest {
+    val post = repository.createPost("Post with Comments", "Content", testAccount1.uid)
+    repository.addComment(post.id, "Comment 1", testAccount2.uid, post.id)
+    repository.addComment(post.id, "Comment 2", testAccount1.uid, post.id)
+
+    // Delete the post with all its comments
+    repository.deletePost(post.id)
+
+    // Verify post no longer exists
+    runBlocking { repository.getPost(post.id) }
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun testGetNonExistentPost() = runTest {
+    runBlocking { repository.getPost("nonexistent-post-id") }
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun testCreatePostViewModelWithBlankTitle() {
+    createVM.createPost("", "Content", testAccount1)
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun testCreatePostViewModelWithBlankBody() {
+    createVM.createPost("Title", "", testAccount1)
+  }
+
+  @Test
+  fun testDeletePostAsAuthor() = runTest {
+    val post = repository.createPost("To Delete", "Content", testAccount1.uid)
+    postVM.deletePost(testAccount1, post)
+    advanceUntilIdle()
+  }
+
+  @Test(expected = PermissionDeniedException::class)
+  fun testDeletePostAsNonAuthor() = runTest {
+    val post = repository.createPost("Protected Post", "Content", testAccount1.uid)
+
+    postVM.deletePost(testAccount2, post)
+  }
+
+  @Test
+  fun testAddCommentToPost() = runTest {
+    val post = repository.createPost("Post", "Content", testAccount1.uid)
+    postVM.addComment(testAccount2, post, post.id, "VM Comment")
+    advanceUntilIdle()
+
+    val updatedPost = repository.getPost(post.id)
+    assertEquals(1, updatedPost.comments.size)
+    assertEquals("VM Comment", updatedPost.comments[0].text)
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun testAddBlankComment() {
+    val post = runBlocking { repository.createPost("Post", "Content", testAccount1.uid) }
+
+    postVM.addComment(testAccount2, post, post.id, "")
+  }
+
+  @Test
+  fun testRemoveCommentAsAuthor() = runBlocking {
+    val post = repository.createPost("Post", "Content", testAccount1.uid)
+    repository.addComment(post.id, "Comment", testAccount2.uid, post.id)
+
+    val postWithComment = repository.getPost(post.id)
+    val comment = postWithComment.comments[0]
+
+    postVM.removeComment(testAccount2, postWithComment, comment)
+    delay(1000)
+
+    val updatedPost = repository.getPost(post.id)
+    assertTrue(updatedPost.comments.isEmpty())
+  }
+
+  @Test(expected = PermissionDeniedException::class)
+  fun testRemoveCommentAsNonAuthor() = runTest {
+    val post = repository.createPost("Post", "Content", testAccount1.uid)
+    repository.addComment(post.id, "Comment", testAccount2.uid, post.id)
+
+    val postWithComment = repository.getPost(post.id)
+    val comment = postWithComment.comments[0]
+
+    postVM.removeComment(testAccount1, postWithComment, comment)
+  }
+
+  @Test
+  fun testGetPostsFromRepository() = runTest {
+    // Create multiple posts
+    val post1 = repository.createPost("Post 1", "Content 1", testAccount1.uid, listOf("tag1"))
+    val post2 = repository.createPost("Post 2", "Content 2", testAccount2.uid, listOf("tag2"))
+    val post3 = repository.createPost("Post 3", "Content 3", testAccount1.uid)
+
+    // Add comments to one of the posts
+    repository.addComment(post1.id, "Comment on post 1", testAccount2.uid, post1.id)
+
+    // Fetch all posts
+    val posts = repository.getPosts()
+
+    // Verify we get all posts
+    assertTrue(posts.size >= 3)
+
+    // Verify posts are sorted by timestamp (newest first)
+    val retrievedPost3 = posts.find { it.id == post3.id }
+    val retrievedPost2 = posts.find { it.id == post2.id }
+    val retrievedPost1 = posts.find { it.id == post1.id }
+
+    assertNotNull(retrievedPost1)
+    assertNotNull(retrievedPost2)
+    assertNotNull(retrievedPost3)
+
+    // Verify post content
+    assertEquals("Post 1", retrievedPost1!!.title)
+    assertEquals("Content 1", retrievedPost1.body)
+    assertEquals(testAccount1.uid, retrievedPost1.authorId)
+    assertEquals(listOf("tag1"), retrievedPost1.tags)
+
+    // Verify comments are NOT loaded (empty list)
+    assertTrue(retrievedPost1.comments.isEmpty())
+    assertTrue(retrievedPost2!!.comments.isEmpty())
+    assertTrue(retrievedPost3!!.comments.isEmpty())
+  }
+
+  @Test
+  fun testGetPostsReturnsEmptyListWhenNoPosts() = runTest {
+    val posts = repository.getPosts()
+    assertNotNull(posts)
+  }
+
+  @Test
+  fun testGetPostsFromViewModel() = runTest {
+    // Create test posts
+    repository.createPost("VM Post 1", "Content 1", testAccount1.uid)
+    repository.createPost("VM Post 2", "Content 2", testAccount2.uid)
+
+    // Verify posts StateFlow is updated
+    val posts = repository.getPosts()
+    assertTrue(posts.size >= 2)
+
+    // Verify posts don't have comments loaded
+    posts.forEach { post -> assertTrue(post.comments.isEmpty()) }
+  }
+
+  @Test
+  fun testGetPostsViewModelInitialState() = runTest {
+    // Verify initial state is empty list
+    val initialPosts = overviewVM.posts.value
+    assertTrue(initialPosts.isEmpty())
+  }
+}

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/DiscussionScreenIntegrationTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/DiscussionScreenIntegrationTest.kt
@@ -6,7 +6,6 @@ import com.github.meeplemeet.model.repositories.FirestoreRepository
 import com.github.meeplemeet.model.structures.*
 import com.github.meeplemeet.model.viewmodels.FirestoreViewModel
 import com.github.meeplemeet.utils.FirestoreTests
-import java.util.*
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.Before

--- a/app/src/main/java/com/github/meeplemeet/model/repositories/AuthRepository.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/repositories/AuthRepository.kt
@@ -6,7 +6,6 @@ import com.github.meeplemeet.FirebaseProvider
 import com.github.meeplemeet.model.structures.Account
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential.Companion.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL
 import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.auth.auth
 import kotlinx.coroutines.tasks.await
 
 /**

--- a/app/src/main/java/com/github/meeplemeet/model/repositories/FirestorePostRepository.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/repositories/FirestorePostRepository.kt
@@ -1,0 +1,231 @@
+// Docs generated with Claude Code.
+
+package com.github.meeplemeet.model.repositories
+
+import com.github.meeplemeet.FirebaseProvider
+import com.github.meeplemeet.model.structures.CommentNoUid
+import com.github.meeplemeet.model.structures.Post
+import com.github.meeplemeet.model.structures.PostNoUid
+import com.github.meeplemeet.model.structures.fromNoUid
+import com.github.meeplemeet.model.structures.toNoUid
+import com.google.firebase.Timestamp
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.ListenerRegistration
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.tasks.await
+
+/** Path to the posts collection in Firestore. */
+const val POSTS_COLLECTION_PATH = "posts"
+
+/** Path to the comments subcollection within each post document. */
+private const val COMMENTS_COLLECTION_PATH = "comments"
+
+/**
+ * Repository for managing posts and their comments in Firestore.
+ *
+ * Each post is stored under `posts/{postId}`. Each post's comments and replies are stored in a
+ * subcollection `posts/{postId}/comments/{commentId}`. Comments can be nested by referencing parent
+ * comment IDs, enabling threaded discussions.
+ *
+ * @property db The Firestore database instance to use for operations.
+ */
+class FirestorePostRepository(private val db: FirebaseFirestore = FirebaseProvider.db) {
+  private val posts = db.collection(POSTS_COLLECTION_PATH)
+
+  /** Generates a new unique ID for a post or comment. */
+  private fun newPostUUID(): String = posts.document().id
+
+  private fun newCommentUUID(postId: String): String =
+      posts.document(postId).collection(COMMENTS_COLLECTION_PATH).document().id
+
+  /**
+   * Creates a new post in Firestore.
+   *
+   * @param title The title of the post.
+   * @param content The main content/body of the post.
+   * @param authorId The UID of the user creating the post.
+   * @param tags Optional list of tags associated with the post for categorization.
+   * @return The created [Post] with its generated ID and timestamp.
+   */
+  suspend fun createPost(
+      title: String,
+      content: String,
+      authorId: String,
+      tags: List<String> = emptyList()
+  ): Post {
+    val postId = newPostUUID()
+    val post = Post(postId, title, content, Timestamp.now(), authorId, tags)
+    val (feedNoUid, comments) = toNoUid(post)
+
+    val batch = db.batch()
+    batch.set(posts.document(postId), feedNoUid)
+    val fieldsCollection = posts.document(postId).collection(COMMENTS_COLLECTION_PATH)
+    comments.forEach { c -> batch.set(fieldsCollection.document(c.id), c) }
+
+    batch.commit().await()
+    return post
+  }
+
+  /**
+   * Deletes a post and all its associated comments from Firestore.
+   *
+   * This operation is performed as a batch write to ensure atomicity.
+   *
+   * @param postId The ID of the post to delete.
+   */
+  suspend fun deletePost(postId: String) {
+    val feedRef = posts.document(postId)
+    val commentsSnap = feedRef.collection(COMMENTS_COLLECTION_PATH).get().await()
+    val batch = db.batch()
+
+    commentsSnap.documents.forEach { batch.delete(it.reference) }
+    batch.delete(feedRef)
+    batch.commit().await()
+  }
+
+  /**
+   * Adds a comment or reply to a post.
+   *
+   * To add a top-level comment, set [parentId] to the post's ID. To add a reply to another comment,
+   * set [parentId] to that comment's ID.
+   *
+   * @param postId The ID of the post to comment on.
+   * @param text The text content of the comment.
+   * @param authorId The UID of the user creating the comment.
+   * @param parentId The ID of the parent (either the post ID for top-level comments, or another
+   *   comment ID for replies).
+   * @return The generated ID of the newly created comment.
+   */
+  suspend fun addComment(postId: String, text: String, authorId: String, parentId: String): String {
+    val commentId = newCommentUUID(postId)
+    val comment =
+        CommentNoUid(
+            id = commentId,
+            text = text,
+            timestamp = Timestamp.now(),
+            authorId = authorId,
+            parentId = parentId)
+    posts
+        .document(postId)
+        .collection(COMMENTS_COLLECTION_PATH)
+        .document(commentId)
+        .set(comment)
+        .await()
+    return commentId
+  }
+
+  /**
+   * Removes a comment and all its direct replies from a post.
+   *
+   * This operation cascades to delete all replies to the specified comment. The operation is
+   * performed as a batch write to ensure atomicity.
+   *
+   * @param postId The ID of the post containing the comment.
+   * @param commentId The ID of the comment to remove.
+   * @throws IllegalArgumentException if the comment does not exist.
+   */
+  suspend fun removeComment(postId: String, commentId: String) {
+    val fieldsRef = posts.document(postId).collection(COMMENTS_COLLECTION_PATH)
+    val commentDoc = fieldsRef.document(commentId).get().await()
+    if (!commentDoc.exists()) throw IllegalArgumentException("No such comment")
+
+    val replies = fieldsRef.whereEqualTo("parentId", commentId).get().await()
+
+    val batch = db.batch()
+    replies.documents.forEach { batch.delete(it.reference) }
+    batch.delete(commentDoc.reference)
+    batch.commit().await()
+  }
+
+  /**
+   * Retrieves a single post with all its comments from Firestore.
+   *
+   * This function fetches both the post document and its comments subcollection, reconstructing the
+   * full hierarchical comment tree.
+   *
+   * @param postId The ID of the post to retrieve.
+   * @return The complete [Post] object with nested comments.
+   * @throws IllegalArgumentException if the post does not exist.
+   */
+  suspend fun getPost(postId: String): Post {
+    val feedRef = posts.document(postId)
+    val feedSnap = feedRef.get().await()
+
+    if (!feedSnap.exists()) {
+      throw IllegalArgumentException("Post with ID $postId does not exist")
+    }
+
+    val postNoUid =
+        feedSnap.toObject(PostNoUid::class.java)
+            ?: throw IllegalArgumentException("Failed to deserialize post")
+
+    val commentsSnap = feedRef.collection(COMMENTS_COLLECTION_PATH).get().await()
+    val comments = commentsSnap.toObjects(CommentNoUid::class.java)
+
+    return fromNoUid(postNoUid, comments)
+  }
+
+  /**
+   * Creates a Flow that emits real-time updates for a post and its comments.
+   *
+   * This function sets up Firestore listeners for both the post document and its comments
+   * subcollection, reconstructing the full hierarchical comment tree whenever any change occurs.
+   *
+   * @param postId The ID of the post to listen to.
+   * @return A [Flow] that emits the complete [Post] object with nested comments whenever updates
+   *   occur.
+   */
+  fun listenPost(postId: String): Flow<Post> = callbackFlow {
+    val feedRef = posts.document(postId)
+    val commentsRef = feedRef.collection(COMMENTS_COLLECTION_PATH)
+
+    // Listen for both feed metadata and comment updates
+    var commentsListener: ListenerRegistration? = null
+    val feedListener =
+        feedRef.addSnapshotListener { feedSnap, e ->
+          if (e != null) {
+            close(e)
+            return@addSnapshotListener
+          }
+          if (feedSnap == null || !feedSnap.exists()) return@addSnapshotListener
+
+          val postNoUid = feedSnap.toObject(PostNoUid::class.java) ?: return@addSnapshotListener
+
+          commentsListener =
+              commentsRef.addSnapshotListener { qs, e2 ->
+                if (e2 != null) {
+                  close(e2)
+                  return@addSnapshotListener
+                }
+                if (qs != null) {
+                  val comments = qs.toObjects(CommentNoUid::class.java)
+                  trySend(fromNoUid(postNoUid, comments))
+                }
+              }
+        }
+
+    awaitClose { commentsListener?.remove() }
+    awaitClose { feedListener.remove() }
+  }
+
+  /**
+   * Retrieves all posts without their comments from Firestore.
+   *
+   * This function fetches all post documents for efficient preview display in feed/overview
+   * screens. Comments are not loaded to improve performance when displaying multiple posts.
+   *
+   * @return A list of [Post] objects without comments, sorted by timestamp (newest first).
+   */
+  suspend fun getPosts(): List<Post> {
+    val postsSnap = posts.get().await()
+
+    return postsSnap.documents
+        .mapNotNull { postDoc ->
+          val postNoUid = postDoc.toObject(PostNoUid::class.java) ?: return@mapNotNull null
+          fromNoUid(postNoUid, emptyList())
+        }
+        .sortedByDescending { it.timestamp }
+  }
+}

--- a/app/src/main/java/com/github/meeplemeet/model/structures/Comment.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/structures/Comment.kt
@@ -1,0 +1,65 @@
+package com.github.meeplemeet.model.structures
+
+import com.google.firebase.Timestamp
+import kotlinx.serialization.Serializable
+
+data class Comment(
+    val id: String,
+    val text: String,
+    val timestamp: Timestamp,
+    val authorId: String,
+    val children: MutableList<Comment> = mutableListOf()
+)
+
+@Serializable
+data class CommentNoUid(
+    val id: String = "",
+    val text: String = "",
+    val timestamp: Timestamp = Timestamp.now(),
+    val authorId: String = "",
+    val parentId: String = "",
+)
+
+fun toNoUid(feedId: String, comments: List<Comment>): List<CommentNoUid> {
+  val result = mutableListOf<CommentNoUid>()
+  val stack = ArrayDeque<Pair<Comment, String>>()
+  comments.forEach { stack.add(it to feedId) }
+
+  while (stack.isNotEmpty()) {
+    val (node, parentId) = stack.removeLast()
+    result.add(
+        CommentNoUid(
+            id = node.id,
+            text = node.text,
+            timestamp = node.timestamp,
+            authorId = node.authorId,
+            parentId = parentId))
+    node.children.forEach { child -> stack.add(child to node.id) }
+  }
+  return result
+}
+
+/** Reconstruct a tree of comments from flat CommentNoUid list. */
+fun fromNoUid(feedId: String, docs: List<CommentNoUid>): List<Comment> {
+  val map =
+      docs
+          .associateBy { it.id }
+          .mapValues { (_, c) ->
+            Comment(
+                id = c.id,
+                text = c.text,
+                timestamp = c.timestamp,
+                authorId = c.authorId,
+                children = mutableListOf())
+          }
+
+  docs.forEach { c ->
+    if (c.parentId.isNotBlank() && c.parentId != feedId) {
+      val parent = map[c.parentId]
+      val child = map[c.id]
+      if (parent != null && child != null) parent.children.add(child)
+    }
+  }
+
+  return docs.filter { it.parentId == feedId || it.parentId.isBlank() }.mapNotNull { map[it.id] }
+}

--- a/app/src/main/java/com/github/meeplemeet/model/structures/Post.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/structures/Post.kt
@@ -1,0 +1,96 @@
+// Docs generated with Claude Code.
+
+package com.github.meeplemeet.model.structures
+
+import com.google.firebase.Timestamp
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents a post in the application with hierarchical comments.
+ *
+ * A post contains main content and can have threaded comments attached to it. Comments are stored
+ * in the [comments] list as a tree structure.
+ *
+ * @property id Unique identifier for the post.
+ * @property title The title/heading of the post.
+ * @property body The main content/body text of the post.
+ * @property timestamp When the post was created.
+ * @property authorId The UID of the user who created the post.
+ * @property tags List of tags for categorizing and filtering posts.
+ * @property comments Top-level comments on this post, which may contain nested replies.
+ */
+data class Post(
+    val id: String,
+    val title: String,
+    val body: String,
+    val timestamp: Timestamp,
+    val authorId: String,
+    val tags: List<String>,
+    val comments: List<Comment> = emptyList()
+)
+
+/**
+ * Firestore-serializable representation of a post without nested comment data.
+ *
+ * This class is used for storing post metadata in Firestore. Comments are stored separately in a
+ * subcollection and are not included in this structure.
+ *
+ * @property id Unique identifier for the post.
+ * @property title The title/heading of the post.
+ * @property body The main content/body text of the post.
+ * @property timestamp When the post was created.
+ * @property tags List of tags for categorizing and filtering posts.
+ * @property authorId The UID of the user who created the post.
+ */
+@Serializable
+data class PostNoUid(
+    val id: String = "",
+    val title: String = "",
+    val body: String = "",
+    val timestamp: Timestamp = Timestamp.now(),
+    val tags: List<String> = emptyList(),
+    val authorId: String = "",
+)
+
+/**
+ * Converts a [Post] with nested comments into Firestore-storable forms.
+ *
+ * This function flattens the hierarchical comment structure into a list of [CommentNoUid] objects
+ * that can be stored in a Firestore subcollection, along with a [PostNoUid] containing the post
+ * metadata.
+ *
+ * @param post The post to convert.
+ * @return A pair of ([PostNoUid], [List]<[CommentNoUid]>) ready for Firestore storage.
+ */
+fun toNoUid(post: Post): Pair<PostNoUid, List<CommentNoUid>> {
+  val postNoUid =
+      PostNoUid(
+          id = post.id,
+          title = post.title,
+          body = post.body,
+          timestamp = post.timestamp,
+          authorId = post.authorId,
+          tags = post.tags)
+  return postNoUid to toNoUid(post.id, post.comments)
+}
+
+/**
+ * Reconstructs a complete [Post] with nested comments from Firestore-stored data.
+ *
+ * This function takes the flat list of comments from Firestore and rebuilds the hierarchical
+ * comment tree structure based on parent-child relationships.
+ *
+ * @param postNoUid The post metadata from Firestore.
+ * @param commentDocs The list of comments from the Firestore subcollection.
+ * @return A fully reconstructed [Post] with nested comment hierarchy.
+ */
+fun fromNoUid(postNoUid: PostNoUid, commentDocs: List<CommentNoUid>): Post =
+    Post(
+        id = postNoUid.id,
+        title = postNoUid.title,
+        body = postNoUid.body,
+        timestamp = postNoUid.timestamp,
+        authorId = postNoUid.authorId,
+        tags = postNoUid.tags,
+        comments = fromNoUid(postNoUid.id, commentDocs),
+    )

--- a/app/src/main/java/com/github/meeplemeet/model/viewmodels/CreatePostViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/viewmodels/CreatePostViewModel.kt
@@ -1,0 +1,41 @@
+// Docs generated with Claude Code.
+
+package com.github.meeplemeet.model.viewmodels
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.github.meeplemeet.model.repositories.FirestorePostRepository
+import com.github.meeplemeet.model.structures.Account
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * ViewModel for creating new posts.
+ *
+ * This ViewModel handles the creation of posts and exposes the resulting post ID through a
+ * [StateFlow] for UI observation.
+ *
+ * @property repository The repository used for post operations.
+ */
+class CreatePostViewModel(
+    private val repository: FirestorePostRepository = FirestorePostRepository()
+) : ViewModel() {
+  /**
+   * Creates a new post in Firestore.
+   *
+   * This operation is performed asynchronously in the viewModelScope. Upon successful creation, the
+   * post ID is emitted through [postId].
+   *
+   * @param title The title of the post.
+   * @param body The main content/body of the post.
+   * @param author The UID of the user creating the post.
+   * @param tags Optional list of tags for categorizing the post.
+   */
+  fun createPost(title: String, body: String, author: Account, tags: List<String> = emptyList()) {
+    if (title.isBlank()) throw IllegalArgumentException("Cannot create a post with an empty title")
+
+    if (body.isBlank()) throw IllegalArgumentException("Cannot create a post with an empty body")
+
+    viewModelScope.launch { repository.createPost(title, body, author.uid, tags) }
+  }
+}

--- a/app/src/main/java/com/github/meeplemeet/model/viewmodels/PostOverviewViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/viewmodels/PostOverviewViewModel.kt
@@ -1,0 +1,56 @@
+// Docs generated with Claude Code.
+
+package com.github.meeplemeet.model.viewmodels
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.github.meeplemeet.model.repositories.FirestorePostRepository
+import com.github.meeplemeet.model.structures.Post
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * ViewModel for managing the overview/feed of posts.
+ *
+ * This ViewModel fetches and exposes a list of posts without their comments for preview purposes.
+ * It maintains the posts in a StateFlow that UI components can observe for reactive updates.
+ *
+ * @property repository The repository for accessing post data from Firestore.
+ */
+class PostOverviewViewModel(
+    private val repository: FirestorePostRepository = FirestorePostRepository()
+) : ViewModel() {
+
+  private val _posts = MutableStateFlow<List<Post>>(emptyList())
+
+  /**
+   * StateFlow containing the current list of posts.
+   *
+   * Posts are provided without their comments for efficient preview display. The list is sorted by
+   * timestamp with newest posts first. UI components can collect this flow to observe updates.
+   */
+  val posts: StateFlow<List<Post>> = _posts
+
+  private val _errorMsg = MutableStateFlow("")
+  val errorMessage: StateFlow<String> = _errorMsg
+
+  /**
+   * Fetches all posts from the repository and updates the [posts] StateFlow.
+   *
+   * This function launches a coroutine in the viewModelScope to fetch posts asynchronously. Posts
+   * are retrieved without their comments for efficient loading in overview/feed screens.
+   */
+  fun getPosts() {
+    viewModelScope.launch {
+      try {
+        val fetchedPosts = repository.getPosts()
+        _posts.value = fetchedPosts
+        _errorMsg.value = ""
+      } catch (_: Exception) {
+        _posts.value = emptyList()
+        _errorMsg.value = "An error occurred while getting all posts."
+      }
+    }
+  }
+}

--- a/app/src/main/java/com/github/meeplemeet/model/viewmodels/PostViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/viewmodels/PostViewModel.kt
@@ -1,0 +1,97 @@
+// Docs generated with Claude Code.
+
+package com.github.meeplemeet.model.viewmodels
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.github.meeplemeet.model.PermissionDeniedException
+import com.github.meeplemeet.model.repositories.FirestorePostRepository
+import com.github.meeplemeet.model.structures.Account
+import com.github.meeplemeet.model.structures.Comment
+import com.github.meeplemeet.model.structures.Post
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+/**
+ * ViewModel for managing post interactions and operations.
+ *
+ * This ViewModel handles post deletion, comment creation, and comment removal with appropriate
+ * permission checks to ensure users can only modify their own content.
+ *
+ * @property repository The repository used for post operations.
+ */
+class PostViewModel(private val repository: FirestorePostRepository = FirestorePostRepository()) :
+    ViewModel() {
+  /**
+   * Deletes a post from Firestore.
+   *
+   * Only the post's author can delete it. This operation is performed asynchronously in the
+   * viewModelScope.
+   *
+   * @param author The account attempting to delete the post.
+   * @param post The post to delete.
+   * @throws PermissionDeniedException if the requester is not the post's author.
+   */
+  fun deletePost(author: Account, post: Post) {
+    if (post.authorId != author.uid)
+        throw PermissionDeniedException("Another users post cannot be deleted")
+
+    viewModelScope.launch { repository.deletePost(post.id) }
+  }
+
+  /**
+   * Adds a comment or reply to a post.
+   *
+   * To add a top-level comment, set [parentId] to the post's ID. To add a reply to another comment,
+   * set [parentId] to that comment's ID. This operation is performed asynchronously in the
+   * viewModelScope.
+   *
+   * @param author The account creating the comment.
+   * @param post The post being commented on.
+   * @param parentId The ID of the parent (post ID for top-level comments, or comment ID for
+   *   replies).
+   * @param text The text content of the comment.
+   * @throws IllegalArgumentException if the text is blank.
+   */
+  fun addComment(author: Account, post: Post, parentId: String, text: String) {
+    if (text.isBlank()) throw IllegalArgumentException("Cannot send a blank comment")
+
+    viewModelScope.launch { repository.addComment(post.id, text, author.uid, parentId) }
+  }
+
+  /**
+   * Removes a comment and all its direct replies from a post.
+   *
+   * Only the comment's author can remove it. This operation cascades to delete all replies to the
+   * specified comment. The operation is performed asynchronously in the viewModelScope.
+   *
+   * @param author The account attempting to remove the comment.
+   * @param post The post containing the comment.
+   * @param comment The comment to remove.
+   * @throws PermissionDeniedException if the requester is not the comment's author.
+   */
+  fun removeComment(author: Account, post: Post, comment: Comment) {
+    if (comment.authorId != author.uid)
+        throw PermissionDeniedException("Another users comment cannot be deleted")
+
+    viewModelScope.launch { repository.removeComment(post.id, comment.id) }
+  }
+
+  /** Holds a [StateFlow] of discussion preview maps keyed by post ID. */
+  private val postFlows = mutableMapOf<String, StateFlow<Post?>>()
+
+  fun postFlow(postId: String): StateFlow<Post?> {
+    if (postId.isBlank()) return MutableStateFlow(null)
+    return postFlows.getOrPut(postId) {
+      repository
+          .listenPost(postId)
+          .stateIn(
+              scope = viewModelScope,
+              started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 0),
+              initialValue = null)
+    }
+  }
+}


### PR DESCRIPTION
This PR manually reverts the revert of PR #69 ("Add Feed/Post Backend with Comments Support") to restore its original changes. SonarCloud is now properly configured, so the original feed backend can be safely reintroduced. No conflicts resolution was required for this restoration.

For full context, including commit history and review discussions, please refer to PR #69 .
For context about the reason of the initial revert, please refer to PR #104.