### PR TITLE
feat(ui): add create space renter screen

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/ui/CreateSpaceRenterScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/CreateSpaceRenterScreenTest.kt
@@ -1,0 +1,433 @@
+// This file was initially done by hand and refactored and improved by ChatGPT-5 Extend Thinking
+// Combinations to tests were given to the LLM so it could generate the code more easily
+package com.github.meeplemeet.ui
+
+import androidx.compose.runtime.*
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.meeplemeet.model.auth.Account
+import com.github.meeplemeet.model.shared.location.Location
+import com.github.meeplemeet.model.shops.OpeningHours
+import com.github.meeplemeet.model.space_renter.CreateSpaceRenterViewModel
+import com.github.meeplemeet.model.space_renter.Space
+import com.github.meeplemeet.ui.components.ShopComponentsTestTags
+import com.github.meeplemeet.ui.components.ShopFormTestTags
+import com.github.meeplemeet.ui.components.SpaceRenterComponentsTestTags
+import com.github.meeplemeet.ui.sessions.SessionTestTags
+import com.github.meeplemeet.ui.space_renter.AddSpaceRenterContent
+import com.github.meeplemeet.ui.space_renter.AddSpaceRenterUi
+import com.github.meeplemeet.ui.space_renter.CreateSpaceRenterScreen
+import com.github.meeplemeet.ui.space_renter.CreateSpaceRenterScreenTestTags
+import com.github.meeplemeet.ui.theme.AppTheme
+import com.github.meeplemeet.utils.FirestoreTests
+import junit.framework.TestCase.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CreateSpaceRenterScreenTest : FirestoreTests() {
+
+  /* ───────────────────────────────── RULES ───────────────────────────────── */
+
+  @get:Rule val compose = createComposeRule()
+
+  /* ────────────────────────────── FIXTURES / FX ──────────────────────────── */
+
+  private val owner =
+      Account(uid = "owner1", handle = "@owner", name = "Owner", email = "owner@example.com")
+
+  /* ────────────────────────────── EXT HELPERS ────────────────────────────── */
+
+  private fun ComposeTestRule.onTag(tag: String) = onNodeWithTag(tag, useUnmergedTree = true)
+
+  private fun ComposeTestRule.onTags(tag: String) = onAllNodesWithTag(tag, useUnmergedTree = true)
+
+  /** Scroll the outer LazyColumn to bring a tagged node into view. */
+  private fun scrollListToTag(tag: String) {
+    compose.onTag(CreateSpaceRenterScreenTestTags.LIST).performScrollToNode(hasTestTag(tag))
+    compose.waitForIdle()
+  }
+
+  /** Expand a collapsible section only if its content isn't currently in the tree. */
+  private fun ensureSectionExpanded(sectionBaseTag: String) {
+    val toggleTag = sectionBaseTag + ShopFormTestTags.SECTION_TOGGLE_SUFFIX
+    val contentTag = sectionBaseTag + ShopFormTestTags.SECTION_CONTENT_SUFFIX
+
+    scrollListToTag(toggleTag)
+    compose.waitForIdle()
+
+    val isExpanded = compose.onTags(contentTag).fetchSemanticsNodes().isNotEmpty()
+    if (!isExpanded) {
+      compose.onTag(toggleTag).assertExists().performClick()
+      compose.waitForIdle()
+    }
+
+    scrollListToTag(contentTag)
+    compose.waitForIdle()
+  }
+
+  /** Returns the LabeledField INPUT inside the given wrapper (FIELD_* tag). */
+  private fun inputIn(wrapperTag: String) =
+      compose.onNode(
+          hasTestTag(ShopComponentsTestTags.LABELED_FIELD_INPUT) and
+              hasAnyAncestor(hasTestTag(wrapperTag)),
+          useUnmergedTree = true)
+
+  /** Convenience accessors for Space row sub-tags. */
+  private fun spaceRowTag(index: Int) = SpaceRenterComponentsTestTags.SPACE_ROW_PREFIX + index
+
+  private fun seatsFieldTag(index: Int) =
+      spaceRowTag(index) + SpaceRenterComponentsTestTags.SPACE_ROW_SEATS_FIELD_SUFFIX
+
+  private fun priceFieldTag(index: Int) =
+      spaceRowTag(index) + SpaceRenterComponentsTestTags.SPACE_ROW_PRICE_FIELD_SUFFIX
+
+  private fun deleteButtonTag(index: Int) =
+      spaceRowTag(index) + SpaceRenterComponentsTestTags.SPACE_ROW_DELETE_SUFFIX
+
+  /** Fill required fields (name, email, address). */
+  private fun fillRequiredFields(
+      name: String = "Meeple Hub",
+      email: String = "space@host.com",
+      address: String = "123 Meeple Street"
+  ) {
+    ensureSectionExpanded(CreateSpaceRenterScreenTestTags.SECTION_REQUIRED)
+
+    // Name
+    inputIn(ShopFormTestTags.FIELD_SHOP).assertExists().performTextClearance()
+    inputIn(ShopFormTestTags.FIELD_SHOP).performTextInput(name)
+
+    // Email
+    inputIn(ShopFormTestTags.FIELD_EMAIL).assertExists().performTextClearance()
+    inputIn(ShopFormTestTags.FIELD_EMAIL).performTextInput(email)
+
+    // Address
+    compose.onTag(SessionTestTags.LOCATION_FIELD).assertExists().performClick()
+    compose.onTag(SessionTestTags.LOCATION_FIELD).performTextClearance()
+    compose.onTag(SessionTestTags.LOCATION_FIELD).performTextInput(address)
+  }
+
+  /** Optional fields (phone, website). */
+  private fun fillOptionalFields(
+      phone: String = "+41 79 555 55 55",
+      website: String = "https://example.com"
+  ) {
+    ensureSectionExpanded(CreateSpaceRenterScreenTestTags.SECTION_REQUIRED)
+    inputIn(ShopFormTestTags.FIELD_PHONE).assertExists().performTextClearance()
+    inputIn(ShopFormTestTags.FIELD_PHONE).performTextInput(phone)
+    inputIn(ShopFormTestTags.FIELD_LINK).assertExists().performTextClearance()
+    inputIn(ShopFormTestTags.FIELD_LINK).performTextInput(website)
+  }
+
+  /** Flip Sunday to “Open 24 hours” via dialog. */
+  private fun setAnyOpeningHoursViaDialog() {
+    ensureSectionExpanded(CreateSpaceRenterScreenTestTags.SECTION_AVAILABILITY)
+
+    scrollListToTag(
+        CreateSpaceRenterScreenTestTags.SECTION_AVAILABILITY +
+            ShopFormTestTags.SECTION_CONTENT_SUFFIX)
+    compose.waitForIdle()
+
+    compose.onTags(ShopComponentsTestTags.DAY_ROW_EDIT).assertCountEquals(7)[0].performClick()
+
+    compose.onTag(ShopFormTestTags.OPENING_HOURS_DIALOG_WRAPPER).assertExists()
+    compose.onTag(ShopComponentsTestTags.DIALOG_OPEN24_CHECKBOX).assertExists().performClick()
+    compose.onTag(ShopComponentsTestTags.DIALOG_SAVE).assertIsEnabled().performClick()
+    compose.waitForIdle()
+  }
+
+  /** Open "Spaces" section and click Add Space. */
+  private fun addSpace() {
+    ensureSectionExpanded(CreateSpaceRenterScreenTestTags.SECTION_SPACES)
+    scrollListToTag(CreateSpaceRenterScreenTestTags.SPACES_ADD_BUTTON)
+    compose.onTag(CreateSpaceRenterScreenTestTags.SPACES_ADD_BUTTON).assertExists().performClick()
+    compose.waitForIdle()
+  }
+
+  /* ────────────────────────────── TESTS ────────────────────────────── */
+
+  /**
+   * Core validation gating:
+   * - create disabled initially and until required pieces are set
+   * - enabled after: name + email + address + opening hours + >=1 space
+   * - seats and price inputs are clamped by component (cannot make them invalid)
+   * - discard clears and disables
+   */
+  @Test
+  fun validation_and_spaces_gating_singleComposition() {
+    var backCalled = false
+
+    compose.setContent {
+      AppTheme {
+        CreateSpaceRenterScreen(
+            owner = owner,
+            onBack = { backCalled = true },
+            onCreated = {},
+            viewModel = CreateSpaceRenterViewModel())
+      }
+    }
+
+    compose.onTag(CreateSpaceRenterScreenTestTags.SCAFFOLD).assertExists()
+    compose.onTag(CreateSpaceRenterScreenTestTags.TOPBAR).assertExists()
+    compose.onTag(CreateSpaceRenterScreenTestTags.TITLE).assertExists()
+    compose.onTag(CreateSpaceRenterScreenTestTags.NAV_BACK).assertExists()
+    compose.onTag(CreateSpaceRenterScreenTestTags.LIST).assertExists()
+
+    // Initially disabled
+    compose.onTag(ShopComponentsTestTags.ACTION_CREATE).assertIsNotEnabled()
+
+    // Fill required text fields
+    fillRequiredFields()
+    compose.onTag(ShopComponentsTestTags.ACTION_CREATE).assertIsNotEnabled()
+
+    // Set hours
+    setAnyOpeningHoursViaDialog()
+    compose.onTag(ShopComponentsTestTags.ACTION_CREATE).assertIsNotEnabled()
+
+    // Add one space -> enabled
+    addSpace()
+    compose.onTag(spaceRowTag(0)).assertExists()
+    compose.onTag(ShopComponentsTestTags.ACTION_CREATE).assertIsEnabled()
+
+    // The component clamps bad input: trying "0" seats shows "1" (min = 1)
+    compose.onTag(seatsFieldTag(0)).performTextClearance()
+    compose.onTag(seatsFieldTag(0)).performTextInput("0")
+    // Move focus to price to trigger clamping/normalization
+    compose.onTag(priceFieldTag(0)).performClick()
+    compose.waitForIdle()
+    compose.onTag(seatsFieldTag(0)).assertTextEquals("1")
+    // Still enabled
+    compose.onTag(ShopComponentsTestTags.ACTION_CREATE).assertIsEnabled()
+
+    // Trying negative price "-1" is sanitized to "1" (no minus sign accepted)
+    compose.onTag(priceFieldTag(0)).performTextClearance()
+    compose.onTag(priceFieldTag(0)).performTextInput("-1")
+    // Move focus back to seats to trigger normalization
+    compose.onTag(seatsFieldTag(0)).performClick()
+    compose.waitForIdle()
+    compose.onTag(priceFieldTag(0)).assertTextEquals("1")
+    // Still enabled
+    compose.onTag(ShopComponentsTestTags.ACTION_CREATE).assertIsEnabled()
+
+    // Discard clears and disables
+    compose.onTag(ShopComponentsTestTags.ACTION_DISCARD).performClick()
+    assertTrue(backCalled)
+
+    ensureSectionExpanded(CreateSpaceRenterScreenTestTags.SECTION_REQUIRED)
+    compose
+        .onAllNodes(
+            hasTestTag(ShopComponentsTestTags.LABELED_FIELD_INPUT) and
+                hasAnyAncestor(
+                    hasTestTag(
+                        CreateSpaceRenterScreenTestTags.SECTION_REQUIRED +
+                            ShopFormTestTags.SECTION_CONTENT_SUFFIX)),
+            useUnmergedTree = true)
+        .apply {
+          this[0].assert(hasText(""))
+          this[1].assert(hasText(""))
+        }
+    compose.onTag(ShopComponentsTestTags.ACTION_CREATE).assertIsNotEnabled()
+  }
+
+  /**
+   * Spaces section behaviors:
+   * - empty message present initially
+   * - add two rows
+   * - edit seats/price including decimal normalization & clamping
+   * - delete a row
+   */
+  @Test
+  fun spacesSection_add_edit_delete_and_input_normalization() {
+    compose.setContent {
+      AppTheme {
+        CreateSpaceRenterScreen(
+            owner = owner, onBack = {}, onCreated = {}, viewModel = CreateSpaceRenterViewModel())
+      }
+    }
+
+    // Empty indicator
+    ensureSectionExpanded(CreateSpaceRenterScreenTestTags.SECTION_SPACES)
+    compose.onTag(SpaceRenterComponentsTestTags.SPACES_EMPTY_TEXT).assertExists()
+
+    // Add first space
+    addSpace()
+    compose.onTag(spaceRowTag(0)).assertExists()
+    compose.onTag(SpaceRenterComponentsTestTags.SPACES_EMPTY_TEXT).assertDoesNotExist()
+
+    // Edit seats & price — decimals normalize to single '.' and digits
+    compose.onTag(seatsFieldTag(0)).performTextClearance()
+    compose.onTag(seatsFieldTag(0)).performTextInput("10")
+    // Shift focus to price
+    compose.onTag(priceFieldTag(0)).performClick()
+    compose.waitForIdle()
+    compose.onTag(seatsFieldTag(0)).assertTextEquals("10")
+
+    compose.onTag(priceFieldTag(0)).performTextClearance()
+    compose.onTag(priceFieldTag(0)).performTextInput("10,5a.9")
+    // Shift focus to seats to trigger normalization
+    compose.onTag(seatsFieldTag(0)).performClick()
+    compose.waitForIdle()
+    compose.onTag(priceFieldTag(0)).assertTextEquals("10.59")
+
+    // Negative ignored -> remains non-negative
+    compose.onTag(priceFieldTag(0)).performTextClearance()
+    compose.onTag(priceFieldTag(0)).performTextInput("-2")
+    compose.onTag(seatsFieldTag(0)).performClick()
+    compose.waitForIdle()
+    compose.onTag(priceFieldTag(0)).assertTextEquals("2")
+
+    // Add second space
+    addSpace()
+    compose.onTag(spaceRowTag(1)).assertExists()
+
+    // Delete second row
+    compose.onTag(deleteButtonTag(1)).assertExists().performClick()
+    compose.waitForIdle()
+    compose.onTag(spaceRowTag(1)).assertDoesNotExist()
+    compose.onTag(spaceRowTag(0)).assertExists()
+  }
+
+  /**
+   * Submit success path using AddSpaceRenterContent directly to capture payload:
+   * - provide onCreate that records all arguments
+   * - ensure phone & website are passed through
+   */
+  @Test
+  fun submit_success_carries_phone_and_website() {
+    var capturedName: String? = null
+    var capturedEmail: String? = null
+    var capturedPhone: String? = null
+    var capturedWebsite: String? = null
+    var capturedAddress: Location? = null
+    var capturedWeek: List<OpeningHours>? = null
+    var capturedSpaces: List<Space>? = null
+    var onCreatedCalled = false
+
+    compose.setContent {
+      AppTheme {
+        val vm = CreateSpaceRenterViewModel()
+        val locationUi by vm.locationUIState.collectAsState()
+
+        AddSpaceRenterContent(
+            owner = owner,
+            onBack = {},
+            onCreated = { onCreatedCalled = true },
+            onCreate = { n, e, p, w, addr, week, spaces ->
+              capturedName = n
+              capturedEmail = e
+              capturedPhone = p
+              capturedWebsite = w
+              capturedAddress = addr
+              capturedWeek = week
+              capturedSpaces = spaces
+            },
+            locationUi = locationUi,
+            viewModel = vm)
+      }
+    }
+
+    // Required + optional + hours + one space
+    fillRequiredFields("Meeple Space", "host@example.com", "42 Boardgame Ave")
+    fillOptionalFields("+41 79 000 00 00", "https://meeple.space")
+    setAnyOpeningHoursViaDialog()
+    addSpace()
+
+    // Submit
+    compose.onTag(ShopComponentsTestTags.ACTION_CREATE).assertIsEnabled().performClick()
+    compose.waitForIdle()
+
+    assertEquals("Meeple Space", capturedName)
+    assertEquals("host@example.com", capturedEmail)
+    assertEquals("+41 79 000 00 00", capturedPhone)
+    assertEquals("https://meeple.space", capturedWebsite)
+    assertEquals("42 Boardgame Ave", capturedAddress?.name)
+    assertTrue(!capturedWeek.isNullOrEmpty())
+    assertTrue(!capturedSpaces.isNullOrEmpty())
+    assertTrue(onCreatedCalled)
+  }
+
+  /** Submit error path: IllegalArgumentException → shows its message. */
+  @Test
+  fun submit_error_shows_snackbar_message_illegalArgument() {
+    compose.setContent {
+      AppTheme {
+        val vm = CreateSpaceRenterViewModel()
+        val locationUi by vm.locationUIState.collectAsState()
+
+        AddSpaceRenterContent(
+            owner = owner,
+            onBack = {},
+            onCreated = { error("shouldn't be called on error") },
+            onCreate = { _, _, _, _, _, _, _ ->
+              throw IllegalArgumentException("Custom validation message")
+            },
+            locationUi = locationUi,
+            viewModel = vm)
+      }
+    }
+    fillRequiredFields()
+    setAnyOpeningHoursViaDialog()
+    addSpace()
+    compose.onTag(ShopComponentsTestTags.ACTION_CREATE).performClick()
+
+    // Wait for snackbar text to appear
+    compose.waitUntil(timeoutMillis = 5_000) {
+      compose
+          .onAllNodes(hasText("Custom validation message", substring = true))
+          .fetchSemanticsNodes()
+          .isNotEmpty()
+    }
+    compose.onNode(hasText("Custom validation message", substring = true)).assertExists()
+  }
+
+  /** Submit error path: generic Exception → shows generic error string. */
+  @Test
+  fun submit_error_shows_snackbar_message_generic() {
+    compose.setContent {
+      AppTheme {
+        val vm = CreateSpaceRenterViewModel()
+        val locationUi by vm.locationUIState.collectAsState()
+
+        AddSpaceRenterContent(
+            owner = owner,
+            onBack = {},
+            onCreated = { error("shouldn't be called on error") },
+            onCreate = { _, _, _, _, _, _, _ -> throw RuntimeException("boom") },
+            locationUi = locationUi,
+            viewModel = vm)
+      }
+    }
+    fillRequiredFields()
+    setAnyOpeningHoursViaDialog()
+    addSpace()
+    compose.onTag(ShopComponentsTestTags.ACTION_CREATE).performClick()
+
+    // Wait for snackbar text to appear
+    compose.waitUntil(timeoutMillis = 5_000) {
+      compose
+          .onAllNodes(hasText(AddSpaceRenterUi.Strings.ERROR_CREATE, substring = true))
+          .fetchSemanticsNodes()
+          .isNotEmpty()
+    }
+    compose.onNode(hasText(AddSpaceRenterUi.Strings.ERROR_CREATE, substring = true)).assertExists()
+  }
+
+  /* ─────────────────────────────── SMOKE ─────────────────────────────────── */
+
+  @Test
+  fun screen_smoke_renders_topbar_and_list() {
+    compose.setContent {
+      AppTheme {
+        CreateSpaceRenterScreen(
+            owner = owner, onBack = {}, onCreated = {}, viewModel = CreateSpaceRenterViewModel())
+      }
+    }
+    compose.onTag(CreateSpaceRenterScreenTestTags.TOPBAR).assertExists()
+    compose.onTag(CreateSpaceRenterScreenTestTags.TITLE).assertExists()
+    compose.onTag(CreateSpaceRenterScreenTestTags.LIST).assertExists()
+  }
+}

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/components/SpaceRenterComponentsTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/components/SpaceRenterComponentsTest.kt
@@ -22,6 +22,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.meeplemeet.model.auth.Account
 import com.github.meeplemeet.model.shared.location.Location
 import com.github.meeplemeet.model.space_renter.Space
