### PR TITLE
Feat(ui): Implemented the SpaceRenterScreen

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/ui/SpaceRenterDetailsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/SpaceRenterDetailsScreenTest.kt
@@ -1,0 +1,169 @@
+package com.github.meeplemeet.ui
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.github.meeplemeet.model.auth.Account
+import com.github.meeplemeet.model.shared.location.Location
+import com.github.meeplemeet.model.shops.OpeningHours
+import com.github.meeplemeet.model.shops.TimeSlot
+import com.github.meeplemeet.model.space_renter.Space
+import com.github.meeplemeet.model.space_renter.SpaceRenter
+import com.github.meeplemeet.model.space_renter.SpaceRenterViewModel
+import com.github.meeplemeet.ui.components.SpaceRenterComponentsTestTags
+import com.github.meeplemeet.ui.navigation.NavigationTestTags
+import com.github.meeplemeet.ui.space_renter.SpaceRenterScreen
+import com.github.meeplemeet.ui.space_renter.SpaceRenterTestTags
+import com.github.meeplemeet.ui.theme.AppTheme
+import com.github.meeplemeet.ui.theme.ThemeMode
+import com.github.meeplemeet.utils.FirestoreTests
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import junit.framework.TestCase.assertTrue
+
+class SpaceRenterDetailsScreenTest : FirestoreTests() {
+
+    @get:Rule val compose = createComposeRule()
+
+    private lateinit var vm: SpaceRenterViewModel
+    private lateinit var renter: SpaceRenter
+    private lateinit var currentUser: Account
+    private lateinit var owner: Account
+
+    private val report = linkedMapOf<String, Boolean>()
+
+    private var theme by mutableStateOf(ThemeMode.LIGHT)
+
+    /* ------- semantic helpers ------- */
+    private fun title() = compose.onNodeWithText(renter.name)
+
+    private fun phoneText() = compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_PHONE_TEXT)
+    private fun emailText() = compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_EMAIL_TEXT)
+    private fun addressText() = compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_ADDRESS_TEXT)
+    private fun websiteText() = compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_WEBSITE_TEXT)
+
+    private fun phoneBtn() = compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_PHONE_BUTTON)
+    private fun emailBtn() = compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_EMAIL_BUTTON)
+    private fun addressBtn() = compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_ADDRESS_BUTTON)
+    private fun websiteBtn() = compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_WEBSITE_BUTTON)
+
+    private fun dayTag(day: Int) = SpaceRenterTestTags.SPACE_RENTER_DAY_PREFIX + day
+    private fun spaceRow(i: Int) = SpaceRenterComponentsTestTags.SPACE_ROW_PREFIX + i
+
+    /* -------------------------------- */
+
+    val address = Location(0.0, 0.0, "123 Meeple St, Boardgame City")
+
+    val dummyOpeningHours =
+        listOf(
+            OpeningHours(0, listOf(TimeSlot("09:00", "18:00"), TimeSlot("19:00", "21:00"))),
+            OpeningHours(1, listOf(TimeSlot("09:00", "18:00"))),
+            OpeningHours(2, listOf(TimeSlot("09:00", "18:00"))),
+            OpeningHours(3, listOf(TimeSlot("09:00", "18:00"))),
+            OpeningHours(4, listOf(TimeSlot("09:00", "18:00"))),
+            OpeningHours(5, listOf(TimeSlot("10:00", "16:00"))),
+            OpeningHours(6, emptyList()))
+
+    private val dummySpaces =
+        listOf(Space(4, 10.0), Space(8, 20.0))
+
+    @Before
+    fun setup() = runBlocking {
+        vm = SpaceRenterViewModel()
+
+        currentUser = accountRepository.createAccount("user_${now()}", "Alice", "alice@test.com", null)
+        owner = accountRepository.createAccount("owner_${now()}", "Owner", "owner@test.com", null)
+
+        val created =
+            spaceRenterRepository.createSpaceRenter(
+                owner,
+                "Meeple Spaces",
+                "555-123-0000",
+                "spaces@meeple.com",
+                "www.meeplespaces.com",
+                address,
+                dummyOpeningHours,
+                dummySpaces)
+
+        renter = spaceRenterRepository.getSpaceRenter(created.id)
+        currentUser = accountRepository.getAccount(currentUser.uid)
+        owner = accountRepository.getAccount(owner.uid)
+    }
+
+    @Test
+    fun full_smoke_all_cases() {
+        val clipboard = FakeClipboardManager()
+
+        compose.setContent {
+            CompositionLocalProvider(LocalClipboardManager provides clipboard) {
+                AppTheme(themeMode = theme) {
+                    SpaceRenterScreen(
+                        spaceId = renter.id, account = currentUser, viewModel = vm, onBack = {}, onEdit = {})
+                }
+            }
+        }
+
+        compose.waitUntil(timeoutMillis = 5000) { vm.spaceRenter.value != null }
+
+        checkpoint("Title visible") { title().assertExists() }
+
+        checkpoint("Phone text") { phoneText().assertTextEquals("- Phone: ${renter.phone}") }
+        checkpoint("Email text") { emailText().assertTextEquals("- Email: ${renter.email}") }
+        checkpoint("Address text") { addressText().assertTextEquals("- Address: ${renter.address.name}") }
+        checkpoint("Website text") { websiteText().assertTextEquals("- Website: ${renter.website}") }
+
+        listOf(
+            phoneBtn() to "- Phone: ${renter.phone}",
+            emailBtn() to "- Email: ${renter.email}",
+            addressBtn() to "- Address: ${renter.address.name}",
+            websiteBtn() to "- Website: ${renter.website}").forEach { (btn, expected) ->
+            checkpoint("Copy via ${btn}") {
+                btn.performClick()
+                assert(clipboard.copiedText == expected)
+            }
+        }
+
+        dummyOpeningHours.forEach { entry ->
+            val tag = dayTag(entry.day)
+            checkpoint("Day label exists: $tag") { compose.onNodeWithTag(tag).assertExists() }
+        }
+
+        dummySpaces.forEachIndexed { i, sp ->
+            val row = spaceRow(i)
+            checkpoint("Space row exists: $row") { compose.onNodeWithTag(row).assertExists() }
+        }
+
+        val failed = report.filterValues { !it }.keys
+        println("Smoke: ${report.size - failed.size}/${report.size} OK" +
+                (if (failed.isNotEmpty()) " → $failed" else ""))
+        assertTrue("Failures: $failed", failed.isEmpty())
+    }
+
+    @Test
+    fun edit_button_visible_for_owner() {
+        var fired = false
+
+        compose.setContent {
+            SpaceRenterScreen(
+                spaceId = renter.id, account = owner, viewModel = vm, onEdit = { fired = true })
+        }
+
+        compose.waitUntil(timeoutMillis = 5000) { vm.spaceRenter.value != null }
+
+        compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_EDIT_BUTTON).assertExists().performClick()
+        assert(fired)
+    }
+
+    /* ------ helper ------ */
+    private inline fun checkpoint(name: String, block: () -> Unit) {
+        runCatching { block() }.onSuccess { report[name] = true }.onFailure { report[name] = false }
+    }
+
+    private fun now() = System.currentTimeMillis().toString()
+}

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/SpaceRenterDetailsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/SpaceRenterDetailsScreenTest.kt
@@ -1,9 +1,9 @@
 package com.github.meeplemeet.ui
 
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -15,155 +15,167 @@ import com.github.meeplemeet.model.space_renter.Space
 import com.github.meeplemeet.model.space_renter.SpaceRenter
 import com.github.meeplemeet.model.space_renter.SpaceRenterViewModel
 import com.github.meeplemeet.ui.components.SpaceRenterComponentsTestTags
