### PR TITLE
Navigation integration across post screens

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -102,22 +102,41 @@ android {
         }
     }
 
+    // Disable Proguard check for demo purpose
+//    buildTypes {
+//        getByName("release") {
+//            isMinifyEnabled = true
+//            proguardFiles(
+//                getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
+//            )
+//            // Only apply signing config if keystore is configured
+//            if (System.getenv("KEYSTORE_PATH") != null) {
+//                signingConfig = signingConfigs.getByName("release")
+//            }
+//        }
+//        debug {
+//            enableUnitTestCoverage = true
+//            enableAndroidTestCoverage = true
+//        }
+//    }
+
+
     buildTypes {
-        getByName("release") {
-            isMinifyEnabled = true
+        release {
+            isMinifyEnabled = false
+            isShrinkResources = false
             proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
             )
-            // Only apply signing config if keystore is configured
-            if (System.getenv("KEYSTORE_PATH") != null) {
-                signingConfig = signingConfigs.getByName("release")
-            }
+            signingConfig = signingConfigs.getByName("release")
         }
         debug {
             enableUnitTestCoverage = true
             enableAndroidTestCoverage = true
         }
     }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11

--- a/app/src/androidTest/java/com/github/meeplemeet/utils/NavigationTestHelpers.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/utils/NavigationTestHelpers.kt
@@ -56,7 +56,7 @@ object NavigationTestHelpers {
   }
 
   fun ComposeTestRule.checkDiscoverScreenIsDisplayed() {
-    checkScreenIsDisplayed(MeepleMeetScreen.DiscoverFeeds.title)
+    checkScreenIsDisplayed(MeepleMeetScreen.DiscoverPosts.title)
   }
 
   fun ComposeTestRule.checkSessionsScreenIsDisplayed() {

--- a/app/src/main/java/com/github/meeplemeet/ui/DiscoverSessionsScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/DiscoverSessionsScreen.kt
@@ -1,38 +1,24 @@
 package com.github.meeplemeet.ui
 
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.CenterAlignedTopAppBar
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.testTag
-import com.github.meeplemeet.ui.navigation.BottomNavigationMenu
-import com.github.meeplemeet.ui.navigation.MeepleMeetScreen
-import com.github.meeplemeet.ui.navigation.NavigationActions
-import com.github.meeplemeet.ui.navigation.NavigationTestTags
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun DiscoverSessionsScreen(navigation: NavigationActions) {
-  Scaffold(
-      topBar = {
-        CenterAlignedTopAppBar(
-            title = {
-              Text(
-                  text = MeepleMeetScreen.DiscoverFeeds.title,
-                  style = MaterialTheme.typography.bodyMedium,
-                  color = MaterialTheme.colorScheme.onPrimary,
-                  modifier = Modifier.testTag(NavigationTestTags.SCREEN_TITLE))
-            })
-      },
-      bottomBar = {
-        BottomNavigationMenu(
-            currentScreen = MeepleMeetScreen.DiscoverFeeds,
-            onTabSelected = { screen -> navigation.navigateTo(screen) })
-      }) { innerPadding ->
-        Text("WIP", modifier = Modifier.padding(innerPadding))
-      }
-}
+// @OptIn(ExperimentalMaterial3Api::class)
+// @Composable
+// fun DiscoverSessionsScreen(navigation: NavigationActions) {
+//  Scaffold(
+//      topBar = {
+//        CenterAlignedTopAppBar(
+//            title = {
+//              Text(
+//                  text = MeepleMeetScreen.DiscoverFeeds.title,
+//                  style = MaterialTheme.typography.bodyMedium,
+//                  color = MaterialTheme.colorScheme.onPrimary,
+//                  modifier = Modifier.testTag(NavigationTestTags.SCREEN_TITLE))
+//            })
+//      },
+//      bottomBar = {
+//        BottomNavigationMenu(
+//            currentScreen = MeepleMeetScreen.DiscoverFeeds,
+//            onTabSelected = { screen -> navigation.navigateTo(screen) })
+//      }) { innerPadding ->
+//        Text("WIP", modifier = Modifier.padding(innerPadding))
+//      }
+// }

--- a/app/src/main/java/com/github/meeplemeet/ui/FeedsOverviewScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/FeedsOverviewScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.meeplemeet.model.structures.Account
@@ -34,7 +33,6 @@ import com.github.meeplemeet.ui.navigation.MeepleMeetScreen
 import com.github.meeplemeet.ui.navigation.NavigationActions
 import com.github.meeplemeet.ui.navigation.NavigationTestTags
 import com.github.meeplemeet.ui.theme.AppColors
-import com.github.meeplemeet.ui.theme.AppTheme
 import com.github.meeplemeet.ui.theme.Elevation
 import java.text.SimpleDateFormat
 import java.util.*
@@ -310,93 +308,3 @@ private fun FeedCard(
         }
       }
 }