+import com.github.meeplemeet.model.space_renter.SpaceRenter
 import com.github.meeplemeet.model.space_renter.SpaceRenterSearchViewModel
 import com.github.meeplemeet.ui.components.SpaceRenterComponentsTestTags as Tags
 import com.github.meeplemeet.ui.sessions.SessionTestTags
@@ -177,24 +178,30 @@ class SpaceRenterComponentsTest : FirestoreTests() {
     val owner = previewOwner()
     val vm = SpaceRenterSearchViewModel()
 
-    var name by mutableStateOf("")
-    var email by mutableStateOf("")
-    var phone by mutableStateOf("")
-    var link by mutableStateOf("")
-    var picked by mutableStateOf<Location?>(null)
-
     setContentThemed {
+      // Keep a draft renter as state; composable reads values from it.
+      var renter by remember {
+        mutableStateOf(
+            SpaceRenter(
+                id = "",
+                owner = owner,
+                name = "",
+                phone = "",
+                email = "",
+                website = "",
+                address = Location(name = ""),
+                openingHours = emptyList(),
+                spaces = emptyList()))
+      }
+
       SpaceRenterRequiredInfoSection(
-          spaceRenter = null,
-          spaceName = name,
-          onSpaceName = { name = it },
-          email = email,
-          onEmail = { email = it },
-          phone = phone,
-          onPhone = { phone = it.filter { ch -> ch.isDigit() } },
-          link = link,
-          onLink = { link = it },
-          onPickLocation = { picked = it },
+          spaceRenter = renter,
+          onSpaceName = { renter = renter.copy(name = it) },
+          onEmail = { renter = renter.copy(email = it) },
+          // test wants digits-only behavior -> filter in the callback
+          onPhone = { renter = renter.copy(phone = it.filter(Char::isDigit)) },
+          onLink = { renter = renter.copy(website = it) },
+          onPickLocation = { loc -> renter = renter.copy(address = loc) },
           viewModel = vm,
           owner = owner)
     }

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/components/SpaceRenterComponentsTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/components/SpaceRenterComponentsTest.kt
@@ -1,0 +1,228 @@
+// This file was initially done by hand and refactored and improved by ChatGPT-5 Extend Thinking
+// Combinations to tests were given to the LLM so it could generate the code more easily
+package com.github.meeplemeet.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextReplacement
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.meeplemeet.model.auth.Account
+import com.github.meeplemeet.model.shared.location.Location
+import com.github.meeplemeet.model.space_renter.Space
+import com.github.meeplemeet.model.space_renter.SpaceRenterSearchViewModel
+import com.github.meeplemeet.ui.components.SpaceRenterComponentsTestTags as Tags
+import com.github.meeplemeet.ui.sessions.SessionTestTags
+import com.github.meeplemeet.ui.theme.AppTheme
+import com.github.meeplemeet.ui.theme.ThemeMode
+import com.github.meeplemeet.utils.FirestoreTests
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SpaceRenterComponentsTest : FirestoreTests() {
+
+  @get:Rule val compose = createComposeRule()
+
+  /* ---------- Helpers ---------- */
+  private fun ComposeTestRule.onTag(tag: String) = onNodeWithTag(tag, useUnmergedTree = true)
+
+  private fun setContentThemed(content: @Composable () -> Unit) =
+      compose.setContent { AppTheme(themeMode = ThemeMode.LIGHT) { content() } }
+
+  private fun spaceRowTag(index: Int) = Tags.SPACE_ROW_PREFIX + index
+
+  private fun seatsFieldTag(index: Int) = spaceRowTag(index) + Tags.SPACE_ROW_SEATS_FIELD_SUFFIX
+
+  private fun priceFieldTag(index: Int) = spaceRowTag(index) + Tags.SPACE_ROW_PRICE_FIELD_SUFFIX
+
+  private fun deleteButtonTag(index: Int) = spaceRowTag(index) + Tags.SPACE_ROW_DELETE_SUFFIX
+
+  private fun ComposeTestRule.fieldInputUnder(parentTag: String) =
+      onNode(hasSetTextAction() and hasAnyAncestor(hasTestTag(parentTag)), useUnmergedTree = true)
+
+  private fun previewOwner() =
+      Account(
+          uid = "preview_uid",
+          handle = "@previewer",
+          name = "Preview Owner",
+          email = "preview@example.com")
+
+  /* =======================================================================
+   * 1) SpacesHeaderRow
+   * ======================================================================= */
+  @Test
+  fun spacesHeaderRow_renders_titles() {
+    val places = "Places"
+    val price = "Price"
+
+    setContentThemed { SpacesHeaderRow(placesTitle = places, priceTitle = price) }
+
+    compose.onTag(Tags.SPACES_HEADER).assertExists().assertIsDisplayed()
+    compose.onTag(Tags.SPACES_HEADER_PLACES).assertExists().assertTextEquals(places)
+    compose.onTag(Tags.SPACES_HEADER_PRICE).assertExists().assertTextEquals(price)
+  }
+
+  /* =======================================================================
+   * 2) SpaceRow
+   * ======================================================================= */
+  @Test
+  fun spaceRow_editMode_toggles_delete_and_numeric_filters_apply() {
+    var updated: Space? = null
+    var deleted = 0
+
+    setContentThemed {
+      Column(Modifier.padding(12.dp)) {
+        // Read-only row: no delete button
+        SpaceRow(
+            index = 0,
+            space = Space(seats = 6, costPerHour = 12.0),
+            onChange = { updated = it },
+            onDelete = { deleted++ },
+            isEditing = false)
+        // Editing row: delete button visible
+        SpaceRow(
+            index = 1,
+            space = Space(seats = 2, costPerHour = 3.5),
+            onChange = { updated = it },
+            onDelete = { deleted++ },
+            isEditing = true)
+      }
+    }
+
+    // row 0 (read-only): no delete button
+    compose.onTag(deleteButtonTag(0)).assertDoesNotExist()
+
+    // row 1 (editing): delete present and clickable
+    compose.onTag(deleteButtonTag(1)).assertExists().performClick()
+    assertEquals(1, deleted)
+
+    // Seats: replace atomically -> 12
+    compose.onTag(seatsFieldTag(1)).performTextReplacement("1a2")
+    compose.waitForIdle()
+    assertEquals(12, updated?.seats)
+
+    // Price: replace atomically -> 10.59
+    compose.onTag(priceFieldTag(1)).performTextReplacement("10,5a.9")
+    compose.waitForIdle()
+    assertEquals(10.59, updated?.costPerHour ?: 0.0, 1e-6)
+  }
+
+  /* =======================================================================
+   * 3) SpacesList
+   * ======================================================================= */
+  @Test
+  fun spacesList_empty_then_populated_callbacks_fire() {
+    val changes = mutableListOf<Pair<Int, Space>>()
+    val deletions = mutableListOf<Int>()
+
+    lateinit var setter: (List<Space>) -> Unit
+
+    setContentThemed {
+      var source by remember { mutableStateOf<List<Space>>(emptyList()) }
+      setter = { new -> source = new }
+
+      SpacesList(
+          spaces = source,
+          onChange = { idx, sp -> changes += idx to sp },
+          onDelete = { idx -> deletions += idx })
+    }
+
+    // Empty state visible
+    compose.onTag(Tags.SPACES_LIST).assertExists().assertIsDisplayed()
+    compose.onTag(Tags.SPACES_EMPTY_TEXT).assertExists().assertIsDisplayed()
+
+    // Populate with 2 spaces
+    compose.runOnUiThread { setter(listOf(Space(4, 8.0), Space(6, 12.5))) }
+    compose.waitForIdle()
+
+    // Header + two rows present
+    compose.onTag(Tags.SPACES_HEADER).assertExists()
+    compose.onTag(spaceRowTag(0)).assertExists()
+    compose.onTag(spaceRowTag(1)).assertExists()
+
+    // Change row 0 seats -> parent receives
+    compose.onTag(seatsFieldTag(0)).performTextReplacement("99")
+    compose.waitForIdle()
+    assertTrue(changes.isNotEmpty())
+    assertEquals(0, changes.last().first)
+    assertEquals(99, changes.last().second.seats)
+
+    // Delete row 1 -> parent receives index
+    compose.onTag(deleteButtonTag(1)).performClick()
+    compose.waitForIdle()
+    assertTrue(deletions.contains(1))
+  }
+
+  /* =======================================================================
+   * 4) SpaceRenterRequiredInfoSection
+   * ======================================================================= */
+  @Test
+  fun requiredInfoSection_fields_and_email_validation_and_location_bar() {
+    val owner = previewOwner()
+    val vm = SpaceRenterSearchViewModel()
+
+    var name by mutableStateOf("")
+    var email by mutableStateOf("")
+    var phone by mutableStateOf("")
+    var link by mutableStateOf("")
+    var picked by mutableStateOf<Location?>(null)
+
+    setContentThemed {
+      SpaceRenterRequiredInfoSection(
+          spaceRenter = null,
+          spaceName = name,
+          onSpaceName = { name = it },
+          email = email,
+          onEmail = { email = it },
+          phone = phone,
+          onPhone = { phone = it.filter { ch -> ch.isDigit() } },
+          link = link,
+          onLink = { link = it },
+          onPickLocation = { picked = it },
+          viewModel = vm,
+          owner = owner)
+    }
+
+    // Name
+    compose.fieldInputUnder(ShopFormTestTags.FIELD_SHOP).performTextReplacement("Meeple Space")
+    compose.fieldInputUnder(ShopFormTestTags.FIELD_SHOP).assertTextEquals("Meeple Space")
+
+    // Email -> invalid then valid
+    compose.fieldInputUnder(ShopFormTestTags.FIELD_EMAIL).performTextReplacement("foo")
+    compose
+        .onNodeWithText("Enter a valid email address.", useUnmergedTree = true)
+        .assertExists()
+        .assertIsDisplayed()
+    compose.fieldInputUnder(ShopFormTestTags.FIELD_EMAIL).performTextReplacement("host@example.com")
+    compose
+        .onNodeWithText("Enter a valid email address.", useUnmergedTree = true)
+        .assertDoesNotExist()
+
+    // Phone (digits only via our onPhone)
+    compose.fieldInputUnder(ShopFormTestTags.FIELD_PHONE).performTextReplacement("123-45a")
+    compose.fieldInputUnder(ShopFormTestTags.FIELD_PHONE).assertTextEquals("12345")
+
+    // Link
+    compose.fieldInputUnder(ShopFormTestTags.FIELD_LINK).performTextReplacement("https://x.y")
+    compose.fieldInputUnder(ShopFormTestTags.FIELD_LINK).assertTextEquals("https://x.y")
+
+    // Location field exists
+    compose.onTag(SessionTestTags.LOCATION_FIELD).assertExists().assertIsDisplayed()
+  }
+}

--- a/app/src/main/java/com/github/meeplemeet/MainActivity.kt
+++ b/app/src/main/java/com/github/meeplemeet/MainActivity.kt
@@ -62,6 +62,7 @@ import com.github.meeplemeet.ui.sessions.SessionsOverviewScreen
 import com.github.meeplemeet.ui.shops.CreateShopScreen
 import com.github.meeplemeet.ui.shops.ShopDetailsScreen
 import com.github.meeplemeet.ui.shops.ShopScreen
+import com.github.meeplemeet.ui.space_renter.CreateSpaceRenterScreen
 import com.github.meeplemeet.ui.theme.AppTheme
 import com.google.firebase.Firebase
 import com.google.firebase.auth.FirebaseAuth
@@ -389,6 +390,12 @@ fun MeepleMeetApp(
       } else {
         LoadingScreen()
       }
+    }
+    composable(MeepleMeetScreen.CreateSpaceRenter.name) {
+      CreateSpaceRenterScreen(
+          owner = account!!,
+          onBack = { navigationActions.goBack() },
+          onCreated = { navigationActions.goBack() /* TODO */ })
     }
   }
 }