-import com.github.meeplemeet.ui.navigation.NavigationTestTags
 import com.github.meeplemeet.ui.space_renter.SpaceRenterScreen
 import com.github.meeplemeet.ui.space_renter.SpaceRenterTestTags
 import com.github.meeplemeet.ui.theme.AppTheme
 import com.github.meeplemeet.ui.theme.ThemeMode
 import com.github.meeplemeet.utils.FirestoreTests
+import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import junit.framework.TestCase.assertTrue
 
 class SpaceRenterDetailsScreenTest : FirestoreTests() {
 
-    @get:Rule val compose = createComposeRule()
+  @get:Rule val compose = createComposeRule()
 
-    private lateinit var vm: SpaceRenterViewModel
-    private lateinit var renter: SpaceRenter
-    private lateinit var currentUser: Account
-    private lateinit var owner: Account
+  private lateinit var vm: SpaceRenterViewModel
+  private lateinit var renter: SpaceRenter
+  private lateinit var currentUser: Account
+  private lateinit var owner: Account
 
-    private val report = linkedMapOf<String, Boolean>()
+  private val report = linkedMapOf<String, Boolean>()
 
-    private var theme by mutableStateOf(ThemeMode.LIGHT)
+  private var theme by mutableStateOf(ThemeMode.LIGHT)
 
-    /* ------- semantic helpers ------- */
-    private fun title() = compose.onNodeWithText(renter.name)
+  /* ------- semantic helpers ------- */
+  private fun title() = compose.onNodeWithText(renter.name)
 
-    private fun phoneText() = compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_PHONE_TEXT)
-    private fun emailText() = compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_EMAIL_TEXT)
-    private fun addressText() = compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_ADDRESS_TEXT)
-    private fun websiteText() = compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_WEBSITE_TEXT)
+  private fun phoneText() = compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_PHONE_TEXT)
 
-    private fun phoneBtn() = compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_PHONE_BUTTON)
-    private fun emailBtn() = compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_EMAIL_BUTTON)
-    private fun addressBtn() = compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_ADDRESS_BUTTON)
-    private fun websiteBtn() = compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_WEBSITE_BUTTON)
+  private fun emailText() = compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_EMAIL_TEXT)
 
-    private fun dayTag(day: Int) = SpaceRenterTestTags.SPACE_RENTER_DAY_PREFIX + day
-    private fun spaceRow(i: Int) = SpaceRenterComponentsTestTags.SPACE_ROW_PREFIX + i
+  private fun addressText() = compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_ADDRESS_TEXT)
 
-    /* -------------------------------- */
+  private fun websiteText() = compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_WEBSITE_TEXT)
 
-    val address = Location(0.0, 0.0, "123 Meeple St, Boardgame City")
+  private fun phoneBtn() = compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_PHONE_BUTTON)
 
-    val dummyOpeningHours =
-        listOf(
-            OpeningHours(0, listOf(TimeSlot("09:00", "18:00"), TimeSlot("19:00", "21:00"))),
-            OpeningHours(1, listOf(TimeSlot("09:00", "18:00"))),
-            OpeningHours(2, listOf(TimeSlot("09:00", "18:00"))),
-            OpeningHours(3, listOf(TimeSlot("09:00", "18:00"))),
-            OpeningHours(4, listOf(TimeSlot("09:00", "18:00"))),
-            OpeningHours(5, listOf(TimeSlot("10:00", "16:00"))),
-            OpeningHours(6, emptyList()))
+  private fun emailBtn() = compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_EMAIL_BUTTON)
 
