### PR TITLE
Feat/account role selection

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/ui/CreateAccountScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/CreateAccountScreenTest.kt
@@ -130,6 +130,7 @@ class CreateAccountScreenTest : FirestoreTests() {
       usernameError().assertTextContains("Username cannot be empty", substring = true)
     }
 
+    /* === 7. using the checkbox properly updates account roles */
     ownerCheckbox().performClick()
     compose.waitForIdle()
     checkpoint("Owner checkbox has an impact on account") {
@@ -145,6 +146,21 @@ class CreateAccountScreenTest : FirestoreTests() {
       runBlocking {
         val acc = firestoreVm.accountFlow(me.uid).value
         acc?.spaceRenter == true
+      }
+    }
+
+    // Owner checkbox is pressed thrice -> on
+    // Renter checkbox is pressed twice -> off
+    ownerCheckbox().performClick()
+    renterCheckbox().performClick()
+    ownerCheckbox().performClick()
+    renterCheckbox().performClick()
+    ownerCheckbox().performClick()
+    compose.waitForIdle()
+    checkpoint("Multiple checkbox clicks have an impact on account") {
+      runBlocking {
+        val acc = firestoreVm.accountFlow(me.uid).value
+        acc?.shopOwner == true && acc?.spaceRenter == false
       }
     }
 

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/CreateAccountScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/CreateAccountScreenTest.kt
@@ -135,7 +135,7 @@ class CreateAccountScreenTest : FirestoreTests() {
     checkpoint("Owner checkbox has an impact on account") {
       runBlocking {
         val acc = firestoreVm.accountFlow(me.uid).value
-        acc?.isShopOwner == true
+        acc?.shopOwner == true
       }
     }
 
@@ -144,7 +144,7 @@ class CreateAccountScreenTest : FirestoreTests() {
     checkpoint("Renter checkbox has an impact on account") {
       runBlocking {
         val acc = firestoreVm.accountFlow(me.uid).value
-        acc?.isSpaceRenter == true
+        acc?.spaceRenter == true
       }
     }
 

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/CreateAccountScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/CreateAccountScreenTest.kt
@@ -44,6 +44,10 @@ class CreateAccountScreenTest : FirestoreTests() {
 
   private fun submitBtn() = compose.onNodeWithTag(CreateAccountTestTags.SUBMIT_BUTTON)
 
+  private fun ownerCheckbox() = compose.onNodeWithTag(CreateAccountTestTags.CHECKBOX_OWNER)
+
+  private fun renterCheckbox() = compose.onNodeWithTag(CreateAccountTestTags.CHECKBOX_RENTER)
+
   private inline fun checkpoint(name: String, crossinline block: () -> Unit) {
     runCatching { block() }.onSuccess { report[name] = true }.onFailure { report[name] = false }
   }
@@ -62,7 +66,7 @@ class CreateAccountScreenTest : FirestoreTests() {
     compose.setContent {
       AppTheme(ThemeMode.DARK) {
         CreateAccountScreen(
-            firestoreVM = firestoreVm,
+            discussionVM = firestoreVm,
             handlesVM = handlesVm,
             account = me,
             onCreate = { report["onCreate triggered"] = true })
@@ -124,6 +128,24 @@ class CreateAccountScreenTest : FirestoreTests() {
     compose.waitForIdle()
     checkpoint("Clearing username shows empty error") {
       usernameError().assertTextContains("Username cannot be empty", substring = true)
+    }
+
+    ownerCheckbox().performClick()
+    compose.waitForIdle()
+    checkpoint("Owner checkbox has an impact on account") {
+      runBlocking {
+        val acc = firestoreVm.accountFlow(me.uid).value
+        acc?.isShopOwner == true
+      }
+    }
+
+    renterCheckbox().performClick()
+    compose.waitForIdle()
+    checkpoint("Renter checkbox has an impact on account") {
+      runBlocking {
+        val acc = firestoreVm.accountFlow(me.uid).value
+        acc?.isSpaceRenter == true
+      }
     }
 
     /* ---------- summary ---------- */

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/DiscussionScreenIntegrationTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/DiscussionScreenIntegrationTest.kt
@@ -147,15 +147,15 @@ class DiscussionScreenIntegrationTest : FirestoreTests() {
           val discussionFlow = viewModel.discussionFlow(testDiscussion.uid)
           val latestDiscussion by discussionFlow.collectAsState(initial = testDiscussion)
           AppTheme(themeMode = ThemeMode.LIGHT) {
-              latestDiscussion?.let {
-                  if (latestDiscussion != null) {
-                  DiscussionScreen(
-                      viewModel = viewModel,
-                      discussion = latestDiscussion!!,
-                      account = currentUser,
-                      onBack = { backPressed = true })
+            latestDiscussion?.let {
+              if (latestDiscussion != null) {
+                DiscussionScreen(
+                    viewModel = viewModel,
+                    discussion = latestDiscussion!!,
+                    account = currentUser,
+                    onBack = { backPressed = true })
               }
-          }
+            }
           }
         }
 

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/DiscussionScreenIntegrationTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/DiscussionScreenIntegrationTest.kt
@@ -147,11 +147,15 @@ class DiscussionScreenIntegrationTest : FirestoreTests() {
           val discussionFlow = viewModel.discussionFlow(testDiscussion.uid)
           val latestDiscussion by discussionFlow.collectAsState(initial = testDiscussion)
           AppTheme(themeMode = ThemeMode.LIGHT) {
-            DiscussionScreen(
-                viewModel = viewModel,
-                discussion = latestDiscussion!!,
-                account = currentUser,
-                onBack = { backPressed = true })
+              latestDiscussion?.let {
+                  if (latestDiscussion != null) {
+                  DiscussionScreen(
+                      viewModel = viewModel,
+                      discussion = latestDiscussion!!,
+                      account = currentUser,
+                      onBack = { backPressed = true })
+              }
+          }
           }
         }
 

--- a/app/src/main/java/com/github/meeplemeet/MainActivity.kt
+++ b/app/src/main/java/com/github/meeplemeet/MainActivity.kt
@@ -335,15 +335,17 @@ fun MeepleMeetApp(
     }
 
     composable(MeepleMeetScreen.Profile.name) {
-      ProfileScreen(
-          navigation = navigationActions,
-          authViewModel = authVM,
-          discussionViewModel = firestoreVM,
-          account = account!!,
-          onSignOut = {
-            signedOut = true
-            navigationActions.navigateTo(MeepleMeetScreen.SignIn)
-          })
+      account?.let {
+        ProfileScreen(
+            navigation = navigationActions,
+            authViewModel = authVM,
+            discussionViewModel = firestoreVM,
+            account = account!!,
+            onSignOut = {
+              navigationActions.navigateTo(MeepleMeetScreen.SignIn)
+              signedOut = true
+            })
+      } ?: navigationActions.navigateTo(MeepleMeetScreen.SignIn)
     }
     composable(MeepleMeetScreen.ShopDetails.name) {
       if (shopId.isNotEmpty()) {

--- a/app/src/main/java/com/github/meeplemeet/MainActivity.kt
+++ b/app/src/main/java/com/github/meeplemeet/MainActivity.kt
@@ -338,7 +338,8 @@ fun MeepleMeetApp(
       ProfileScreen(
           navigation = navigationActions,
           authViewModel = authVM,
-          firestoreVM,
+          discussionViewModel = firestoreVM,
+          account = account!!,
           onSignOut = {
             signedOut = true
             navigationActions.navigateTo(MeepleMeetScreen.SignIn)

--- a/app/src/main/java/com/github/meeplemeet/model/auth/Account.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/auth/Account.kt
@@ -17,8 +17,8 @@ import kotlinx.serialization.Serializable
  *   participates in.
  * @property photoUrl User's profile picture
  * @property description A user's description about himself
- * @property isShopOwner Tells if this account is a shop owner
- * @property isSpaceRenter Tells if this account is a space renter
+ * @property shopOwner Tells if this account is a shop owner
+ * @property spaceRenter Tells if this account is a space renter
  */
 data class Account(
     val uid: String,
@@ -28,8 +28,8 @@ data class Account(
     val previews: Map<String, DiscussionPreview> = emptyMap(),
     var photoUrl: String? = null,
     var description: String? = null,
-    var isShopOwner: Boolean = false,
-    var isSpaceRenter: Boolean = false
+    var shopOwner: Boolean = false,
+    var spaceRenter: Boolean = false
 )
 
 /**
@@ -44,8 +44,8 @@ data class AccountNoUid(
     val email: String = "",
     val photoUrl: String? = null,
     val description: String? = null,
-    val isShopOwner: Boolean = false,
-    val isSpaceRenter: Boolean = false
+    val shopOwner: Boolean = false,
+    val spaceRenter: Boolean = false
 )
 
 /**
@@ -69,6 +69,6 @@ fun fromNoUid(
         previews.mapValues { (uid, preview) -> fromNoUid(uid, preview) },
         photoUrl = accountNoUid.photoUrl,
         description = accountNoUid.description,
-        isShopOwner = accountNoUid.isShopOwner,
-        isSpaceRenter = accountNoUid.isSpaceRenter,
+        shopOwner = accountNoUid.shopOwner,
+        spaceRenter = accountNoUid.spaceRenter,
     )

--- a/app/src/main/java/com/github/meeplemeet/model/auth/Account.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/auth/Account.kt
@@ -9,10 +9,16 @@ import kotlinx.serialization.Serializable
  * Represents a user account stored in Firestore.
  *
  * @property uid Globally unique identifier of the account (Firestore document ID).
+ * @property handle unique human-readable identifier for the user
  * @property name Human-readable name of the account.
+ * @property email User's email used to create the account
  * @property previews Map of discussion previews keyed by discussion ID. Each preview stores
  *   lightweight metadata (e.g. last message, unread count) for discussions this account
  *   participates in.
+ * @property photoUrl User's profile picture
+ * @property description A user's description about himself
+ * @property isShopOwner Tells if this account is a shop owner
+ * @property isSpaceRenter Tells if this account is a space renter
  */
 data class Account(
     val uid: String,
@@ -21,7 +27,9 @@ data class Account(
     val email: String,
     val previews: Map<String, DiscussionPreview> = emptyMap(),
     var photoUrl: String? = null,
-    var description: String? = null
+    var description: String? = null,
+    var isShopOwner: Boolean = false,
+    var isSpaceRenter: Boolean = false
 )
 
 /**
@@ -35,7 +43,9 @@ data class AccountNoUid(
     val name: String = "",
     val email: String = "",
     val photoUrl: String? = null,
-    val description: String? = null
+    val description: String? = null,
+    val isShopOwner: Boolean = false,
+    val isSpaceRenter: Boolean = false
 )
 
 /**
@@ -58,4 +68,7 @@ fun fromNoUid(
         email = accountNoUid.email,
         previews.mapValues { (uid, preview) -> fromNoUid(uid, preview) },
         photoUrl = accountNoUid.photoUrl,
-        description = accountNoUid.description)
+        description = accountNoUid.description,
+        isShopOwner = accountNoUid.isShopOwner,
+        isSpaceRenter = accountNoUid.isSpaceRenter,
+    )

--- a/app/src/main/java/com/github/meeplemeet/model/discussions/DiscussionRepository.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/discussions/DiscussionRepository.kt
@@ -335,8 +335,8 @@ class DiscussionRepository(db: FirebaseFirestore = FirebaseProvider.db) {
   /** Update account roles (space renter & shop owner) */
   suspend fun setAccountRole(id: String, isShopOwner: Boolean?, isSpaceRenter: Boolean?) {
     val updates = mutableMapOf<String, Any>()
-    isShopOwner?.let { updates[AccountNoUid::isShopOwner.name] = isShopOwner }
-    isSpaceRenter?.let { updates[AccountNoUid::isSpaceRenter.name] = isSpaceRenter }
+    isShopOwner?.let { updates[AccountNoUid::shopOwner.name] = isShopOwner }
+    isSpaceRenter?.let { updates[AccountNoUid::spaceRenter.name] = isSpaceRenter }
     accounts.document(id).update(updates).await()
   }
 

--- a/app/src/main/java/com/github/meeplemeet/model/discussions/DiscussionRepository.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/discussions/DiscussionRepository.kt
@@ -332,6 +332,12 @@ class DiscussionRepository(db: FirebaseFirestore = FirebaseProvider.db) {
     accounts.document(id).update(Account::name.name, name).await()
   }
 
+  /** Update account roles (space renter & shop owner) */
+  suspend fun setAccountRole(id: String, isShopOwner: Boolean, isSpaceRenter: Boolean) {
+    accounts.document(id).update(Account::isShopOwner.name, isShopOwner).await()
+    accounts.document(id).update(Account::isSpaceRenter.name, isSpaceRenter).await()
+  }
+
   /** Delete an account document. */
   suspend fun deleteAccount(id: String) {
     accounts.document(id).delete().await()

--- a/app/src/main/java/com/github/meeplemeet/model/discussions/DiscussionRepository.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/discussions/DiscussionRepository.kt
@@ -332,7 +332,13 @@ class DiscussionRepository(db: FirebaseFirestore = FirebaseProvider.db) {
     accounts.document(id).update(Account::name.name, name).await()
   }
 
-  /** Update account roles (space renter & shop owner) */
+  /**
+   * Update account roles in the repository (space renter & shop owner)
+   *
+   * @param id Account id's to update it's roles
+   * @param isShopOwner Boolean for the role Shop Owner
+   * @param isSpaceRenter Boolean for the role Space Renter
+   */
   suspend fun setAccountRole(id: String, isShopOwner: Boolean?, isSpaceRenter: Boolean?) {
     val updates = mutableMapOf<String, Any>()
     isShopOwner?.let { updates[AccountNoUid::shopOwner.name] = isShopOwner }

--- a/app/src/main/java/com/github/meeplemeet/model/discussions/DiscussionRepository.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/discussions/DiscussionRepository.kt
@@ -334,8 +334,14 @@ class DiscussionRepository(db: FirebaseFirestore = FirebaseProvider.db) {
 
   /** Update account roles (space renter & shop owner) */
   suspend fun setAccountRole(id: String, isShopOwner: Boolean, isSpaceRenter: Boolean) {
-    accounts.document(id).update(Account::isShopOwner.name, isShopOwner).await()
-    accounts.document(id).update(Account::isSpaceRenter.name, isSpaceRenter).await()
+    accounts
+        .document(id)
+        .update(
+            AccountNoUid::isShopOwner.name,
+            isShopOwner,
+            AccountNoUid::isSpaceRenter.name,
+            isSpaceRenter)
+        .await()
   }
 
   /** Delete an account document. */

--- a/app/src/main/java/com/github/meeplemeet/model/discussions/DiscussionRepository.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/discussions/DiscussionRepository.kt
@@ -333,15 +333,11 @@ class DiscussionRepository(db: FirebaseFirestore = FirebaseProvider.db) {
   }
 
   /** Update account roles (space renter & shop owner) */
-  suspend fun setAccountRole(id: String, isShopOwner: Boolean, isSpaceRenter: Boolean) {
-    accounts
-        .document(id)
-        .update(
-            AccountNoUid::isShopOwner.name,
-            isShopOwner,
-            AccountNoUid::isSpaceRenter.name,
-            isSpaceRenter)
-        .await()
+  suspend fun setAccountRole(id: String, isShopOwner: Boolean?, isSpaceRenter: Boolean?) {
+    val updates = mutableMapOf<String, Any>()
+    isShopOwner?.let { updates[AccountNoUid::isShopOwner.name] = isShopOwner }
+    isSpaceRenter?.let { updates[AccountNoUid::isSpaceRenter.name] = isSpaceRenter }
+    accounts.document(id).update(updates).await()
   }
 
   /** Delete an account document. */

--- a/app/src/main/java/com/github/meeplemeet/model/discussions/DiscussionViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/discussions/DiscussionViewModel.kt
@@ -210,7 +210,11 @@ class DiscussionViewModel(
   }
 
   /** Update account roles. */
-  fun setAccountRole(account: Account, isShopOwner: Boolean, isSpaceRenter: Boolean) {
+  fun setAccountRole(
+      account: Account,
+      isShopOwner: Boolean? = null,
+      isSpaceRenter: Boolean? = null
+  ) {
     viewModelScope.launch {
       repository.setAccountRole(
           account.uid, isShopOwner = isShopOwner, isSpaceRenter = isSpaceRenter)

--- a/app/src/main/java/com/github/meeplemeet/model/discussions/DiscussionViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/discussions/DiscussionViewModel.kt
@@ -209,7 +209,13 @@ class DiscussionViewModel(
     viewModelScope.launch { repository.setAccountName(account.uid, newName.ifBlank { "~" }) }
   }
 
-  /** Update account roles. */
+  /**
+   * Update account roles.
+   *
+   * @param account Account to update it's roles
+   * @param isShopOwner Boolean for the role Shop Owner
+   * @param isSpaceRenter Boolean for the role Space Renter
+   */
   fun setAccountRole(
       account: Account,
       isShopOwner: Boolean? = null,

--- a/app/src/main/java/com/github/meeplemeet/model/discussions/DiscussionViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/discussions/DiscussionViewModel.kt
@@ -209,6 +209,22 @@ class DiscussionViewModel(
     viewModelScope.launch { repository.setAccountName(account.uid, newName.ifBlank { "~" }) }
   }
 
+  /** Update account roles. */
+  fun setAccountRole(
+      account: Account,
+      isShopOwner: Boolean? = null,
+      isSpaceRenter: Boolean? = null
+  ) {
+    val shopOwner = isShopOwner ?: account.isShopOwner
+    val spacerRenter = isSpaceRenter ?: account.isSpaceRenter
+
+    account.isShopOwner = shopOwner
+    account.isSpaceRenter = spacerRenter
+    viewModelScope.launch {
+      repository.setAccountRole(account.uid, isShopOwner = shopOwner, isSpaceRenter = spacerRenter)
+    }
+  }
+
   /** Delete an account. */
   fun deleteAccount(account: Account) {
     viewModelScope.launch { repository.deleteAccount(account.uid) }

--- a/app/src/main/java/com/github/meeplemeet/model/discussions/DiscussionViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/discussions/DiscussionViewModel.kt
@@ -210,18 +210,10 @@ class DiscussionViewModel(
   }
 
   /** Update account roles. */
-  fun setAccountRole(
-      account: Account,
-      isShopOwner: Boolean? = null,
-      isSpaceRenter: Boolean? = null
-  ) {
-    val shopOwner = isShopOwner ?: account.isShopOwner
-    val spacerRenter = isSpaceRenter ?: account.isSpaceRenter
-
-    account.isShopOwner = shopOwner
-    account.isSpaceRenter = spacerRenter
+  fun setAccountRole(account: Account, isShopOwner: Boolean, isSpaceRenter: Boolean) {
     viewModelScope.launch {
-      repository.setAccountRole(account.uid, isShopOwner = shopOwner, isSpaceRenter = spacerRenter)
+      repository.setAccountRole(
+          account.uid, isShopOwner = isShopOwner, isSpaceRenter = isSpaceRenter)
     }
   }
 

--- a/app/src/main/java/com/github/meeplemeet/ui/CreateAccountScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/CreateAccountScreen.kt
@@ -145,8 +145,6 @@ fun CreateAccountScreen(
                     contentDescription = "Meeple Meet Logo",
                     modifier = Modifier.fillMaxSize())
               }
-              Spacer(modifier = Modifier.height(28.dp))
-
               /** Title text shown below the image placeholder. */
               Text(
                   "You're almost there!",
@@ -245,22 +243,22 @@ fun CreateAccountScreen(
                   style = MaterialTheme.typography.bodyMedium,
                   modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp))
 
-              Row(
-                  verticalAlignment = Alignment.CenterVertically,
-                  modifier = Modifier.fillMaxWidth()) {
-                    // Checkbox for shop owners
-                    Checkbox(
-                        checked = isShopChecked,
-                        modifier = Modifier.testTag(CreateAccountTestTags.CHECKBOX_OWNER),
-                        onCheckedChange = { checked -> isShopChecked = checked },
-                        colors =
-                            CheckboxDefaults.colors(
-                                checkedColor = AppColors.affirmative,
-                                uncheckedColor = AppColors.textIcons,
-                                checkmarkColor = AppColors.textIcons))
-                    Column {
+              Row(verticalAlignment = Alignment.Top, modifier = Modifier.fillMaxWidth()) {
+                // Checkbox for shop owners
+                Checkbox(
+                    checked = isShopChecked,
+                    modifier = Modifier.testTag(CreateAccountTestTags.CHECKBOX_OWNER).padding(2.dp),
+                    onCheckedChange = { checked -> isShopChecked = checked },
+                    colors =
+                        CheckboxDefaults.colors(
+                            checkedColor = AppColors.affirmative,
+                            uncheckedColor = AppColors.textIcons,
+                            checkmarkColor = AppColors.textIcons))
+                Column(
+                    modifier = Modifier.padding(top = 12.dp),
+                    verticalArrangement = Arrangement.Center) {
                       Text(
-                          text = "Sell items (Become a Shop Owner)",
+                          text = "Sell items",
                           color = AppColors.textIcons,
                           style = MaterialTheme.typography.bodyMedium)
                       Text(
@@ -268,26 +266,27 @@ fun CreateAccountScreen(
                           color = AppColors.textIconsFade,
                           style = MaterialTheme.typography.bodySmall)
                     }
-                  }
+              }
 
               Spacer(modifier = Modifier.height(16.dp))
 
-              Row(
-                  verticalAlignment = Alignment.CenterVertically,
-                  modifier = Modifier.fillMaxWidth()) {
-                    // Checkbox for space renters
-                    Checkbox(
-                        checked = isSpaceRented,
-                        modifier = Modifier.testTag(CreateAccountTestTags.CHECKBOX_RENTER),
-                        onCheckedChange = { checked -> isSpaceRented = checked },
-                        colors =
-                            CheckboxDefaults.colors(
-                                checkedColor = AppColors.affirmative,
-                                uncheckedColor = AppColors.textIcons,
-                                checkmarkColor = AppColors.textIcons))
-                    Column {
+              Row(verticalAlignment = Alignment.Top, modifier = Modifier.fillMaxWidth()) {
+                // Checkbox for space renters
+                Checkbox(
+                    checked = isSpaceRented,
+                    modifier =
+                        Modifier.testTag(CreateAccountTestTags.CHECKBOX_RENTER).padding(top = 2.dp),
+                    onCheckedChange = { checked -> isSpaceRented = checked },
+                    colors =
+                        CheckboxDefaults.colors(
+                            checkedColor = AppColors.affirmative,
+                            uncheckedColor = AppColors.textIcons,
+                            checkmarkColor = AppColors.textIcons))
+                Column(
+                    modifier = Modifier.padding(top = 12.dp),
+                    verticalArrangement = Arrangement.Center) {
                       Text(
-                          text = "Rent out spaces (Become a Space Host)",
+                          text = "Rent out spaces",
                           color = AppColors.textIcons,
                           style = MaterialTheme.typography.bodyMedium)
                       Text(
@@ -295,7 +294,7 @@ fun CreateAccountScreen(
                           color = AppColors.textIconsFade,
                           style = MaterialTheme.typography.bodySmall)
                     }
-                  }
+              }
 
               Spacer(modifier = Modifier.height(16.dp))
             }

--- a/app/src/main/java/com/github/meeplemeet/ui/CreateAccountScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/CreateAccountScreen.kt
@@ -122,7 +122,7 @@ fun CreateAccountScreen(
                       discussionVM.setAccountName(account, username)
                       discussionVM.setAccountRole(
                           account, isSpaceRenter = isSpaceRented, isShopOwner = isShopChecked)
-                      if (errorMessage.isBlank()) onCreate()
+                      onCreate()
                     }
                   },
                   modifier = Modifier.weight(1f).testTag(CreateAccountTestTags.SUBMIT_BUTTON)) {

--- a/app/src/main/java/com/github/meeplemeet/ui/CreateAccountScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/CreateAccountScreen.kt
@@ -267,6 +267,15 @@ fun CreateAccountScreen(
       }
 }
 
+/**
+ * Composable representing a checkbox that gives the user's it's roles
+ *
+ * @param isChecked If the checkbox is checked
+ * @param onCheckedChange lambda when the user interacts with the checkbox
+ * @param label Main text appearing to t he right of the checkbox
+ * @param description Secondary text appearing below the label
+ * @param testTag Tag to append for UI testing
+ */
 @Composable
 fun RoleCheckBox(
     isChecked: Boolean,

--- a/app/src/main/java/com/github/meeplemeet/ui/CreateAccountScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/CreateAccountScreen.kt
@@ -44,9 +44,11 @@ object CreateAccountTestTags {
  * [HandlesViewModel] to ensure the handle is available. Once valid, it triggers [onCreate] to
  * continue the account creation flow.
  *
- * @param handlesVM The ViewModel responsible for handling Firestore handle validation.
  * @param account The [Account] object representing the user creating an account.
- * @param onCreate Lambda to be executed when account creation is successfully validated.
+ * @param discussionVM The viewModel for managing discussions and account details.
+ * @param handlesVM The ViewModel responsible for handling Firestore handle validation.
+ * @param onCreate Callback function to be executed when account creation is successfully validated.
+ * @param onBack Callback function to be executed when the user wants to go back to the previous screen.
  */
 @Composable
 fun CreateAccountScreen(

--- a/app/src/main/java/com/github/meeplemeet/ui/CreateAccountScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/CreateAccountScreen.kt
@@ -246,60 +246,51 @@ fun CreateAccountScreen(
                   style = MaterialTheme.typography.bodyMedium,
                   modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp))
 
-              Row(verticalAlignment = Alignment.Top, modifier = Modifier.fillMaxWidth()) {
-                // Checkbox for shop owners
-                Checkbox(
-                    checked = isShopChecked,
-                    modifier = Modifier.testTag(CreateAccountTestTags.CHECKBOX_OWNER).padding(2.dp),
-                    onCheckedChange = { checked -> isShopChecked = checked },
-                    colors =
-                        CheckboxDefaults.colors(
-                            checkedColor = AppColors.affirmative,
-                            uncheckedColor = AppColors.textIcons,
-                            checkmarkColor = AppColors.textIcons))
-                Column(
-                    modifier = Modifier.padding(top = 12.dp),
-                    verticalArrangement = Arrangement.Center) {
-                      Text(
-                          text = "Sell items",
-                          color = AppColors.textIcons,
-                          style = MaterialTheme.typography.bodyMedium)
-                      Text(
-                          text = "List your shop and the games you sell.",
-                          color = AppColors.textIconsFade,
-                          style = MaterialTheme.typography.bodySmall)
-                    }
-              }
+              RoleCheckBox(
+                  isChecked = isShopChecked,
+                  onCheckedChange = { checked: Boolean -> isShopChecked = checked },
+                  label = "Sell items",
+                  description = "List your shop and the games you sell.",
+                  testTag = CreateAccountTestTags.CHECKBOX_OWNER)
 
               Spacer(modifier = Modifier.height(16.dp))
 
-              Row(verticalAlignment = Alignment.Top, modifier = Modifier.fillMaxWidth()) {
-                // Checkbox for space renters
-                Checkbox(
-                    checked = isSpaceRented,
-                    modifier =
-                        Modifier.testTag(CreateAccountTestTags.CHECKBOX_RENTER).padding(top = 2.dp),
-                    onCheckedChange = { checked -> isSpaceRented = checked },
-                    colors =
-                        CheckboxDefaults.colors(
-                            checkedColor = AppColors.affirmative,
-                            uncheckedColor = AppColors.textIcons,
-                            checkmarkColor = AppColors.textIcons))
-                Column(
-                    modifier = Modifier.padding(top = 12.dp),
-                    verticalArrangement = Arrangement.Center) {
-                      Text(
-                          text = "Rent out spaces",
-                          color = AppColors.textIcons,
-                          style = MaterialTheme.typography.bodyMedium)
-                      Text(
-                          text = "Offer your play spaces for other players to book.",
-                          color = AppColors.textIconsFade,
-                          style = MaterialTheme.typography.bodySmall)
-                    }
-              }
+              RoleCheckBox(
+                  isChecked = isSpaceRented,
+                  onCheckedChange = { checked: Boolean -> isSpaceRented = checked },
+                  label = "Rent out spaces",
+                  description = "Offer your play spaces for other players to book.",
+                  testTag = CreateAccountTestTags.CHECKBOX_RENTER)
 
               Spacer(modifier = Modifier.height(16.dp))
             }
       }
+}
+
+@Composable
+fun RoleCheckBox(
+    isChecked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    label: String,
+    description: String,
+    testTag: String
+) {
+  Row(verticalAlignment = Alignment.Top, modifier = Modifier.fillMaxWidth()) {
+    Checkbox(
+        checked = isChecked,
+        modifier = Modifier.testTag(testTag).padding(top = 2.dp),
+        onCheckedChange = onCheckedChange,
+        colors =
+            CheckboxDefaults.colors(
+                checkedColor = AppColors.affirmative,
+                uncheckedColor = AppColors.textIcons,
+                checkmarkColor = AppColors.textIcons))
+    Column(modifier = Modifier.padding(top = 12.dp), verticalArrangement = Arrangement.Center) {
+      Text(text = label, color = AppColors.textIcons, style = MaterialTheme.typography.bodyMedium)
+      Text(
+          text = description,
+          color = AppColors.textIconsFade,
+          style = MaterialTheme.typography.bodySmall)
+    }
+  }
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/CreateAccountScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/CreateAccountScreen.kt
@@ -33,6 +33,8 @@ object CreateAccountTestTags {
   const val USERNAME_FIELD = "CreateAccountUsernameField"
   const val USERNAME_ERROR = "CreateAccountUsernameError"
   const val SUBMIT_BUTTON = "CreateAccountSubmitButton"
+  const val CHECKBOX_OWNER = "CreateAccountCheckboxOwner"
+  const val CHECKBOX_RENTER = "CreateAccountCheckboxRenter"
 }
 
 /**
@@ -49,7 +51,7 @@ object CreateAccountTestTags {
 @Composable
 fun CreateAccountScreen(
     account: Account,
-    firestoreVM: DiscussionViewModel,
+    discussionVM: DiscussionViewModel,
     handlesVM: HandlesViewModel,
     onCreate: () -> Unit = {},
     onBack: () -> Unit = {}
@@ -60,6 +62,9 @@ fun CreateAccountScreen(
 
   val errorMessage by handlesVM.errorMessage.collectAsState()
   var showErrors by remember { mutableStateOf(false) }
+
+  var isShopChecked by remember { mutableStateOf(false) }
+  var isSpaceRented by remember { mutableStateOf(false) }
 
   /** Checks the handle availability and updates the ViewModel state. */
   fun validateHandle(handle: String) {
@@ -84,7 +89,7 @@ fun CreateAccountScreen(
   Scaffold(
       bottomBar = {
         Row(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 32.dp, vertical = 25.dp),
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 32.dp, vertical = 24.dp),
             horizontalArrangement = Arrangement.spacedBy(16.dp)) {
               OutlinedButton(
                   onClick = onBack,
@@ -114,7 +119,9 @@ fun CreateAccountScreen(
                     /** Create the handle and call onCreate if there are no errors */
                     if ((errorMessage.isBlank()) && usernameValidation == null) {
                       handlesVM.createAccountHandle(account = account, handle = handle)
-                      firestoreVM.setAccountName(account, username)
+                      discussionVM.setAccountName(account, username)
+                      discussionVM.setAccountRole(
+                          account, isSpaceRenter = isSpaceRented, isShopOwner = isShopChecked)
                       if (errorMessage.isBlank()) onCreate()
                     }
                   },
@@ -127,7 +134,6 @@ fun CreateAccountScreen(
             modifier = Modifier.fillMaxSize().background(AppColors.primary).padding(24.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center) {
-              Spacer(modifier = Modifier.height(24.dp))
 
               // App logo displayed on top of text.
               val isDarkTheme = isSystemInDarkTheme()
@@ -139,7 +145,7 @@ fun CreateAccountScreen(
                     contentDescription = "Meeple Meet Logo",
                     modifier = Modifier.fillMaxSize())
               }
-              Spacer(modifier = Modifier.height(32.dp))
+              Spacer(modifier = Modifier.height(28.dp))
 
               /** Title text shown below the image placeholder. */
               Text(
@@ -229,6 +235,69 @@ fun CreateAccountScreen(
                             .padding(start = 16.dp, top = 4.dp)
                             .testTag(CreateAccountTestTags.USERNAME_ERROR))
               }
+
+              // Spacing between input fields and text
+              Spacer(modifier = Modifier.height(24.dp))
+
+              Text(
+                  text = "I also want to:",
+                  color = AppColors.textIcons,
+                  style = MaterialTheme.typography.bodyMedium,
+                  modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp))
+
+              Row(
+                  verticalAlignment = Alignment.CenterVertically,
+                  modifier = Modifier.fillMaxWidth()) {
+                    // Checkbox for shop owners
+                    Checkbox(
+                        checked = isShopChecked,
+                        modifier = Modifier.testTag(CreateAccountTestTags.CHECKBOX_OWNER),
+                        onCheckedChange = { checked -> isShopChecked = checked },
+                        colors =
+                            CheckboxDefaults.colors(
+                                checkedColor = AppColors.affirmative,
+                                uncheckedColor = AppColors.textIcons,
+                                checkmarkColor = AppColors.textIcons))
+                    Column {
+                      Text(
+                          text = "Sell items (Become a Shop Owner)",
+                          color = AppColors.textIcons,
+                          style = MaterialTheme.typography.bodyMedium)
+                      Text(
+                          text = "List your shop and the games you sell.",
+                          color = AppColors.textIconsFade,
+                          style = MaterialTheme.typography.bodySmall)
+                    }
+                  }
+
+              Spacer(modifier = Modifier.height(16.dp))
+
+              Row(
+                  verticalAlignment = Alignment.CenterVertically,
+                  modifier = Modifier.fillMaxWidth()) {
+                    // Checkbox for space renters
+                    Checkbox(
+                        checked = isSpaceRented,
+                        modifier = Modifier.testTag(CreateAccountTestTags.CHECKBOX_RENTER),
+                        onCheckedChange = { checked -> isSpaceRented = checked },
+                        colors =
+                            CheckboxDefaults.colors(
+                                checkedColor = AppColors.affirmative,
+                                uncheckedColor = AppColors.textIcons,
+                                checkmarkColor = AppColors.textIcons))
+                    Column {
+                      Text(
+                          text = "Rent out spaces (Become a Space Host)",
+                          color = AppColors.textIcons,
+                          style = MaterialTheme.typography.bodyMedium)
+                      Text(
+                          text = "Offer your play spaces for other players to book.",
+                          color = AppColors.textIconsFade,
+                          style = MaterialTheme.typography.bodySmall)
+                    }
+                  }
+
+              Spacer(modifier = Modifier.height(16.dp))
             }
       }
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/CreateAccountScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/CreateAccountScreen.kt
@@ -48,7 +48,8 @@ object CreateAccountTestTags {
  * @param discussionVM The viewModel for managing discussions and account details.
  * @param handlesVM The ViewModel responsible for handling Firestore handle validation.
  * @param onCreate Callback function to be executed when account creation is successfully validated.
- * @param onBack Callback function to be executed when the user wants to go back to the previous screen.
+ * @param onBack Callback function to be executed when the user wants to go back to the previous
+ *   screen.
  */
 @Composable
 fun CreateAccountScreen(

--- a/app/src/main/java/com/github/meeplemeet/ui/ProfileScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/ProfileScreen.kt
@@ -1,6 +1,10 @@
 package com.github.meeplemeet.ui
 
+import android.util.Log
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
@@ -11,10 +15,13 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import com.github.meeplemeet.model.auth.Account
 import com.github.meeplemeet.model.auth.AuthViewModel
 import com.github.meeplemeet.model.discussions.DiscussionViewModel
 import com.github.meeplemeet.ui.navigation.BottomNavigationMenu
@@ -31,6 +38,7 @@ object ProfileTestTags {
 fun ProfileScreen(
     navigation: NavigationActions,
     authViewModel: AuthViewModel,
+    account: Account,
     discussionViewModel: DiscussionViewModel,
     onSignOut: () -> Unit
 ) {
@@ -53,6 +61,33 @@ fun ProfileScreen(
         Box(
             modifier = Modifier.fillMaxSize().padding(innerPadding),
             contentAlignment = Alignment.Center) {
+              Column(
+                  modifier = Modifier.fillMaxSize().padding(24.dp),
+                  verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                    Text(text = "Email", style = MaterialTheme.typography.bodyMedium)
+                    Text(text = account.email, style = MaterialTheme.typography.bodySmall)
+
+                    Text(text = "Username", style = MaterialTheme.typography.bodyMedium)
+                    Text(text = account.name, style = MaterialTheme.typography.bodySmall)
+
+                    Text(text = "Handle", style = MaterialTheme.typography.bodyMedium)
+                    Text(text = "@${account.handle}", style = MaterialTheme.typography.bodySmall)
+
+                    Text(text = "Roles", style = MaterialTheme.typography.bodyMedium)
+                    Log.d(
+                        "Roles",
+                        "Shopowner: ${account.isShopOwner}, SpaceRenter: ${account.isSpaceRenter}")
+                    Text(
+                        text =
+                            buildString {
+                              if (account.isShopOwner) append("Shop Owner\n")
+                              if (account.isSpaceRenter) append("Space Renter\n")
+                              if (!account.isShopOwner && !account.isSpaceRenter) append("None")
+                            },
+                        style = MaterialTheme.typography.bodySmall)
+
+                    Spacer(modifier = Modifier.weight(1f))
+                  }
               Button(
                   onClick = {
                     onSignOut()

--- a/app/src/main/java/com/github/meeplemeet/ui/ProfileScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/ProfileScreen.kt
@@ -32,6 +32,16 @@ object ProfileTestTags {
   const val LOG_OUT_BUTTON = "Logout Button"
 }
 
+/**
+ * Composable function to display the Profile Screen. The screen displays information
+ * about your account, as well as allowing you to sign out.
+ *
+ * @param navigation Navigation actions for screen transitions.
+ * @param authViewModel ViewModel for authentication-related operations.
+ * @param account The current user's account.
+ * @param discussionViewModel ViewModel for discussion-related operations.
+ * @param onSignOut Callback function to be invoked on sign out.
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ProfileScreen(
@@ -73,9 +83,6 @@ fun ProfileScreen(
                     Text(text = "@${account.handle}", style = MaterialTheme.typography.bodySmall)
 
                     Text(text = "Roles", style = MaterialTheme.typography.bodyMedium)
-                    Log.d(
-                        "Roles",
-                        "Shopowner: ${account.shopOwner}, SpaceRenter: ${account.spaceRenter}")
                     Text(
                         text =
                             buildString {

--- a/app/src/main/java/com/github/meeplemeet/ui/ProfileScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/ProfileScreen.kt
@@ -1,6 +1,5 @@
 package com.github.meeplemeet.ui
 
-import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -33,8 +32,8 @@ object ProfileTestTags {
 }
 
 /**
- * Composable function to display the Profile Screen. The screen displays information
- * about your account, as well as allowing you to sign out.
+ * Composable function to display the Profile Screen. The screen displays information about your
+ * account, as well as allowing you to sign out.
  *
  * @param navigation Navigation actions for screen transitions.
  * @param authViewModel ViewModel for authentication-related operations.

--- a/app/src/main/java/com/github/meeplemeet/ui/ProfileScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/ProfileScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -76,13 +75,13 @@ fun ProfileScreen(
                     Text(text = "Roles", style = MaterialTheme.typography.bodyMedium)
                     Log.d(
                         "Roles",
-                        "Shopowner: ${account.isShopOwner}, SpaceRenter: ${account.isSpaceRenter}")
+                        "Shopowner: ${account.shopOwner}, SpaceRenter: ${account.spaceRenter}")
                     Text(
                         text =
                             buildString {
-                              if (account.isShopOwner) append("Shop Owner\n")
-                              if (account.isSpaceRenter) append("Space Renter\n")
-                              if (!account.isShopOwner && !account.isSpaceRenter) append("None")
+                              if (account.shopOwner) append("Shop Owner\n")
+                              if (account.spaceRenter) append("Space Renter\n")
+                              if (!account.shopOwner && !account.spaceRenter) append("None")
                             },
                         style = MaterialTheme.typography.bodySmall)
 


### PR DESCRIPTION
## Summary
This PR introduces the ability to select your role when creating your account. This will come in use once the map/location based features are fully implemented.

### UI Changes
- 2 checkboxes are now displayed in the `accountCreationScreen` allowing the user to select whether he's a `ShopOwner` or a `SpaceRenter`, they're both turned off by default. 
- Account information can be viewed from the `ProfileScreen`, this includes: 
  - User's name
  - User's handle
  - User's email
  - User's roles 

### Backend
- Added backend functions to deal with user's roles appropriately.

### Testing
- Added a small test checking the role selection feature.

<img width="400" height="750" alt="image" src="https://github.com/user-attachments/assets/37301f6a-4e9a-48be-b63a-b2f48437c71c" />
<img width="400" height="750" alt="image" src="https://github.com/user-attachments/assets/bddf0e73-26b7-4ddc-9f0c-08bdab0c0f2b" />