-
-/* ==========  PREVIEWS  ======================================================= */
-@Preview(showBackground = true, name = "Card – AppColors")
-@Composable
-private fun FeedCardPreview() {
-  AppTheme {
-    Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
-      FeedCard(
-          authorName = "Alice",
-          postTitle = "Tomorrow party !",
-          lastMsg = "Be on time please",
-          commentCount = 12,
-          date = "31/10/2025",
-          firstTag = "board-games",
-          modifier = Modifier.fillMaxWidth())
-    }
-  }
-}
-
-// @OptIn(ExperimentalMaterial3Api::class)
-// @Preview(showBackground = true, name = "Overview – scaffold mock")
-// @Composable
-// private fun FeedsOverviewPreview() {
-//  AppTheme {
-//    Scaffold(
-//        topBar = {
-//          CenterAlignedTopAppBar(
-//              title = {
-//                Text(
-//                    text = MeepleMeetScreen.DiscoverPosts.name,
-//                    style = MaterialTheme.typography.bodyMedium,
-//                    color = MaterialTheme.colorScheme.onPrimary)
-//              })
-//        },
-//        bottomBar = {
-//          BottomNavigationMenu(
-//              currentScreen = MeepleMeetScreen.DiscoverPosts, onTabSelected = { /* preview only
-// */})
-//        }) { inner ->
-//          LazyColumn(
-//              modifier =
-//                  Modifier.fillMaxSize()
-//                      .background(MaterialTheme.colorScheme.background)
-//                      .padding(inner),
-//              verticalArrangement = Arrangement.spacedBy(10.dp),
-//              contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp)) {
-//                item {
-//                  FeedCard(
-//                      authorName = "Catan Crew",
-//                      postTitle = "Catan Crew",
-//                      lastMsg = "You: I’ll bring wheat 🍞",
-//                      commentCount = 0,
-//                      date = "31/10/2025",
-//                      firstTag = "board-games",
-//                      modifier = Modifier.fillMaxWidth())
-//                }
-//                item {
-//                  FeedCard(
-//                      authorName = "Alice",
-//                      postTitle = "Gloomhaven Sunday",
-//                      lastMsg = "Alice: Scenario 12 tonight? Need traps disarmed.",
-//                      commentCount = 3,
-//                      date = "30/10/2025",
-//                      firstTag = "rpg",
-//                      modifier = Modifier.fillMaxWidth())
-//                }
-//                item {
-//                  FeedCard(
-//                      authorName = "Ben",
-//                      postTitle = "Arkham Horror Night",
-//                      lastMsg = "Ben: Chaos bag updated. Don’t forget new weakness cards!",
-//                      commentCount = 1,
-//                      date = "29/10/2025",
-//                      firstTag = "horror",
-//                      modifier = Modifier.fillMaxWidth())
-//                }
-//                item {
-//                  FeedCard(
-//                      authorName = "System",
-//                      postTitle = "Ticket to Ride: Europe",
-//                      lastMsg = "(No messages yet)",
-//                      commentCount = 0,
-//                      date = "28/10/2025",
-//                      firstTag = null,
-//                      modifier = Modifier.fillMaxWidth())
-//                }
-//              }
-//        }
-//  }
-// }