-    private val dummySpaces =
-        listOf(Space(4, 10.0), Space(8, 20.0))
+  private fun addressBtn() = compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_ADDRESS_BUTTON)
 
-    @Before
-    fun setup() = runBlocking {
-        vm = SpaceRenterViewModel()
+  private fun websiteBtn() = compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_WEBSITE_BUTTON)
 
-        currentUser = accountRepository.createAccount("user_${now()}", "Alice", "alice@test.com", null)
-        owner = accountRepository.createAccount("owner_${now()}", "Owner", "owner@test.com", null)
+  private fun dayTag(day: Int) = SpaceRenterTestTags.SPACE_RENTER_DAY_PREFIX + day
 
-        val created =
-            spaceRenterRepository.createSpaceRenter(
-                owner,
-                "Meeple Spaces",
-                "555-123-0000",
-                "spaces@meeple.com",
-                "www.meeplespaces.com",
-                address,
-                dummyOpeningHours,
-                dummySpaces)
+  private fun spaceRow(i: Int) = SpaceRenterComponentsTestTags.SPACE_ROW_PREFIX + i
 
-        renter = spaceRenterRepository.getSpaceRenter(created.id)
-        currentUser = accountRepository.getAccount(currentUser.uid)
-        owner = accountRepository.getAccount(owner.uid)
+  /* -------------------------------- */
+
+  val address = Location(0.0, 0.0, "123 Meeple St, Boardgame City")
+
+  val dummyOpeningHours =
+      listOf(
+          OpeningHours(0, listOf(TimeSlot("09:00", "18:00"), TimeSlot("19:00", "21:00"))),
+          OpeningHours(1, listOf(TimeSlot("09:00", "18:00"))),
+          OpeningHours(2, listOf(TimeSlot("09:00", "18:00"))),
+          OpeningHours(3, listOf(TimeSlot("09:00", "18:00"))),
+          OpeningHours(4, listOf(TimeSlot("09:00", "18:00"))),
+          OpeningHours(5, listOf(TimeSlot("10:00", "16:00"))),
+          OpeningHours(6, emptyList()))
+
+  private val dummySpaces = listOf(Space(4, 10.0), Space(8, 20.0))
+
+  @Before
+  fun setup() = runBlocking {
+    vm = SpaceRenterViewModel()
+
+    currentUser = accountRepository.createAccount("user_${now()}", "Alice", "alice@test.com", null)
+    owner = accountRepository.createAccount("owner_${now()}", "Owner", "owner@test.com", null)
+
+    val created =
+        spaceRenterRepository.createSpaceRenter(
+            owner,
+            "Meeple Spaces",
+            "555-123-0000",
+            "spaces@meeple.com",
+            "www.meeplespaces.com",
+            address,
+            dummyOpeningHours,
+            dummySpaces)
+
+    renter = spaceRenterRepository.getSpaceRenter(created.id)
+    currentUser = accountRepository.getAccount(currentUser.uid)
+    owner = accountRepository.getAccount(owner.uid)
+  }
+
+  @Test
+  fun full_smoke_all_cases() {
+    val clipboard = FakeClipboardManager()
+
+    compose.setContent {
+      CompositionLocalProvider(LocalClipboardManager provides clipboard) {
+        AppTheme(themeMode = theme) {
+          SpaceRenterScreen(
+              spaceId = renter.id, account = currentUser, viewModel = vm, onBack = {}, onEdit = {})
+        }
+      }
     }
 
-    @Test
-    fun full_smoke_all_cases() {
-        val clipboard = FakeClipboardManager()
+    compose.waitUntil(timeoutMillis = 5000) { vm.spaceRenter.value != null }
 
-        compose.setContent {
-            CompositionLocalProvider(LocalClipboardManager provides clipboard) {
-                AppTheme(themeMode = theme) {
-                    SpaceRenterScreen(
-                        spaceId = renter.id, account = currentUser, viewModel = vm, onBack = {}, onEdit = {})
-                }
-            }
-        }
+    checkpoint("Title visible") { title().assertExists() }
 
-        compose.waitUntil(timeoutMillis = 5000) { vm.spaceRenter.value != null }
+    checkpoint("Phone text") { phoneText().assertTextEquals("- Phone: ${renter.phone}") }
+    checkpoint("Email text") { emailText().assertTextEquals("- Email: ${renter.email}") }
+    checkpoint("Address text") {
+      addressText().assertTextEquals("- Address: ${renter.address.name}")
+    }
+    checkpoint("Website text") { websiteText().assertTextEquals("- Website: ${renter.website}") }
 
-        checkpoint("Title visible") { title().assertExists() }
-
-        checkpoint("Phone text") { phoneText().assertTextEquals("- Phone: ${renter.phone}") }
-        checkpoint("Email text") { emailText().assertTextEquals("- Email: ${renter.email}") }
-        checkpoint("Address text") { addressText().assertTextEquals("- Address: ${renter.address.name}") }
-        checkpoint("Website text") { websiteText().assertTextEquals("- Website: ${renter.website}") }
-
-        listOf(
+    listOf(
             phoneBtn() to "- Phone: ${renter.phone}",
             emailBtn() to "- Email: ${renter.email}",
             addressBtn() to "- Address: ${renter.address.name}",
-            websiteBtn() to "- Website: ${renter.website}").forEach { (btn, expected) ->
-            checkpoint("Copy via ${btn}") {
-                btn.performClick()
-                assert(clipboard.copiedText == expected)
-            }
+            websiteBtn() to "- Website: ${renter.website}")
+        .forEach { (btn, expected) ->
+          checkpoint("Copy via ${btn}") {
+            btn.performClick()
+            assert(clipboard.copiedText == expected)
+          }
         }
 
-        dummyOpeningHours.forEach { entry ->
-            val tag = dayTag(entry.day)
-            checkpoint("Day label exists: $tag") { compose.onNodeWithTag(tag).assertExists() }
-        }
-
-        dummySpaces.forEachIndexed { i, sp ->
-            val row = spaceRow(i)
-            checkpoint("Space row exists: $row") { compose.onNodeWithTag(row).assertExists() }
-        }
-
-        val failed = report.filterValues { !it }.keys
-        println("Smoke: ${report.size - failed.size}/${report.size} OK" +
-                (if (failed.isNotEmpty()) " → $failed" else ""))
-        assertTrue("Failures: $failed", failed.isEmpty())
+    dummyOpeningHours.forEach { entry ->
+      val tag = dayTag(entry.day)
+      checkpoint("Day label exists: $tag") { compose.onNodeWithTag(tag).assertExists() }
     }
 
-    @Test
-    fun edit_button_visible_for_owner() {
-        var fired = false
-
-        compose.setContent {
-            SpaceRenterScreen(
-                spaceId = renter.id, account = owner, viewModel = vm, onEdit = { fired = true })
-        }
-
-        compose.waitUntil(timeoutMillis = 5000) { vm.spaceRenter.value != null }
-
-        compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_EDIT_BUTTON).assertExists().performClick()
-        assert(fired)
+    dummySpaces.forEachIndexed { i, sp ->
+      val row = spaceRow(i)
+      checkpoint("Space row exists: $row") { compose.onNodeWithTag(row).assertExists() }
     }
 
-    /* ------ helper ------ */
-    private inline fun checkpoint(name: String, block: () -> Unit) {
-        runCatching { block() }.onSuccess { report[name] = true }.onFailure { report[name] = false }
+    val failed = report.filterValues { !it }.keys
+    println(
+        "Smoke: ${report.size - failed.size}/${report.size} OK" +
+            (if (failed.isNotEmpty()) " → $failed" else ""))
+    assertTrue("Failures: $failed", failed.isEmpty())
+  }
+
+  @Test
+  fun edit_button_visible_for_owner() {
+    var fired = false
+
+    compose.setContent {
+      SpaceRenterScreen(
+          spaceId = renter.id, account = owner, viewModel = vm, onEdit = { fired = true })
     }
 
-    private fun now() = System.currentTimeMillis().toString()
+    compose.waitUntil(timeoutMillis = 5000) { vm.spaceRenter.value != null }
+
+    compose
+        .onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_EDIT_BUTTON)
+        .assertExists()
+        .performClick()
+    assert(fired)
+  }
+
+  /* ------ helper ------ */
+  private inline fun checkpoint(name: String, block: () -> Unit) {
+    runCatching { block() }.onSuccess { report[name] = true }.onFailure { report[name] = false }
+  }
+
+  private fun now() = System.currentTimeMillis().toString()
 }

--- a/app/src/main/java/com/github/meeplemeet/MainActivity.kt
+++ b/app/src/main/java/com/github/meeplemeet/MainActivity.kt
@@ -335,7 +335,7 @@ fun MeepleMeetApp(
       MapScreen(
           navigation = navigationActions,
           account = account!!,
-          onFABCLick = { navigationActions.navigateTo(MeepleMeetScreen.CreateShop) },
+          onFABCLick = { navigationActions.navigateTo(MeepleMeetScreen.CreateSpaceRenter) },
           onRedirect = { geoPin ->
             when (geoPin.type) {
               PinType.SHOP -> {

--- a/app/src/main/java/com/github/meeplemeet/MainActivity.kt
+++ b/app/src/main/java/com/github/meeplemeet/MainActivity.kt
@@ -41,6 +41,7 @@ import com.github.meeplemeet.model.shared.location.LocationRepository
 import com.github.meeplemeet.model.shared.location.NominatimLocationRepository
 import com.github.meeplemeet.model.shops.Shop
 import com.github.meeplemeet.model.shops.ShopRepository
+import com.github.meeplemeet.model.space_renter.SpaceRenter
 import com.github.meeplemeet.model.space_renter.SpaceRenterRepository
 import com.github.meeplemeet.ui.MapScreen
 import com.github.meeplemeet.ui.auth.CreateAccountScreen
@@ -63,6 +64,7 @@ import com.github.meeplemeet.ui.shops.CreateShopScreen
 import com.github.meeplemeet.ui.shops.ShopDetailsScreen
 import com.github.meeplemeet.ui.shops.ShopScreen
 import com.github.meeplemeet.ui.space_renter.CreateSpaceRenterScreen
+import com.github.meeplemeet.ui.space_renter.SpaceRenterScreen
 import com.github.meeplemeet.ui.theme.AppTheme
 import com.google.firebase.Firebase
 import com.google.firebase.auth.FirebaseAuth
@@ -176,6 +178,9 @@ fun MeepleMeetApp(
   var postId by remember { mutableStateOf("") }
   var shopId by remember { mutableStateOf("") }
   var shop by remember { mutableStateOf<Shop?>(null) }
+
+  var spaceId by remember { mutableStateOf("") }
+  var spaceRenter by remember { mutableStateOf<SpaceRenter?>(null) }
 
   DisposableEffect(Unit) {
     val listener = FirebaseAuth.AuthStateListener { accountId = it.currentUser?.uid ?: "" }
@@ -338,8 +343,8 @@ fun MeepleMeetApp(
                 navigationActions.navigateTo(MeepleMeetScreen.ShopDetails)
               }
               PinType.SPACE -> {
-                // spaceId = geoPin.uid
-                // navigationActions.navigateTo(MeepleMeetScreen.SpaceDetails)
+                spaceId = geoPin.uid
+                navigationActions.navigateTo(MeepleMeetScreen.SpaceDetails)
               }
               PinType.SESSION -> {
                 discussionId = geoPin.uid
@@ -360,6 +365,7 @@ fun MeepleMeetApp(
             })
       } ?: navigationActions.navigateTo(MeepleMeetScreen.SignIn)
     }
+
     composable(MeepleMeetScreen.ShopDetails.name) {
       if (shopId.isNotEmpty()) {
         ShopScreen(
@@ -374,12 +380,14 @@ fun MeepleMeetApp(
         LoadingScreen()
       }
     }
+
     composable(MeepleMeetScreen.CreateShop.name) {
       CreateShopScreen(
           owner = account!!,
           onBack = { navigationActions.goBack() },
           onCreated = { navigationActions.navigateTo(MeepleMeetScreen.Map) })
     }
+
     composable(MeepleMeetScreen.EditShop.name) {
       if (shop != null) {
         ShopDetailsScreen(
@@ -396,6 +404,22 @@ fun MeepleMeetApp(
           owner = account!!,
           onBack = { navigationActions.goBack() },
           onCreated = { navigationActions.goBack() /* TODO */ })
+    }
+
+    composable(MeepleMeetScreen.SpaceDetails.name) {
+      if (spaceId.isNotEmpty()) {
+        SpaceRenterScreen(
+            account = account!!,
+            spaceId = spaceId,
+            onBack = { navigationActions.goBack() },
+            onEdit = {
+              spaceRenter = it
+              //              navigationActions.navigateTo(MeepleMeetScreen.EditSpaceRenter, popUpTo
+              // = false) /* TODO: uncomment once EditSpaceRenter is implemented */
+            })
+      } else {
+        LoadingScreen()
+      }
     }
   }
 }

--- a/app/src/main/java/com/github/meeplemeet/MainActivity.kt
+++ b/app/src/main/java/com/github/meeplemeet/MainActivity.kt
@@ -335,7 +335,7 @@ fun MeepleMeetApp(
       MapScreen(
           navigation = navigationActions,
           account = account!!,
-          onFABCLick = { navigationActions.navigateTo(MeepleMeetScreen.CreateSpaceRenter) },
+          onFABCLick = { navigationActions.navigateTo(MeepleMeetScreen.CreateShop) },
           onRedirect = { geoPin ->
             when (geoPin.type) {
               PinType.SHOP -> {

--- a/app/src/main/java/com/github/meeplemeet/ui/navigation/NavigationSystem.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/navigation/NavigationSystem.kt
@@ -145,6 +145,7 @@ enum class MeepleMeetScreen(
   CreateShop("Create Shop"),
   EditShop("Edit Shop"),
   CreateSpaceRenter("Create Space Renter"),
+  SpaceDetails("Space Renter Details"),
 }
 
 /**

--- a/app/src/main/java/com/github/meeplemeet/ui/space_renter/SpaceRenterScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/space_renter/SpaceRenterScreen.kt
@@ -1,0 +1,287 @@
+// AI was used to help comment this screen
+package com.github.meeplemeet.ui.space_renter
+
+import android.widget.Toast
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.ClipboardManager
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextIndent
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.github.meeplemeet.model.auth.Account
+import com.github.meeplemeet.model.shops.OpeningHours
+import com.github.meeplemeet.model.space_renter.SpaceRenter
+import com.github.meeplemeet.model.space_renter.SpaceRenterViewModel
+import com.github.meeplemeet.ui.components.SpacesList
+import com.github.meeplemeet.ui.components.TopBarWithDivider
+import com.github.meeplemeet.ui.theme.AppColors
+import java.text.DateFormatSymbols
+import java.util.Calendar
+
+/** Object containing test tags used in the Space Renter screen UI for UI testing purposes. */
+object SpaceRenterTestTags {
+  // Contact section tags
+  const val SPACE_RENTER_PHONE_TEXT = "SPACE_RENTER_TEXT"
+  const val SPACE_RENTER_PHONE_BUTTON = "SPACE_RENTER_PHONE_BUTTON"
+  const val SPACE_RENTER_EMAIL_TEXT = "SPACE_RENTER_EMAIL_TEXT"
+  const val SPACE_RENTER_EMAIL_BUTTON = "SPACE_RENTER_EMAIL_BUTTON"
+  const val SPACE_RENTER_ADDRESS_TEXT = "SPACE_RENTER_ADDRESS_TEXT"
+  const val SPACE_RENTER_ADDRESS_BUTTON = "SPACE_RENTER_ADDRESS_BUTTON"
+  const val SPACE_RENTER_WEBSITE_TEXT = "SPACE_RENTER_WEBSITE_TEXT"
+  const val SPACE_RENTER_WEBSITE_BUTTON = "SPACE_RENTER_WEBSITE_BUTTON"
+  const val SPACE_RENTER_EDIT_BUTTON = "EDIT_SPACE_BUTTON"
+
+  // Availability section tags
+  const val SPACE_RENTER_DAY_PREFIX = "SPACE_RENTER_DAY_"
+}
+
+/**
+ * Composable that displays the Space Renter screen, including the top bar and Space Renter details.
+ *
+ * @param spaceId The ID of the Space Renter to display.
+ * @param account The current user account.
+ * @param viewModel The ViewModel providing space renter data.
+ * @param onBack Callback invoked when the back button is pressed.
+ * @param onEdit Callback invoked when the edit button is pressed.
+ */
+@Composable
+fun SpaceRenterScreen(
+    spaceId: String,
+    account: Account,
+    viewModel: SpaceRenterViewModel = viewModel(),
+    onBack: () -> Unit = {},
+    onEdit: (SpaceRenter?) -> Unit = {},
+) {
+  // Collect the current space renter state from the ViewModel
+  val spaceState by viewModel.spaceRenter.collectAsStateWithLifecycle()
+  // Trigger loading of space renter data when spaceId changes
+  LaunchedEffect(spaceId) { viewModel.getSpaceRenter(spaceId) }
+
+  Scaffold(
+      topBar = {
+        TopBarWithDivider(
+            text = spaceState?.name ?: "Space Renter",
+            onReturn = { onBack() },
+            trailingIcons = {
+              // Show edit button only if current account is the space renter owner
+              if (account == (spaceState?.owner ?: false)) {
+                IconButton(
+                    onClick = { onEdit(spaceState) },
+                    modifier = Modifier.testTag(SpaceRenterTestTags.SPACE_RENTER_EDIT_BUTTON)) {
+                      Icon(Icons.Default.Edit, contentDescription = "Edit")
+                    }
+              }
+            })
+      }) { innerPadding ->
+        // Show space renter details if loaded, otherwise show a loading indicator
+        spaceState?.let { space ->
+          SpaceRenterDetails(
+              spaceRenter = space,
+              modifier = Modifier.padding(innerPadding).padding(16.dp).fillMaxSize())
+        }
+            ?: Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+              CircularProgressIndicator()
+            }
+      }
+}
+
+/**
+ * Composable that displays detailed information about a space renter, including contact info,
+ * availability, and game list.
+ *
+ * @param spaceRenter The space renter data to display.
+ * @param modifier Modifier to be applied to the layout.
+ */
+@Composable
+fun SpaceRenterDetails(spaceRenter: SpaceRenter, modifier: Modifier = Modifier) {
+  Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(24.dp)) {
+    ContactSection(spaceRenter)
+    HorizontalDivider(modifier = Modifier.fillMaxWidth().padding(horizontal = 100.dp))
+    AvailabilitySection(spaceRenter.openingHours)
+    HorizontalDivider(modifier = Modifier.fillMaxWidth().padding(horizontal = 100.dp))
+    Column(
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 30.dp)) {
+          Text(
+              "Available spaces",
+              style = MaterialTheme.typography.titleLarge,
+              fontWeight = FontWeight.SemiBold)
+
+          SpacesList(
+              spaces = spaceRenter.spaces,
+              modifier = Modifier.fillMaxWidth(),
+              onChange = { _, _ -> },
+              onDelete = {},
+              isEditing = false,
+          )
+        }
+  }
+}
+
+// -------------------- CONTACT SECTION --------------------
+
+/**
+ * Composable that displays the contact information section of the space renter.
+ *
+ * @param spaceRenter The space renter whose contact information is displayed.
+ */
+@Composable
+fun ContactSection(spaceRenter: SpaceRenter) {
+  Column(
+      verticalArrangement = Arrangement.spacedBy(8.dp),
+      modifier = Modifier.fillMaxWidth().padding(horizontal = 25.dp)) {
+        Text(
+            "Contact",
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.SemiBold)
+
+        // Display phone contact row
+        ContactRow(
+            Icons.Default.Phone,
+            "- Phone: ${spaceRenter.phone}",
+            SpaceRenterTestTags.SPACE_RENTER_PHONE_TEXT,
+            SpaceRenterTestTags.SPACE_RENTER_PHONE_BUTTON)
+
+        // Display email contact row
+        ContactRow(
+            Icons.Default.Email,
+            "- Email: ${spaceRenter.email}",
+            SpaceRenterTestTags.SPACE_RENTER_EMAIL_TEXT,
+            SpaceRenterTestTags.SPACE_RENTER_EMAIL_BUTTON)
+
+        // Display address contact row
+        ContactRow(
+            Icons.Default.Place,
+            "- Address: ${spaceRenter.address.name}",
+            SpaceRenterTestTags.SPACE_RENTER_ADDRESS_TEXT,
+            SpaceRenterTestTags.SPACE_RENTER_ADDRESS_BUTTON)
+
+        // Display website contact row
+        ContactRow(
+            Icons.Default.Language,
+            "- Website: ${spaceRenter.website}",
+            SpaceRenterTestTags.SPACE_RENTER_WEBSITE_TEXT,
+            SpaceRenterTestTags.SPACE_RENTER_WEBSITE_BUTTON)
+      }
+}
+
+/**
+ * Composable that displays a single row of contact information with an icon, text, and a button to
+ * copy the text to the clipboard.
+ *
+ * @param icon The icon to display for the contact method.
+ * @param text The contact text to display and copy.
+ * @param textTag The test tag for the text element.
+ * @param buttonTag The test tag for the copy button.
+ */
+@Composable
+fun ContactRow(icon: ImageVector, text: String, textTag: String, buttonTag: String) {
+  val clipboardManager: ClipboardManager = LocalClipboardManager.current
+  val context = LocalContext.current
+  Row(
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.spacedBy(8.dp),
+      modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp)) {
+        Text(
+            text,
+            style = LocalTextStyle.current.copy(textIndent = TextIndent(restLine = 8.sp)),
+            modifier = Modifier.weight(1f).testTag(textTag))
+        IconButton(
+            onClick = {
+              // Copy the contact text to the clipboard and show a toast confirmation
+              clipboardManager.setText(AnnotatedString(text))
+              Toast.makeText(context, "Copied to clipboard", Toast.LENGTH_SHORT).show()
+            },
+            content = { Icon(icon, contentDescription = null, tint = AppColors.neutral) },
+            modifier = Modifier.size(24.dp).testTag(buttonTag))
+      }
+}
+
+// -------------------- AVAILABILITY SECTION --------------------
+
+/**
+ * Composable that displays the space renter's opening hours for each day of the week.
+ *
+ * @param openingHours List of OpeningHours representing the space renter's weekly schedule.
+ */
+@Composable
+fun AvailabilitySection(openingHours: List<OpeningHours>) {
+  val daysOfWeek = remember { DateFormatSymbols().weekdays }
+  val currentDay = Calendar.getInstance().get(Calendar.DAY_OF_WEEK)
+  Column(
+      verticalArrangement = Arrangement.spacedBy(8.dp),
+      modifier = Modifier.fillMaxWidth().padding(horizontal = 25.dp)) {
+        Text(
+            "Availability",
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.SemiBold)
+
+        // Loop through each day's opening hours
+        openingHours.forEach { entry ->
+          // Get the day name from the weekdays array (offset by 1 because weekdays start at 1)
+          val dayName = daysOfWeek.getOrNull(entry.day + 1) ?: "Unknown"
+          // Check if this day is the current day to highlight it
+          val isToday = (entry.day + 1) == currentDay
+
+          if (entry.hours.isEmpty()) {
+            // No opening hours means the space renter is closed on this day
+            Row(
+                modifier =
+                    Modifier.fillMaxWidth()
+                        .testTag("${SpaceRenterTestTags.SPACE_RENTER_DAY_PREFIX}${entry.day}"),
+                horizontalArrangement = Arrangement.SpaceBetween) {
+                  Text(
+                      dayName,
+                      fontWeight = if (isToday) FontWeight.Bold else FontWeight.Normal,
+                      modifier = Modifier.weight(1f))
+                  Text(
+                      "Closed",
+                      fontWeight = if (isToday) FontWeight.Bold else FontWeight.Normal,
+                      modifier =
+                          Modifier.testTag(
+                              "${SpaceRenterTestTags.SPACE_RENTER_DAY_PREFIX}${entry.day}_HOURS"))
+                }
+          } else {
+            // Display each time interval for the day
+            entry.hours.forEachIndexed { idx, (start, end) ->
+              Row(
+                  modifier =
+                      Modifier.fillMaxWidth()
+                          .testTag(
+                              "${SpaceRenterTestTags.SPACE_RENTER_DAY_PREFIX}${entry.day}_HOURS_${idx}"),
+                  horizontalArrangement = Arrangement.SpaceBetween) {
+                    if (idx == 0) {
+                      // Show the day name only on the first interval row
+                      Text(
+                          dayName,
+                          fontWeight = if (isToday) FontWeight.Bold else FontWeight.Normal,
+                          modifier =
+                              Modifier.weight(1f)
+                                  .testTag(
+                                      "${SpaceRenterTestTags.SPACE_RENTER_DAY_PREFIX}${entry.day}"))
+                    } else {
+                      // Empty space for subsequent interval rows to align with day name column
+                      Text("", modifier = Modifier.weight(1f))
+                    }
+                    // Format the time interval or show "Closed" if times are null
+                    val timeText = if (start != null && end != null) "$start - $end" else "Closed"
+                    Text(timeText, fontWeight = if (isToday) FontWeight.Bold else FontWeight.Normal)
+                  }
+            }
+          }
+        }
+      }
+}

--- a/app/src/main/java/com/github/meeplemeet/ui/space_renter/SpaceRenterScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/space_renter/SpaceRenterScreen.kt
@@ -29,7 +29,6 @@ import com.github.meeplemeet.model.shops.OpeningHours
 import com.github.meeplemeet.model.space_renter.SpaceRenter
 import com.github.meeplemeet.model.space_renter.SpaceRenterViewModel
 import com.github.meeplemeet.ui.components.SpacesList
-import com.github.meeplemeet.ui.components.TopBarWithDivider
 import com.github.meeplemeet.ui.components.humanize
 import com.github.meeplemeet.ui.theme.AppColors
 import java.text.DateFormatSymbols
@@ -76,7 +75,7 @@ fun SpaceRenterScreen(
 
   Scaffold(
       topBar = {
-        TopBarWithDivider(
+        TopBarAndDivider(
             text = spaceState?.name ?: "Space Renter",
             onReturn = { onBack() },
             trailingIcons = {
@@ -273,4 +272,46 @@ fun AvailabilitySection(openingHours: List<OpeningHours>) {
                   }
             }
       }
+}
+
+@Composable
+fun TopBarAndDivider(
+    text: String,
+    onReturn: () -> Unit,
+    trailingIcons: @Composable (() -> Unit)? = null
+) {
+  Column {
+    Box(modifier = Modifier.fillMaxWidth().padding(vertical = 12.dp)) {
+
+      // Left icon area (fixed width)
+      Row(
+          modifier = Modifier.align(Alignment.CenterStart).width(48.dp),
+          verticalAlignment = Alignment.CenterVertically) {
+            IconButton(onClick = onReturn) {
+              Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+            }
+          }
+
+      // Center Title, constrained so it NEVER touches icons
+      Text(
+          text = text,
+          style = MaterialTheme.typography.titleLarge,
+          maxLines = Int.MAX_VALUE, // Allows vertical expansion when text is long
+          modifier =
+              Modifier.align(Alignment.Center)
+                  .padding(horizontal = 48.dp) // <-- Critical fix
+                  .fillMaxWidth(),
+          textAlign = TextAlign.Center)
+
+      // Right icon area (fixed width)
+      Row(
+          modifier = Modifier.align(Alignment.CenterEnd).width(48.dp),
+          horizontalArrangement = Arrangement.End,
+          verticalAlignment = Alignment.CenterVertically) {
+            trailingIcons?.invoke()
+          }
+    }
+
+    HorizontalDivider(modifier = Modifier.fillMaxWidth().padding(horizontal = 100.dp))
+  }
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/space_renter/SpaceRenterScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/space_renter/SpaceRenterScreen.kt
@@ -79,7 +79,7 @@ fun SpaceRenterScreen(
             text = spaceState?.name ?: "Space Renter",
             onReturn = { onBack() },
             trailingIcons = {
-              // Show edit button only if current account is the space renter owner
+              // Edit button should only show if current account is the space renter owner
               if (account.uid == (spaceState?.owner?.uid)) {
                 IconButton(
                     onClick = { onEdit(spaceState) },
@@ -274,6 +274,14 @@ fun AvailabilitySection(openingHours: List<OpeningHours>) {
       }
 }
 
+/**
+ * Composable that replaces material3's TopBarWithDivider The main difference is the text is now
+ * centered horizontally and can expand vertically if needed
+ *
+ * @param text The title's text to display in the top bar.
+ * @param onReturn Callback function for the back button is pressed.
+ * @param trailingIcons Optional composable for an additional trailing icon (to the right)
+ */
 @Composable
 fun TopBarAndDivider(
     text: String,
@@ -282,8 +290,7 @@ fun TopBarAndDivider(
 ) {
   Column {
     Box(modifier = Modifier.fillMaxWidth().padding(vertical = 12.dp)) {
-
-      // Left icon area (fixed width)
+      // Button to the left
       Row(
           modifier = Modifier.align(Alignment.CenterStart).width(48.dp),
           verticalAlignment = Alignment.CenterVertically) {
@@ -292,18 +299,15 @@ fun TopBarAndDivider(
             }
           }
 
-      // Center Title, constrained so it NEVER touches icons
       Text(
           text = text,
           style = MaterialTheme.typography.titleLarge,
-          maxLines = Int.MAX_VALUE, // Allows vertical expansion when text is long
-          modifier =
-              Modifier.align(Alignment.Center)
-                  .padding(horizontal = 48.dp) // <-- Critical fix
-                  .fillMaxWidth(),
+          maxLines =
+              Int.MAX_VALUE, // Allows vertical expansion when text is too to fit horizontally
+          modifier = Modifier.align(Alignment.Center).padding(horizontal = 48.dp).fillMaxWidth(),
           textAlign = TextAlign.Center)
 
-      // Right icon area (fixed width)
+      // (Optional) Button to the right
       Row(
           modifier = Modifier.align(Alignment.CenterEnd).width(48.dp),
           horizontalArrangement = Arrangement.End,

--- a/app/src/main/java/com/github/meeplemeet/ui/space_renter/SpaceRenterScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/space_renter/SpaceRenterScreen.kt
@@ -189,8 +189,8 @@ fun ContactSection(spaceRenter: SpaceRenter) {
 }
 
 /**
- * Composable that displays a single row of contact information with an icon, text, and a button to
- * copy the text to the clipboard.
+ * Composable displaying a row of contact info. This includes an clickable icon, and information
+ * about the spaceRenter The clickable icons currently only copy the text to the clipboard.
  *
  * @param icon The icon to display for the contact method.
  * @param text The contact text to display and copy.
@@ -201,6 +201,15 @@ fun ContactSection(spaceRenter: SpaceRenter) {
 fun ContactRow(icon: ImageVector, text: String, textTag: String, buttonTag: String) {
   val clipboardManager: ClipboardManager = LocalClipboardManager.current
   val context = LocalContext.current
+
+  val copyToClipboard =
+      remember(text) {
+        {
+          clipboardManager.setText(AnnotatedString(text))
+          Toast.makeText(context, "Copied to clipboard", Toast.LENGTH_SHORT).show()
+        }
+      }
+
   Row(
       verticalAlignment = Alignment.CenterVertically,
       horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -209,14 +218,10 @@ fun ContactRow(icon: ImageVector, text: String, textTag: String, buttonTag: Stri
             text,
             style = LocalTextStyle.current.copy(textIndent = TextIndent(restLine = 8.sp)),
             modifier = Modifier.weight(1f).testTag(textTag))
-        IconButton(
-            onClick = {
-              // Copy the contact text to the clipboard and show a toast confirmation
-              clipboardManager.setText(AnnotatedString(text))
-              Toast.makeText(context, "Copied to clipboard", Toast.LENGTH_SHORT).show()
-            },
-            content = { Icon(icon, contentDescription = null, tint = AppColors.neutral) },
-            modifier = Modifier.size(24.dp).testTag(buttonTag))
+
+        IconButton(onClick = copyToClipboard, modifier = Modifier.size(24.dp).testTag(buttonTag)) {
+          Icon(imageVector = icon, contentDescription = null, tint = AppColors.neutral)
+        }
       }
 }
 


### PR DESCRIPTION
This PR introduces the **SpaceRenterScreen** to the app, allowing users to view detailed information about a space renter. This includes the following:
- Contact Information: email, phone, website/informative link and their location.
- Availability, a 7 day schedule showing the availability of rentable spaces.
- Available rentable spaces, showing the number of seats available and their price.

### Additional Details
- The screen is tested and locally (with jacoco) achieves 80%+ coverage.
- Documentation is available for all of the UI components.

### Known Limitations
- The `edit` button does not navigate to the `EditSpaceRenterScreen` as it is not yet merged into main.
<img width="400" height="750" alt="studio64_P4griW6uQN" src="https://github.com/user-attachments/assets/3d89d092-c811-4c30-bcd6-0d9ad10bb3a4" />

<img width="400" height="750" alt="studio64_GUnNPG0rkZ" src="https://github.com/user-attachments/assets/ffed602d-a60b-4b1a-bd2f-3080a6ef5102" />

https://i.imgur.com/oWkYqIF.gif