--- a/app/src/main/java/com/github/meeplemeet/model/shops/CreateShopViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/shops/CreateShopViewModel.kt
@@ -5,6 +5,7 @@ package com.github.meeplemeet.model.shops
 import com.github.meeplemeet.RepositoryProvider
 import com.github.meeplemeet.model.auth.Account
 import com.github.meeplemeet.model.shared.game.Game
+import com.github.meeplemeet.model.shared.game.GameRepository
 import com.github.meeplemeet.model.shared.location.Location
 
 /**
@@ -17,7 +18,8 @@ import com.github.meeplemeet.model.shared.location.Location
  */
 class CreateShopViewModel(
     private val shopRepo: ShopRepository = RepositoryProvider.shops,
-) : ShopSearchViewModel() {
+    gameRepository: GameRepository = RepositoryProvider.games
+) : ShopSearchViewModel(gameRepository) {
   /**
    * Creates a new shop in Firestore.
    *

--- a/app/src/main/java/com/github/meeplemeet/model/shops/CreateShopViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/shops/CreateShopViewModel.kt
@@ -5,9 +5,7 @@ package com.github.meeplemeet.model.shops
 import com.github.meeplemeet.RepositoryProvider
 import com.github.meeplemeet.model.auth.Account
 import com.github.meeplemeet.model.shared.game.Game
-import com.github.meeplemeet.model.shared.game.GameRepository
 import com.github.meeplemeet.model.shared.location.Location
-import com.github.meeplemeet.model.shared.location.LocationRepository
 
 /**
  * ViewModel for creating new shops.
@@ -19,9 +17,7 @@ import com.github.meeplemeet.model.shared.location.LocationRepository
  */
 class CreateShopViewModel(
     private val shopRepo: ShopRepository = RepositoryProvider.shops,
-    gameRepository: GameRepository = RepositoryProvider.games,
-    locationRepository: LocationRepository = RepositoryProvider.locations
-) : ShopSearchViewModel(gameRepository, locationRepository) {
+) : ShopSearchViewModel() {
   /**
    * Creates a new shop in Firestore.
    *

--- a/app/src/main/java/com/github/meeplemeet/model/shops/ShopSearchViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/shops/ShopSearchViewModel.kt
@@ -2,14 +2,11 @@
 
 package com.github.meeplemeet.model.shops
 
-import com.github.meeplemeet.RepositoryProvider
 import com.github.meeplemeet.model.PermissionDeniedException
 import com.github.meeplemeet.model.auth.Account
 import com.github.meeplemeet.model.shared.SearchViewModel
 import com.github.meeplemeet.model.shared.game.Game
-import com.github.meeplemeet.model.shared.game.GameRepository
 import com.github.meeplemeet.model.shared.location.Location
-import com.github.meeplemeet.model.shared.location.LocationRepository
 
 private const val PERMISSION_DENIED_MESSAGE = "Only the shop's owner can edit his own shop"
 
@@ -20,10 +17,7 @@ private const val PERMISSION_DENIED_MESSAGE = "Only the shop's owner can edit hi
  * permission validation. This ViewModel ensures that only the shop owner can modify
  * game/location-related data.
  */
-open class ShopSearchViewModel(
-    gameRepository: GameRepository = RepositoryProvider.games,
-    locationRepository: LocationRepository = RepositoryProvider.locations
-) : SearchViewModel(gameRepository, locationRepository) {
+open class ShopSearchViewModel : SearchViewModel() {
 
   /**
    * Sets the selected game for a shop with permission validation.

--- a/app/src/main/java/com/github/meeplemeet/model/shops/ShopSearchViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/shops/ShopSearchViewModel.kt
@@ -2,11 +2,14 @@
 
 package com.github.meeplemeet.model.shops
 
+import com.github.meeplemeet.RepositoryProvider
 import com.github.meeplemeet.model.PermissionDeniedException
 import com.github.meeplemeet.model.auth.Account
 import com.github.meeplemeet.model.shared.SearchViewModel
 import com.github.meeplemeet.model.shared.game.Game
+import com.github.meeplemeet.model.shared.game.GameRepository
 import com.github.meeplemeet.model.shared.location.Location
+import com.github.meeplemeet.model.shared.location.LocationRepository
 
 private const val PERMISSION_DENIED_MESSAGE = "Only the shop's owner can edit his own shop"
 
@@ -17,7 +20,10 @@ private const val PERMISSION_DENIED_MESSAGE = "Only the shop's owner can edit hi
  * permission validation. This ViewModel ensures that only the shop owner can modify
  * game/location-related data.
  */
-open class ShopSearchViewModel : SearchViewModel() {
+open class ShopSearchViewModel(
+    gameRepository: GameRepository = RepositoryProvider.games,
+    locationRepository: LocationRepository = RepositoryProvider.locations
+) : SearchViewModel(gameRepository, locationRepository) {
 
   /**
    * Sets the selected game for a shop with permission validation.

--- a/app/src/main/java/com/github/meeplemeet/model/space_renter/CreateSpaceRenterViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/space_renter/CreateSpaceRenterViewModel.kt
@@ -2,7 +2,6 @@
 
 package com.github.meeplemeet.model.space_renter
 
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.github.meeplemeet.RepositoryProvider
 import com.github.meeplemeet.model.auth.Account
@@ -20,7 +19,7 @@ import kotlinx.coroutines.launch
  */
 class CreateSpaceRenterViewModel(
     private val repository: SpaceRenterRepository = RepositoryProvider.spaceRenters
-) : ViewModel() {
+) : SpaceRenterSearchViewModel() {
   /**
    * Creates a new space renter in Firestore.
    *

--- a/app/src/main/java/com/github/meeplemeet/model/space_renter/EditSpaceRenterViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/space_renter/EditSpaceRenterViewModel.kt
@@ -2,7 +2,6 @@
 
 package com.github.meeplemeet.model.space_renter
 
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.github.meeplemeet.RepositoryProvider
 import com.github.meeplemeet.model.PermissionDeniedException
@@ -21,7 +20,7 @@ import kotlinx.coroutines.launch
  */
 class EditSpaceRenterViewModel(
     private val repository: SpaceRenterRepository = RepositoryProvider.spaceRenters
-) : ViewModel() {
+) : SpaceRenterSearchViewModel() {
 
   /**
    * Updates one or more fields of an existing space renter.

--- a/app/src/main/java/com/github/meeplemeet/model/space_renter/SpaceRenterSearchViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/space_renter/SpaceRenterSearchViewModel.kt
@@ -1,0 +1,58 @@
+// Docs generated with Claude Code.
+
+package com.github.meeplemeet.model.space_renter
+
+import com.github.meeplemeet.model.PermissionDeniedException
+import com.github.meeplemeet.model.auth.Account
+import com.github.meeplemeet.model.shared.SearchViewModel
+import com.github.meeplemeet.model.shared.location.Location
+
+private const val PERMISSION_DENIED_MESSAGE =
+    "Only the space renter's owner can edit their own space renter"
+
+/**
+ * Base ViewModel for space renter-related screens that need location selection functionality.
+ *
+ * Extends [SearchViewModel] to provide location search and selection with space renter owner
+ * permission validation. This ViewModel ensures that only the space renter owner can modify
+ * location-related data.
+ */
+open class SpaceRenterSearchViewModel : SearchViewModel() {
+
+  /**
+   * Sets the selected location for a space renter with permission validation.
+   *
+   * Only the space renter owner can select location for their space renter. Updates the location UI
+   * state with the selected location.
+   *
+   * @param spaceRenter The space renter to modify.
+   * @param requester The account requesting the change.
+   * @param location The location to select.
+   * @throws PermissionDeniedException if the requester is not the space renter owner.
+   */
+  fun setLocation(spaceRenter: SpaceRenter, requester: Account, location: Location) {
+    if (spaceRenter.owner.uid != requester.uid)
+        throw PermissionDeniedException(PERMISSION_DENIED_MESSAGE)
+
+    setLocation(location)
+  }
+
+  /**
+   * Updates the location search query for a space renter with permission validation.
+   *
+   * Only the space renter owner can search for location to add to their space renter. This method
+   * updates the visible location query in the UI state and triggers a background search for
+   * matching location.
+   *
+   * @param spaceRenter The space renter context.
+   * @param requester The account requesting the search.
+   * @param query The search query string.
+   * @throws PermissionDeniedException if the requester is not the space renter owner.
+   */
+  fun setLocationQuery(spaceRenter: SpaceRenter, requester: Account, query: String) {
+    if (spaceRenter.owner.uid != requester.uid)
+        throw PermissionDeniedException(PERMISSION_DENIED_MESSAGE)
+
+    setLocationQuery(query)
+  }
+}

--- a/app/src/main/java/com/github/meeplemeet/model/space_renter/SpaceRenterViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/space_renter/SpaceRenterViewModel.kt
@@ -2,7 +2,6 @@
 
 package com.github.meeplemeet.model.space_renter
 
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.github.meeplemeet.RepositoryProvider
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -18,7 +17,7 @@ import kotlinx.coroutines.launch
  */
 class SpaceRenterViewModel(
     private val repository: SpaceRenterRepository = RepositoryProvider.spaceRenters
-) : ViewModel() {
+) : SpaceRenterSearchViewModel() {
   private val _spaceRenter = MutableStateFlow<SpaceRenter?>(null)
 
   /**

--- a/app/src/main/java/com/github/meeplemeet/ui/components/SessionComponents.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/SessionComponents.kt
@@ -83,6 +83,8 @@ import com.github.meeplemeet.model.shared.game.Game
 import com.github.meeplemeet.model.shared.location.Location
 import com.github.meeplemeet.model.shops.Shop
 import com.github.meeplemeet.model.shops.ShopSearchViewModel
+import com.github.meeplemeet.model.space_renter.SpaceRenter
+import com.github.meeplemeet.model.space_renter.SpaceRenterSearchViewModel
 import com.github.meeplemeet.ui.navigation.NavigationTestTags
 import com.github.meeplemeet.ui.sessions.SessionTestTags
 import com.github.meeplemeet.ui.theme.AppColors
@@ -722,6 +724,29 @@ fun ShopLocationSearchBar(
       viewModel,
       inputFieldTestTag,
       dropdownItemTestTag)
+}
+
+@Composable
+fun SpaceRenterLocationSearchBar(
+    account: Account,
+    spaceRenter: SpaceRenter?,
+    viewModel: SpaceRenterSearchViewModel,
+    inputFieldTestTag: String = "",
+    dropdownItemTestTag: String = ""
+) {
+  LocationSearchBar(
+      setLocation = { loc ->
+        spaceRenter?.let { viewModel.setLocation(spaceRenter, account, loc) }
+            ?: viewModel.setLocation(loc)
+      },
+      setLocationQuery = { q ->
+        spaceRenter?.let { viewModel.setLocationQuery(spaceRenter, account, q) }
+            ?: viewModel.setLocationQuery(q)
+      },
+      initial = spaceRenter?.address ?: Location(),
+      viewModel = viewModel,
+      inputFieldTestTag = inputFieldTestTag,
+      dropdownItemTestTag = dropdownItemTestTag)
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/com/github/meeplemeet/ui/components/SessionComponents.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/SessionComponents.kt
@@ -784,17 +784,20 @@ private fun LocationSearchBar(
         )
 
         ExposedDropdownMenu(
-            expanded = menuOpen && hasSuggestions, onDismissRequest = { menuOpen = false }) {
-              results.locationSuggestions.take(5).forEachIndexed { i, loc ->
-                DropdownMenuItem(
-                    text = { Text(loc.name) },
-                    onClick = {
-                      menuOpen = false
-                      setLocation(loc)
-                    },
-                    modifier = Modifier.testTag("$dropdownItemTestTag:$i"))
-              }
-            }
+            expanded = menuOpen && hasSuggestions,
+            onDismissRequest = { menuOpen = false },
+            containerColor = MaterialTheme.colorScheme.background,
+        ) {
+          results.locationSuggestions.take(5).forEachIndexed { i, loc ->
+            DropdownMenuItem(
+                text = { Text(loc.name) },
+                onClick = {
+                  menuOpen = false
+                  setLocation(loc)
+                },
+                modifier = Modifier.testTag("$dropdownItemTestTag:$i"))
+          }
+        }
       }
 }
 

--- a/app/src/main/java/com/github/meeplemeet/ui/components/ShopComponents.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/ShopComponents.kt
@@ -685,6 +685,7 @@ fun OpeningHoursDialog(
 
   AlertDialog(
       onDismissRequest = onDismiss,
+      containerColor = MaterialTheme.colorScheme.background,
       shape = MaterialTheme.shapes.extraLarge,
       title = {
         Box(

--- a/app/src/main/java/com/github/meeplemeet/ui/components/ShopComponents.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/ShopComponents.kt
@@ -234,6 +234,11 @@ object ShopUiDefaults {
   object RangesMagicNumbers {
     val qtyGameDialog: IntRange = 1..40
   }
+
+  object Numbers {
+    const val MIN_LINES_DEFAULT = 1
+    const val MAX_LINES_DEFAULT = 1
+  }
 }
 
 /* =============================================================================
@@ -432,7 +437,7 @@ fun LabeledField(
     modifier: Modifier = Modifier,
     keyboardType: KeyboardType = KeyboardType.Text,
     singleLine: Boolean = true,
-    minLines: Int = 1,
+    minLines: Int = ShopUiDefaults.Numbers.MIN_LINES_DEFAULT,
 ) {
   Box(modifier.fillMaxWidth().testTag(ShopComponentsTestTags.labeledField(label))) {
     OutlinedTextField(
@@ -719,7 +724,9 @@ fun OpeningHoursDialog(
                       },
                       modifier = Modifier.testTag(ShopComponentsTestTags.DIALOG_OPEN24_CHECKBOX))
                   Spacer(Modifier.width(ShopUiDefaults.DimensionsMagicNumbers.space8))
-                  Text(ShopUiDefaults.StringsMagicNumbers.OPEN_24, maxLines = 1)
+                  Text(
+                      ShopUiDefaults.StringsMagicNumbers.OPEN_24,
+                      maxLines = ShopUiDefaults.Numbers.MAX_LINES_DEFAULT)
                 }
             Row(
                 modifier = Modifier.weight(1f).testTag(ShopComponentsTestTags.DIALOG_CLOSED_ROW),
@@ -739,7 +746,9 @@ fun OpeningHoursDialog(
                       },
                       modifier = Modifier.testTag(ShopComponentsTestTags.DIALOG_CLOSED_CHECKBOX))
                   Spacer(Modifier.width(ShopUiDefaults.DimensionsMagicNumbers.space8))
-                  Text(ShopUiDefaults.StringsMagicNumbers.CLOSED, maxLines = 1)
+                  Text(
+                      ShopUiDefaults.StringsMagicNumbers.CLOSED,
+                      maxLines = ShopUiDefaults.Numbers.MAX_LINES_DEFAULT)
                 }
           }
 
@@ -1166,7 +1175,7 @@ fun GameItem(
                           Text(
                               label,
                               style = MaterialTheme.typography.labelSmall,
-                              maxLines = 1,
+                              maxLines = ShopUiDefaults.Numbers.MAX_LINES_DEFAULT,
                               softWrap = false,
                               modifier = Modifier.padding(horizontal = 4.dp))
                         }

--- a/app/src/main/java/com/github/meeplemeet/ui/components/ShopFormComponents.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/ShopFormComponents.kt
@@ -295,10 +295,20 @@ fun CollapsibleSection(
     initiallyExpanded: Boolean = true,
     header: (@Composable RowScope.() -> Unit)? = null,
     content: @Composable ColumnScope.() -> Unit,
-    testTag: String? = null
+    testTag: String? = null,
+    expanded: Boolean? = null,
+    onExpandedChange: ((Boolean) -> Unit)? = null,
 ) {
-  var expanded by rememberSaveable { mutableStateOf(initiallyExpanded) }
-  val arrowRotation by animateFloatAsState(if (expanded) 180f else 0f, label = "arrow")
+  val (isExpanded, setExpanded) =
+      if (expanded != null && onExpandedChange != null) {
+        expanded to onExpandedChange
+      } else {
+        var localExpanded by rememberSaveable { mutableStateOf(initiallyExpanded) }
+        localExpanded to { v: Boolean -> localExpanded = v }
+      }
+
+  val arrowRotation by
+      animateFloatAsState(targetValue = if (isExpanded) 180f else 0f, label = "arrow")
 
   Column(Modifier.fillMaxWidth()) {
     Row(
@@ -316,9 +326,11 @@ fun CollapsibleSection(
                     if (testTag != null) m.testTag(testTag + ShopFormTestTags.SECTION_TITLE_SUFFIX)
                     else m
                   })
+
           header?.invoke(this)
+
           IconButton(
-              onClick = { expanded = !expanded },
+              onClick = { setExpanded(!isExpanded) },
               modifier =
                   Modifier.let { m ->
                     if (testTag != null) m.testTag(testTag + ShopFormTestTags.SECTION_TOGGLE_SUFFIX)
@@ -327,10 +339,11 @@ fun CollapsibleSection(
                 Icon(
                     Icons.Filled.ExpandMore,
                     contentDescription =
-                        if (expanded) ShopFormUi.Strings.COLLAPSE else ShopFormUi.Strings.EXPAND,
+                        if (isExpanded) ShopFormUi.Strings.COLLAPSE else ShopFormUi.Strings.EXPAND,
                     modifier = Modifier.rotate(arrowRotation))
               }
         }
+
     HorizontalDivider(
         thickness = 1.dp,
         color = MaterialTheme.colorScheme.outlineVariant,
@@ -340,7 +353,7 @@ fun CollapsibleSection(
               else m
             })
 
-    AnimatedVisibility(visible = expanded) {
+    AnimatedVisibility(visible = isExpanded) {
       Column(
           Modifier.padding(top = 0.dp).let { m ->
             if (testTag != null) m.testTag(testTag + ShopFormTestTags.SECTION_CONTENT_SUFFIX) else m

--- a/app/src/main/java/com/github/meeplemeet/ui/components/ShopFormComponents.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/ShopFormComponents.kt
@@ -67,6 +67,11 @@ object ShopFormUi {
     val betweenControls = 6.dp
   }
 
+  object Numbers {
+    const val EXPANDED_ANGLE = 180f
+    const val COLLAPSED_ANGLE = 0f
+  }
+
   object Strings {
     const val SHOP_LABEL = "Shop"
     const val SHOP_PLACEHOLDER = "Shop name"
@@ -308,7 +313,11 @@ fun CollapsibleSection(
       }
 
   val arrowRotation by
-      animateFloatAsState(targetValue = if (isExpanded) 180f else 0f, label = "arrow")
+      animateFloatAsState(
+          targetValue =
+              if (isExpanded) ShopFormUi.Numbers.EXPANDED_ANGLE
+              else ShopFormUi.Numbers.COLLAPSED_ANGLE,
+          label = "arrow")
 
   Column(Modifier.fillMaxWidth()) {
     Row(

--- a/app/src/main/java/com/github/meeplemeet/ui/components/SpaceRenterComponents.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/SpaceRenterComponents.kt
@@ -1,6 +1,8 @@
 package com.github.meeplemeet.ui.components
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
@@ -13,6 +15,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.github.meeplemeet.model.auth.Account
 import com.github.meeplemeet.model.shared.location.Location
@@ -185,6 +188,48 @@ fun SpaceRow(
           Icons.Filled.Delete,
           contentDescription = "Remove space",
           tint = MaterialTheme.colorScheme.error)
+    }
+  }
+}
+
+@Composable
+fun SpacesList(
+    spaces: List<Space>,
+    onChange: (index: Int, updated: Space) -> Unit,
+    onDelete: (index: Int) -> Unit,
+    placesTitle: String,
+    priceTitle: String,
+    emptyText: String,
+    modifier: Modifier = Modifier,
+    rowBorderOpacity: Float = 1f,
+    rowBorderColor: Color = MaterialTheme.colorScheme.onSurface,
+    maxListHeight: Dp = 600.dp,
+    rowSpacing: Dp = 8.dp
+) {
+  Column(modifier = modifier) {
+    SpacesHeaderRow(placesTitle = placesTitle, priceTitle = priceTitle)
+
+    if (spaces.isEmpty()) {
+      Text(
+          emptyText,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+          style = MaterialTheme.typography.bodyMedium,
+      )
+    } else {
+      LazyColumn(
+          verticalArrangement = Arrangement.spacedBy(rowSpacing),
+          contentPadding = PaddingValues(bottom = 16.dp),
+          modifier = Modifier.heightIn(max = maxListHeight)) {
+            itemsIndexed(spaces) { idx, space ->
+              SpaceRow(
+                  index = idx,
+                  space = space,
+                  onChange = { updated -> onChange(idx, updated) },
+                  onDelete = { onDelete(idx) },
+                  borderOpacity = rowBorderOpacity,
+                  borderColor = rowBorderColor)
+            }
+          }
     }
   }
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/components/SpaceRenterComponents.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/SpaceRenterComponents.kt
@@ -77,6 +77,23 @@ private object SpaceRenterUi {
 /* ================================================================================================
  * Required info section
  * ================================================================================================ */
+
+/**
+ * Section with required info fields for a space renter: name, email, phone, link, address.
+ *
+ * @param spaceRenter The space renter being edited, or null if creating a new one.
+ * @param spaceName The current value of the space name field.
+ * @param onSpaceName Callback when the space name changes.
+ * @param email The current value of the email field.
+ * @param onEmail Callback when the email changes.
+ * @param phone The current value of the phone field.
+ * @param onPhone Callback when the phone changes.
+ * @param link The current value of the link field.
+ * @param onLink Callback when the link changes.
+ * @param onPickLocation Callback when a location is picked.
+ * @param viewModel The SpaceRenterSearchViewModel for location searching.
+ * @param owner The account of the owner of the space renter.
+ */
 @Composable
 fun SpaceRenterRequiredInfoSection(
     spaceRenter: SpaceRenter?,
@@ -151,6 +168,13 @@ fun SpaceRenterRequiredInfoSection(
 /* ================================================================================================
  * Spaces section
  * ================================================================================================ */
+
+/**
+ * Header row for the spaces list, showing titles for places and price columns.
+ *
+ * @param placesTitle The title for the places column.
+ * @param priceTitle The title for the price column.
+ */
 @Composable
 fun SpacesHeaderRow(placesTitle: String, priceTitle: String) {
   Row(
@@ -183,6 +207,15 @@ fun SpacesHeaderRow(placesTitle: String, priceTitle: String) {
       }
 }
 
+/**
+ * A row representing a single space, with fields for number of seats and cost per hour.
+ *
+ * @param index The index of the space in the list.
+ * @param space The space data.
+ * @param onChange Callback when the space is changed.
+ * @param onDelete Callback when the space is deleted.
+ * @param isEditing Whether the row is in editing mode (shows delete button).
+ */
 @Composable
 fun SpaceRow(
     index: Int,
@@ -332,6 +365,15 @@ fun SpaceRow(
   }
 }
 
+/**
+ * A list of spaces with the ability to edit or delete each space.
+ *
+ * @param spaces The list of spaces to display.
+ * @param onChange Callback when a space is changed, providing the index and updated space.
+ * @param onDelete Callback when a space is deleted, providing the index.
+ * @param modifier Modifier for the list container.
+ * @param isEditing Whether the list is in editing mode (shows delete buttons).
+ */
 @Composable
 fun SpacesList(
     spaces: List<Space>,

--- a/app/src/main/java/com/github/meeplemeet/ui/components/SpaceRenterComponents.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/SpaceRenterComponents.kt
@@ -1,0 +1,207 @@
+package com.github.meeplemeet.ui.components
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.github.meeplemeet.model.auth.Account
+import com.github.meeplemeet.model.shared.location.Location
+import com.github.meeplemeet.model.space_renter.Space
+import com.github.meeplemeet.model.space_renter.SpaceRenter
+import com.github.meeplemeet.model.space_renter.SpaceRenterSearchViewModel
+import com.github.meeplemeet.ui.sessions.SessionTestTags
+
+/* ----- sizes to keep columns aligned across header and rows ----- */
+private val SpaceLabelWidth = 110.dp
+private val FieldBoxWidth = 88.dp
+private val ColumnsGap = 16.dp
+
+/* ================================================================
+ * Required info section (same as shop, adapted to space renters)
+ * ================================================================ */
+@Composable
+fun SpaceRenterRequiredInfoSection(
+    spaceRenter: SpaceRenter?,
+    spaceName: String,
+    onSpaceName: (String) -> Unit,
+    email: String,
+    onEmail: (String) -> Unit,
+    phone: String,
+    onPhone: (String) -> Unit,
+    link: String,
+    onLink: (String) -> Unit,
+    onPickLocation: (Location) -> Unit,
+    viewModel: SpaceRenterSearchViewModel,
+    owner: Account
+) {
+  // Name
+  Box(Modifier.testTag(ShopFormTestTags.FIELD_SHOP)) {
+    LabeledField(
+        label = "Space name",
+        placeholder = "Space name",
+        value = spaceName,
+        onValueChange = onSpaceName)
+  }
+
+  // Email
+  Box(Modifier.testTag(ShopFormTestTags.FIELD_EMAIL)) {
+    LabeledField(
+        label = ShopFormUi.Strings.EMAIL_LABEL,
+        placeholder = ShopFormUi.Strings.EMAIL_PLACEHOLDER,
+        value = email,
+        onValueChange = onEmail,
+        keyboardType = KeyboardType.Email)
+  }
+  val showEmailError = email.isNotEmpty() && !isValidEmail(email)
+  if (showEmailError) {
+    Text(
+        "Enter a valid email address.",
+        color = MaterialTheme.colorScheme.error,
+        style = MaterialTheme.typography.bodySmall)
+  }
+
+  // Phone
+  Box(Modifier.testTag(ShopFormTestTags.FIELD_PHONE)) {
+    LabeledField(
+        label = ShopFormUi.Strings.PHONE_LABEL,
+        placeholder = ShopFormUi.Strings.PHONE_PLACEHOLDER,
+        value = phone,
+        onValueChange = onPhone,
+        keyboardType = KeyboardType.Phone)
+  }
+
+  // Link
+  Box(Modifier.testTag(ShopFormTestTags.FIELD_LINK)) {
+    LabeledField(
+        label = ShopFormUi.Strings.LINK_LABEL,
+        placeholder = ShopFormUi.Strings.LINK_PLACEHOLDER,
+        value = link,
+        onValueChange = onLink,
+        keyboardType = KeyboardType.Uri)
+  }
+
+  // Address
+  Box(Modifier.testTag(ShopFormTestTags.FIELD_ADDRESS)) {
+    SpaceRenterLocationSearchBar(
+        account = owner,
+        spaceRenter = spaceRenter,
+        viewModel = viewModel,
+        inputFieldTestTag = SessionTestTags.LOCATION_FIELD)
+  }
+}
+
+/* ================================================================
+ * Spaces section header + row (used by CreateSpaceRenterScreen)
+ * ================================================================ */
+@Composable
+fun SpacesHeaderRow(placesTitle: String, priceTitle: String) {
+  Row(
+      modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+      verticalAlignment = Alignment.CenterVertically) {
+        Spacer(Modifier.width(SpaceLabelWidth))
+
+        Text(
+            text = placesTitle,
+            modifier = Modifier.width(FieldBoxWidth).wrapContentWidth(Alignment.CenterHorizontally),
+            style = MaterialTheme.typography.titleMedium)
+
+        Spacer(Modifier.width(ColumnsGap))
+
+        Text(
+            text = priceTitle,
+            modifier = Modifier.width(FieldBoxWidth).wrapContentWidth(Alignment.CenterHorizontally),
+            style = MaterialTheme.typography.titleMedium)
+
+        Spacer(Modifier.weight(1f))
+      }
+}
+
+@Composable
+fun SpaceRow(
+    index: Int,
+    space: Space,
+    onChange: (Space) -> Unit,
+    onDelete: () -> Unit,
+    borderOpacity: Float = 1f,
+    borderColor: Color = MaterialTheme.colorScheme.onSurface
+) {
+  val outline = borderColor.copy(alpha = borderOpacity)
+  val tfColors =
+      OutlinedTextFieldDefaults.colors(
+          focusedBorderColor = outline,
+          unfocusedBorderColor = outline,
+          disabledBorderColor = outline,
+          errorBorderColor = outline)
+
+  Row(verticalAlignment = Alignment.CenterVertically) {
+    Text(
+        "Space N°${index + 1}",
+        style = MaterialTheme.typography.titleMedium,
+        modifier = Modifier.width(SpaceLabelWidth))
+
+    OutlinedTextField(
+        value = space.seats.toString(),
+        onValueChange = { raw ->
+          val clean = raw.filter { it.isDigit() }
+          onChange(space.copy(seats = clean.toIntOrNull() ?: 0))
+        },
+        singleLine = true,
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+        textStyle = LocalTextStyle.current.copy(textAlign = TextAlign.Center),
+        colors = tfColors,
+        modifier = Modifier.width(FieldBoxWidth))
+
+    Spacer(Modifier.width(ColumnsGap))
+
+    OutlinedTextField(
+        value = space.costPerHour.toString().removeSuffix(".0"),
+        onValueChange = { raw ->
+          val cleaned =
+              raw.replace(',', '.').filterIndexed { i, c ->
+                c.isDigit() || (c == '.' && raw.replace(',', '.').indexOf('.') == i)
+              }
+          onChange(space.copy(costPerHour = cleaned.toDoubleOrNull() ?: 0.0))
+        },
+        singleLine = true,
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+        textStyle = LocalTextStyle.current.copy(textAlign = TextAlign.Center),
+        colors = tfColors,
+        modifier = Modifier.width(FieldBoxWidth))
+
+    Spacer(Modifier.weight(1f))
+
+    IconButton(onClick = onDelete) {
+      Icon(
+          Icons.Filled.Delete,
+          contentDescription = "Remove space",
+          tint = MaterialTheme.colorScheme.error)
+    }
+  }
+}
+
+/** Isolated row preview so you can tweak integer/double inputs quickly. */
+@Preview(name = "Space Row – inputs", showBackground = true, widthDp = 390)
+@Composable
+private fun Preview_SpaceRow() {
+  MaterialTheme {
+    Surface {
+      Column(Modifier.padding(16.dp)) {
+        SpaceRow(
+            index = 0, space = Space(seats = 4, costPerHour = 8.5), onChange = {}, onDelete = {})
+        Spacer(Modifier.height(12.dp))
+        SpaceRow(
+            index = 1, space = Space(seats = 10, costPerHour = 15.0), onChange = {}, onDelete = {})
+      }
+    }
+  }
+}

--- a/app/src/main/java/com/github/meeplemeet/ui/components/SpaceRenterComponents.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/SpaceRenterComponents.kt
@@ -1,3 +1,6 @@
+// This file was initially done by hand and
+// then improved and refactored using ChatGPT-5 Extend Thinking
+// Docstrings were generated using copilot from Android studio
 package com.github.meeplemeet.ui.components
 
 import androidx.compose.foundation.layout.*

--- a/app/src/main/java/com/github/meeplemeet/ui/components/SpaceRenterComponents.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/SpaceRenterComponents.kt
@@ -180,14 +180,10 @@ private fun handleDecimalFocusChange(
  * Section with required info fields for a space renter: name, email, phone, link, address.
  *
  * @param spaceRenter The space renter being edited, or null if creating a new one.
- * @param spaceName The current value of the space name field.
  * @param onSpaceName Callback when the space name changes.
- * @param email The current value of the email field.
  * @param onEmail Callback when the email changes.
- * @param phone The current value of the phone field.
  * @param onPhone Callback when the phone changes.
- * @param link The current value of the link field.
- * @param onLink Callback when the link changes.
+ * @param onLink Callback when the website/link changes.
  * @param onPickLocation Callback when a location is picked.
  * @param viewModel The SpaceRenterSearchViewModel for location searching.
  * @param owner The account of the owner of the space renter.
@@ -195,24 +191,26 @@ private fun handleDecimalFocusChange(
 @Composable
 fun SpaceRenterRequiredInfoSection(
     spaceRenter: SpaceRenter?,
-    spaceName: String,
     onSpaceName: (String) -> Unit,
-    email: String,
     onEmail: (String) -> Unit,
-    phone: String,
     onPhone: (String) -> Unit,
-    link: String,
     onLink: (String) -> Unit,
     onPickLocation: (Location) -> Unit,
     viewModel: SpaceRenterSearchViewModel,
     owner: Account
 ) {
+  // Read current values from the model
+  val nameValue = spaceRenter?.name.orEmpty()
+  val emailValue = spaceRenter?.email.orEmpty()
+  val phoneValue = spaceRenter?.phone.orEmpty()
+  val linkValue = spaceRenter?.website.orEmpty()
+
   // Name
   Box(Modifier.testTag(ShopFormTestTags.FIELD_SHOP)) {
     LabeledField(
         label = SpaceRenterUi.Strings.spaceNameField,
         placeholder = SpaceRenterUi.Strings.spaceNameField,
-        value = spaceName,
+        value = nameValue,
         onValueChange = onSpaceName)
   }
 
@@ -221,11 +219,11 @@ fun SpaceRenterRequiredInfoSection(
     LabeledField(
         label = ShopFormUi.Strings.EMAIL_LABEL,
         placeholder = ShopFormUi.Strings.EMAIL_PLACEHOLDER,
-        value = email,
+        value = emailValue,
         onValueChange = onEmail,
         keyboardType = KeyboardType.Email)
   }
-  val showEmailError = email.isNotEmpty() && !isValidEmail(email)
+  val showEmailError = emailValue.isNotEmpty() && !isValidEmail(emailValue)
   if (showEmailError) {
     Text(
         SpaceRenterUi.Strings.validEmailMsg,
@@ -238,17 +236,17 @@ fun SpaceRenterRequiredInfoSection(
     LabeledField(
         label = ShopFormUi.Strings.PHONE_LABEL,
         placeholder = ShopFormUi.Strings.PHONE_PLACEHOLDER,
-        value = phone,
+        value = phoneValue,
         onValueChange = onPhone,
         keyboardType = KeyboardType.Phone)
   }
 
-  // Link
+  // Link / Website
   Box(Modifier.testTag(ShopFormTestTags.FIELD_LINK)) {
     LabeledField(
         label = ShopFormUi.Strings.LINK_LABEL,
         placeholder = ShopFormUi.Strings.LINK_PLACEHOLDER,
-        value = link,
+        value = linkValue,
         onValueChange = onLink,
         keyboardType = KeyboardType.Uri)
   }

--- a/app/src/main/java/com/github/meeplemeet/ui/components/SpaceRenterComponents.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/SpaceRenterComponents.kt
@@ -338,7 +338,7 @@ fun SpaceRow(
                       val normalized = priceText.trimEnd('.')
                       val parsed = normalized.toDoubleOrNull() ?: 0.0
                       val clamped = if (parsed < 0.0) 0.0 else parsed
-                      val display = if (normalized.isBlank()) "0" else normalized
+                      val display = normalized.ifBlank { "0" }
                       if (priceText != display) priceText = display
                       if (space.costPerHour != clamped) {
                         onChange(space.copy(costPerHour = clamped))

--- a/app/src/main/java/com/github/meeplemeet/ui/components/SpaceRenterComponents.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/SpaceRenterComponents.kt
@@ -25,9 +25,6 @@ import com.github.meeplemeet.model.space_renter.SpaceRenterSearchViewModel
 import com.github.meeplemeet.ui.sessions.SessionTestTags
 import kotlin.math.max
 
-// TODO: only allow >= 1 seats and >= 0 prices
-// TODO: allow decimal prices
-
 /* ================================================================================================
  * Test tags
  * ================================================================================================ */
@@ -195,7 +192,11 @@ fun SpaceRow(
     isEditing: Boolean = false
 ) {
   // Outline opacity: 1f when editing, 0.3f otherwise
-  val outline = MaterialTheme.colorScheme.onSurface.copy(alpha = if (isEditing) 1f else 0.3f)
+  val outline =
+      MaterialTheme.colorScheme.onSurface.copy(
+          alpha =
+              if (isEditing) SpaceRenterUi.Styles.editingBorderAlpha
+              else SpaceRenterUi.Styles.readonlyBorderAlpha)
   val tfColors =
       OutlinedTextFieldDefaults.colors(
           focusedBorderColor = outline,

--- a/app/src/main/java/com/github/meeplemeet/ui/navigation/NavigationSystem.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/navigation/NavigationSystem.kt
@@ -143,7 +143,8 @@ enum class MeepleMeetScreen(
   Post("Post"),
   ShopDetails("Shop Details"),
   CreateShop("Create Shop"),
-  EditShop("Edit Shop")
+  EditShop("Edit Shop"),
+  CreateSpaceRenter("Create Space Renter"),
 }
 
 /**

--- a/app/src/main/java/com/github/meeplemeet/ui/space_renter/CreateSpaceRenterScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/space_renter/CreateSpaceRenterScreen.kt
@@ -63,6 +63,11 @@ object AddSpaceRenterUi {
     const val ERROR_VALIDATION = "Validation error"
     const val ERROR_CREATE = "Failed to create space renter"
   }
+
+  object Numbers {
+    const val MIN_SEATS_PER_SPACE = 1
+    const val MIN_COST_PER_HOUR = 0.0
+  }
 }
 
 /* ================================================================================================
@@ -168,7 +173,11 @@ internal fun AddSpaceRenterContent(
   }
 
   fun addSpace() {
-    spaces = spaces + Space(seats = 1, costPerHour = 0.0)
+    spaces =
+        spaces +
+            Space(
+                seats = AddSpaceRenterUi.Numbers.MIN_SEATS_PER_SPACE,
+                costPerHour = AddSpaceRenterUi.Numbers.MIN_COST_PER_HOUR)
   }
 
   val draftRenter =

--- a/app/src/main/java/com/github/meeplemeet/ui/space_renter/CreateSpaceRenterScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/space_renter/CreateSpaceRenterScreen.kt
@@ -135,7 +135,14 @@ internal fun AddSpaceRenterContent(
   val hasOpeningHours by remember(week) { derivedStateOf { week.any { it.hours.isNotEmpty() } } }
   val hasAtLeastOneSpace by remember(spaces) { derivedStateOf { spaces.isNotEmpty() } }
   val allSpacesValid by
-      remember(spaces) { derivedStateOf { spaces.all { it.seats >= 1 && it.costPerHour >= 0.0 } } }
+      remember(spaces) {
+        derivedStateOf {
+          spaces.all {
+            it.seats >= AddSpaceRenterUi.Numbers.MIN_SEATS_PER_SPACE &&
+                it.costPerHour >= AddSpaceRenterUi.Numbers.MIN_COST_PER_HOUR
+          }
+        }
+      }
 
   val hasLocation by
       remember(locationUi.selectedLocation) {

--- a/app/src/main/java/com/github/meeplemeet/ui/space_renter/CreateSpaceRenterScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/space_renter/CreateSpaceRenterScreen.kt
@@ -127,6 +127,7 @@ internal fun AddSpaceRenterContent(
   var showHoursDialog by remember { mutableStateOf(false) }
 
   var spaces by remember { mutableStateOf(listOf<Space>()) }
+  var spacesExpanded by rememberSaveable { mutableStateOf(false) }
 
   val hasOpeningHours by remember(week) { derivedStateOf { week.any { it.hours.isNotEmpty() } } }
   val hasAtLeastOneSpace by remember(spaces) { derivedStateOf { spaces.isNotEmpty() } }
@@ -169,6 +170,7 @@ internal fun AddSpaceRenterContent(
     editingDay = null
     showHoursDialog = false
     spaces = emptyList()
+    spacesExpanded = false
     onBack()
   }
 
@@ -178,6 +180,7 @@ internal fun AddSpaceRenterContent(
             Space(
                 seats = AddSpaceRenterUi.Numbers.MIN_SEATS_PER_SPACE,
                 costPerHour = AddSpaceRenterUi.Numbers.MIN_COST_PER_HOUR)
+    spacesExpanded = true
   }
 
   val draftRenter =
@@ -188,7 +191,7 @@ internal fun AddSpaceRenterContent(
           phone = phone,
           email = email,
           website = link,
-          address = locationUi.selectedLocation ?: Location(name = locationUi.locationQuery),
+          address = locationUi.selectedLocation ?: Location(),
           openingHours = week,
           spaces = spaces)
 
@@ -278,6 +281,8 @@ internal fun AddSpaceRenterContent(
                 CollapsibleSection(
                     title = AddSpaceRenterUi.Strings.SECTION_SPACES,
                     initiallyExpanded = false,
+                    expanded = spacesExpanded,
+                    onExpandedChange = { spacesExpanded = it },
                     header = {
                       TextButton(
                           onClick = { addSpace() },

--- a/app/src/main/java/com/github/meeplemeet/ui/space_renter/CreateSpaceRenterScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/space_renter/CreateSpaceRenterScreen.kt
@@ -301,11 +301,9 @@ internal fun AddSpaceRenterContent(
                       SpacesList(
                           spaces = spaces,
                           onChange = { idx, updated ->
-                            spaces = spaces.toMutableList().also { it[idx] = updated }
+                            spaces = spaces.mapIndexed { i, sp -> if (i == idx) updated else sp }
                           },
-                          onDelete = { idx ->
-                            spaces = spaces.toMutableList().also { it.removeAt(idx) }
-                          },
+                          onDelete = { idx -> spaces = spaces.filterIndexed { i, _ -> i != idx } },
                       )
                     },
                     testTag = CreateSpaceRenterScreenTestTags.SECTION_SPACES)

--- a/app/src/main/java/com/github/meeplemeet/ui/space_renter/CreateSpaceRenterScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/space_renter/CreateSpaceRenterScreen.kt
@@ -1,0 +1,1 @@
+package com.github.meeplemeet.ui.space_renter

--- a/app/src/main/java/com/github/meeplemeet/ui/space_renter/CreateSpaceRenterScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/space_renter/CreateSpaceRenterScreen.kt
@@ -1,3 +1,6 @@
+// This file was initially done by hand and
+// then improved and refactored using ChatGPT-5 Extend Thinking
+// Docstrings were generated using copilot from Android studio
 package com.github.meeplemeet.ui.space_renter
 
 import androidx.compose.foundation.layout.*


### PR DESCRIPTION
**Description**
This PR introduces the space renter components and space renter creation screen that lets users create their own space renter
It introduces the following features:
* UI to input the required informations for space renters (space renter name, email, location, phone number and website link)
* UI to see the actual opening hours
* Collapsible sections
* Discard and Create buttons in bottom bar

**Visuals**
<video controls playsinline muted
       src="https://github.com/user-attachments/assets/516f9a62-311e-42b7-aaf0-57710df754ed">

**Testing**
* Number of tests: 10
* Running time: ~1min30 seconds (locally)
* Line coverage: ~90%

<img width="2554" height="922" alt="Coverage  CreateSpaceRenterScreen_JacocoReport" src="https://github.com/user-attachments/assets/dea28bba-1437-49f4-a736-04d602962fc2" />

<img width="2516" height="348" alt="Coverage  SpaceRenterComponents_JacocoReport" src="https://github.com/user-attachments/assets/77e0c523-6182-4a71-8338-4a077d44dd48" />


**References**
* Issues: [[https://github.com/Meeple-Meet/Meeple-Meet/issues/84 and https://github.com/Meeple-Meet/Meeple-Meet/issues/86](https://github.com/Meeple-Meet/Meeple-Meet/issues/97)](https://github.com/Meeple-Meet/Meeple-Meet/issues/97)

**TODOS**
* Integrate it in the app (waiting for the necessary screens to be integrated first)