--- a/app/src/main/java/com/github/meeplemeet/ui/FeedsOverviewScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/FeedsOverviewScreen.kt
@@ -93,7 +93,7 @@ fun FeedsOverviewScreen(
         CenterAlignedTopAppBar(
             title = {
               Text(
-                  text = MeepleMeetScreen.FeedsOverview.title,
+                  text = MeepleMeetScreen.DiscoverPosts.title,
                   style = MaterialTheme.typography.bodyMedium,
                   color = MaterialTheme.colorScheme.onPrimary,
                   modifier = Modifier.testTag(NavigationTestTags.SCREEN_TITLE))
@@ -101,7 +101,7 @@ fun FeedsOverviewScreen(
       },
       bottomBar = {
         BottomNavigationMenu(
-            currentScreen = MeepleMeetScreen.FeedsOverview,
+            currentScreen = MeepleMeetScreen.DiscoverPosts,
             modifier = Modifier.testTag(NavigationTestTags.BOTTOM_NAVIGATION_MENU),
             onTabSelected = { screen -> navigation.navigateTo(screen) })
       }) { innerPadding ->
@@ -329,73 +329,74 @@ private fun FeedCardPreview() {
   }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
-@Preview(showBackground = true, name = "Overview – scaffold mock")
-@Composable
-private fun FeedsOverviewPreview() {
-  AppTheme {
-    Scaffold(
-        topBar = {
-          CenterAlignedTopAppBar(
-              title = {
-                Text(
-                    text = MeepleMeetScreen.FeedsOverview.name,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onPrimary)
-              })
-        },
-        bottomBar = {
-          BottomNavigationMenu(
-              currentScreen = MeepleMeetScreen.FeedsOverview, onTabSelected = { /* preview only */})
-        }) { inner ->
-          LazyColumn(
-              modifier =
-                  Modifier.fillMaxSize()
-                      .background(MaterialTheme.colorScheme.background)
-                      .padding(inner),
-              verticalArrangement = Arrangement.spacedBy(10.dp),
-              contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp)) {
-                item {
-                  FeedCard(
-                      authorName = "Catan Crew",
-                      postTitle = "Catan Crew",
-                      lastMsg = "You: I’ll bring wheat 🍞",
-                      commentCount = 0,
-                      date = "31/10/2025",
-                      firstTag = "board-games",
-                      modifier = Modifier.fillMaxWidth())
-                }
-                item {
-                  FeedCard(
-                      authorName = "Alice",
-                      postTitle = "Gloomhaven Sunday",
-                      lastMsg = "Alice: Scenario 12 tonight? Need traps disarmed.",
-                      commentCount = 3,
-                      date = "30/10/2025",
-                      firstTag = "rpg",
-                      modifier = Modifier.fillMaxWidth())
-                }
-                item {
-                  FeedCard(
-                      authorName = "Ben",
-                      postTitle = "Arkham Horror Night",
-                      lastMsg = "Ben: Chaos bag updated. Don’t forget new weakness cards!",
-                      commentCount = 1,
-                      date = "29/10/2025",
-                      firstTag = "horror",
-                      modifier = Modifier.fillMaxWidth())
-                }
-                item {
-                  FeedCard(
-                      authorName = "System",
-                      postTitle = "Ticket to Ride: Europe",
-                      lastMsg = "(No messages yet)",
-                      commentCount = 0,
-                      date = "28/10/2025",
-                      firstTag = null,
-                      modifier = Modifier.fillMaxWidth())
-                }
-              }
-        }
-  }
-}
+// @OptIn(ExperimentalMaterial3Api::class)
+// @Preview(showBackground = true, name = "Overview – scaffold mock")
+// @Composable
+// private fun FeedsOverviewPreview() {
+//  AppTheme {
+//    Scaffold(
+//        topBar = {
+//          CenterAlignedTopAppBar(
+//              title = {
+//                Text(
+//                    text = MeepleMeetScreen.DiscoverPosts.name,
+//                    style = MaterialTheme.typography.bodyMedium,
+//                    color = MaterialTheme.colorScheme.onPrimary)
+//              })
+//        },
+//        bottomBar = {
+//          BottomNavigationMenu(
+//              currentScreen = MeepleMeetScreen.DiscoverPosts, onTabSelected = { /* preview only
+// */})
+//        }) { inner ->
+//          LazyColumn(
+//              modifier =
+//                  Modifier.fillMaxSize()
+//                      .background(MaterialTheme.colorScheme.background)
+//                      .padding(inner),
+//              verticalArrangement = Arrangement.spacedBy(10.dp),
+//              contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp)) {
+//                item {
+//                  FeedCard(
+//                      authorName = "Catan Crew",
+//                      postTitle = "Catan Crew",
+//                      lastMsg = "You: I’ll bring wheat 🍞",
+//                      commentCount = 0,
+//                      date = "31/10/2025",
+//                      firstTag = "board-games",
+//                      modifier = Modifier.fillMaxWidth())
+//                }
+//                item {
+//                  FeedCard(
+//                      authorName = "Alice",
+//                      postTitle = "Gloomhaven Sunday",
+//                      lastMsg = "Alice: Scenario 12 tonight? Need traps disarmed.",
+//                      commentCount = 3,
+//                      date = "30/10/2025",
+//                      firstTag = "rpg",
+//                      modifier = Modifier.fillMaxWidth())
+//                }
+//                item {
+//                  FeedCard(
+//                      authorName = "Ben",
+//                      postTitle = "Arkham Horror Night",
+//                      lastMsg = "Ben: Chaos bag updated. Don’t forget new weakness cards!",
+//                      commentCount = 1,
+//                      date = "29/10/2025",
+//                      firstTag = "horror",
+//                      modifier = Modifier.fillMaxWidth())
+//                }
+//                item {
+//                  FeedCard(
+//                      authorName = "System",
+//                      postTitle = "Ticket to Ride: Europe",
+//                      lastMsg = "(No messages yet)",
+//                      commentCount = 0,
+//                      date = "28/10/2025",
+//                      firstTag = null,
+//                      modifier = Modifier.fillMaxWidth())
+//                }
+//              }
+//        }
+//  }
+// }

--- a/app/src/main/java/com/github/meeplemeet/ui/navigation/NavigationSystem.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/navigation/NavigationSystem.kt
@@ -102,7 +102,7 @@ enum class MeepleMeetScreen(
   DiscussionsOverview(
       "Discussions", true, Icons.Default.ChatBubbleOutline, NavigationTestTags.DISCUSSIONS_TAB),
   SessionsOverview("Sessions", true, Icons.Default.Groups, NavigationTestTags.SESSIONS_TAB),
-  DiscoverFeeds("Discover", true, Icons.Default.Language, NavigationTestTags.DISCOVER_TAB),
+  DiscoverPosts("Discover posts", true, Icons.Default.Language, NavigationTestTags.DISCOVER_TAB),
   Profile("Profile", true, Icons.Default.AccountCircle, NavigationTestTags.PROFILE_TAB),
   AddDiscussion("Add Discussion"),
   Discussion("Discussion"),
@@ -110,8 +110,8 @@ enum class MeepleMeetScreen(
   AddSession("Add Session"),
   Session("Session"),
   SessionDetails("Session Details"),
-  FeedsOverview("Feeds"),
-  CreatePost("Create post")
+  CreatePost("Create post"),
+  Post("Post")
 }
 
 /**


### PR DESCRIPTION
**Description**

- Full integration of the three Post-related screens (`FeedsOverviewScreen`, `PostScreen`, `CreatePostScreen`) into the main navigation flow.
- Implementation of callback links between screens to ensure smooth transitions.
- Temporary removal of unused screens to streamline the user experience.

**Additional note** : _Disable Proguard Rules for demo_

_This PR was reformulated with Copilot to improve readability._