### PR TITLE
Feat/space renter edit screen

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/ui/EditSpaceRenterScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/EditSpaceRenterScreenTest.kt
@@ -1,0 +1,213 @@
+package com.github.meeplemeet.ui
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.meeplemeet.model.auth.Account
+import com.github.meeplemeet.model.shared.location.Location
+import com.github.meeplemeet.model.shops.OpeningHours
+import com.github.meeplemeet.model.shops.TimeSlot
+import com.github.meeplemeet.model.space_renter.EditSpaceRenterViewModel
+import com.github.meeplemeet.model.space_renter.Space
+import com.github.meeplemeet.model.space_renter.SpaceRenter
+import com.github.meeplemeet.ui.components.ShopComponentsTestTags
+import com.github.meeplemeet.ui.components.ShopFormTestTags
+import com.github.meeplemeet.ui.space_renter.EditSpaceRenterScreen
+import com.github.meeplemeet.ui.space_renter.EditSpaceRenterScreenTestTags
+import com.github.meeplemeet.ui.theme.AppTheme
+import com.github.meeplemeet.utils.FirestoreTests
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.tasks.await
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class EditSpaceRenterScreenTest : FirestoreTests() {
+
+  private lateinit var vm: EditSpaceRenterViewModel
+  private lateinit var renter: SpaceRenter
+  private lateinit var owner: Account
+  val testOpeningHours =
+      listOf(
+          OpeningHours(day = 0, hours = emptyList()),
+          OpeningHours(day = 1, hours = listOf(TimeSlot("09:00", "18:00"))),
+          OpeningHours(day = 2, hours = listOf(TimeSlot("09:00", "18:00"))),
+          OpeningHours(day = 3, hours = listOf(TimeSlot("09:00", "18:00"))),
+          OpeningHours(day = 4, hours = listOf(TimeSlot("09:00", "20:00"))),
+          OpeningHours(day = 5, hours = listOf(TimeSlot("09:00", "20:00"))),
+          OpeningHours(day = 6, hours = listOf(TimeSlot("10:00", "16:00"))))
+  val testLocation =
+      Location(latitude = 46.5197, longitude = 6.6323, name = "EPFL Campus, Lausanne")
+
+  @Before
+  fun setup() {
+    runBlocking {
+      vm = EditSpaceRenterViewModel()
+      owner =
+          accountRepository.createAccount(
+              name = "owner1", userHandle = "@owner", email = "owner@example.com", photoUrl = null)
+      renter =
+          SpaceRenter(
+              owner = owner,
+              name = "Test Space Renter",
+              phone = "12345678",
+              email = "owner@example.com",
+              website = "https://example.com",
+              address = testLocation,
+              openingHours = testOpeningHours,
+              spaces = listOf(Space(seats = 10, costPerHour = 15.0)),
+              id = "renter1")
+      val noUid = com.github.meeplemeet.model.space_renter.toNoUid(renter)
+      db.collection("space_renters").document(renter.id).set(noUid).await()
+      renter = spaceRenterRepository.getSpaceRenter(renter.id)
+    }
+  }
+
+  @get:Rule val compose = createComposeRule()
+
+  private fun ComposeTestRule.onTag(tag: String) = onNodeWithTag(tag, useUnmergedTree = true)
+
+  private fun ComposeTestRule.onTags(tag: String) = onAllNodesWithTag(tag, useUnmergedTree = true)
+
+  private fun scrollListToTag(tag: String) {
+    try {
+      compose.onTag(EditSpaceRenterScreenTestTags.LIST).performScrollToNode(hasTestTag(tag))
+      compose.waitForIdle()
+    } catch (e: AssertionError) {
+      // Ignore: node may already be visible or not present inside the lazy list
+    }
+  }
+
+  private fun ensureSectionExpanded(sectionBaseTag: String) {
+    val toggleTag = sectionBaseTag + "_toggle"
+    val contentTag = sectionBaseTag + "_content"
+
+    scrollListToTag(toggleTag)
+    compose.waitForIdle()
+
+    val isExpanded = compose.onTags(contentTag).fetchSemanticsNodes().isNotEmpty()
+    if (!isExpanded) {
+      compose.onTag(toggleTag).assertExists().performClick()
+      compose.waitForIdle()
+    }
+
+    scrollListToTag(contentTag)
+    compose.waitForIdle()
+  }
+
+  private fun spaceRowTag(index: Int) = "space_row_$index"
+
+  private fun seatsFieldTag(index: Int) = spaceRowTag(index) + "_seats"
+
+  private fun priceFieldTag(index: Int) = spaceRowTag(index) + "_price"
+
+  private fun deleteButtonTag(index: Int) = spaceRowTag(index) + "_delete"
+
+  @Test
+  fun screen_prefills_data_and_allows_editing() {
+    var backCalled = false
+    val vm = EditSpaceRenterViewModel()
+
+    compose.setContent {
+      AppTheme {
+        EditSpaceRenterScreen(
+            spaceRenter = renter,
+            owner = owner,
+            onBack = { backCalled = true },
+            onUpdated = {},
+            viewModel = vm)
+      }
+    }
+
+    Thread.sleep(10000) // Wait for Compose to settle
+
+    // Top & list exist
+    compose.onTag(EditSpaceRenterScreenTestTags.SCAFFOLD).assertExists()
+    compose.onTag(EditSpaceRenterScreenTestTags.TOPBAR).assertExists()
+    compose.onTag(EditSpaceRenterScreenTestTags.TITLE).assertExists()
+    compose.onTag(EditSpaceRenterScreenTestTags.LIST).assertExists()
+
+    // Check that initial fields are prefilled
+    ensureSectionExpanded(EditSpaceRenterScreenTestTags.SECTION_REQUIRED)
+    compose.onNodeWithText(renter.name).assertExists()
+    compose.onNodeWithText(renter.email).assertExists()
+    compose.onNodeWithText(renter.phone).assertExists()
+    compose.onNodeWithText(renter.website).assertExists()
+
+    // Check that spaces are prefilled
+    ensureSectionExpanded(EditSpaceRenterScreenTestTags.SECTION_SPACES)
+    compose.onTag(spaceRowTag(0)).assertExists()
+    compose.onTag(seatsFieldTag(0)).assertTextEquals("10")
+    compose.onTag(priceFieldTag(0)).assertTextEquals("15")
+
+    // Edit space values
+    compose.onTag(seatsFieldTag(0)).performTextClearance()
+    compose.onTag(seatsFieldTag(0)).performTextInput("12")
+    compose.onTag(priceFieldTag(0)).performTextClearance()
+    compose.onTag(priceFieldTag(0)).performTextInput("18.5")
+    compose.waitForIdle()
+    compose.onTag(seatsFieldTag(0)).assertTextEquals("12")
+    compose.onTag(priceFieldTag(0)).assertTextEquals("18.5")
+
+    // Discard updates
+    compose.onTag(EditSpaceRenterScreenTestTags.NAV_BACK).performClick()
+    assertTrue(backCalled)
+  }
+
+  /** Returns the LabeledField INPUT inside the given wrapper (FIELD_* tag). */
+  private fun inputIn(wrapperTag: String) =
+      compose.onNode(
+          hasTestTag(ShopComponentsTestTags.LABELED_FIELD_INPUT) and
+              hasAnyAncestor(hasTestTag(wrapperTag)),
+          useUnmergedTree = true)
+
+  @Test
+  fun screen_saves_on_update() {
+    var updatedCalled = false
+    val vm = EditSpaceRenterViewModel()
+
+    // Make the renter valid by putting one non-empty OpeningHours entry (one TimeSlot).
+    val validRenter =
+        renter.copy(
+            openingHours =
+                renter.openingHours.mapIndexed { idx, oh ->
+                  if (idx == 0)
+                      oh.copy(
+                          hours =
+                              listOf(
+                                  com.github.meeplemeet.model.shops.TimeSlot(
+                                      open = "16:00", close = "20:00")))
+                  else oh
+                })
+
+    compose.setContent {
+      AppTheme {
+        EditSpaceRenterScreen(
+            spaceRenter = validRenter,
+            owner = owner,
+            onBack = {},
+            onUpdated = { updatedCalled = true },
+            viewModel = vm)
+      }
+    }
+
+    // Make a change to enable the save button
+    ensureSectionExpanded(EditSpaceRenterScreenTestTags.SECTION_REQUIRED)
+
+    val nameEditable = inputIn(ShopFormTestTags.FIELD_SHOP)
+    nameEditable.assertExists()
+    nameEditable.performTextClearance()
+    nameEditable.performTextInput("Updated Space Name")
+    compose.waitForIdle()
+
+    // Save updates
+    compose.onTag(ShopComponentsTestTags.ACTION_SAVE).performClick()
+    compose.waitForIdle()
+
+    assertTrue(updatedCalled)
+  }
+}

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/EditSpaceRenterScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/EditSpaceRenterScreenTest.kt
@@ -123,8 +123,6 @@ class EditSpaceRenterScreenTest : FirestoreTests() {
       }
     }
 
-    Thread.sleep(10000) // Wait for Compose to settle
-
     // Top & list exist
     compose.onTag(EditSpaceRenterScreenTestTags.SCAFFOLD).assertExists()
     compose.onTag(EditSpaceRenterScreenTestTags.TOPBAR).assertExists()

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/EditSpaceRenterScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/EditSpaceRenterScreenTest.kt
@@ -186,7 +186,8 @@ class EditSpaceRenterScreenTest : FirestoreTests() {
             spaceRenter = validRenter,
             owner = owner,
             onBack = {},
-            onUpdated = { updatedCalled = true },)
+            onUpdated = { updatedCalled = true },
+        )
       }
     }
 

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/EditSpaceRenterScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/EditSpaceRenterScreenTest.kt
@@ -110,7 +110,6 @@ class EditSpaceRenterScreenTest : FirestoreTests() {
   @Test
   fun screen_prefills_data_and_allows_editing() {
     var backCalled = false
-    val vm = EditSpaceRenterViewModel()
 
     compose.setContent {
       AppTheme {
@@ -166,7 +165,6 @@ class EditSpaceRenterScreenTest : FirestoreTests() {
   @Test
   fun screen_saves_on_update() {
     var updatedCalled = false
-    val vm = EditSpaceRenterViewModel()
 
     // Make the renter valid by putting one non-empty OpeningHours entry (one TimeSlot).
     val validRenter =
@@ -188,8 +186,7 @@ class EditSpaceRenterScreenTest : FirestoreTests() {
             spaceRenter = validRenter,
             owner = owner,
             onBack = {},
-            onUpdated = { updatedCalled = true },
-            viewModel = vm)
+            onUpdated = { updatedCalled = true },)
       }
     }
 

--- a/app/src/main/java/com/github/meeplemeet/MainActivity.kt
+++ b/app/src/main/java/com/github/meeplemeet/MainActivity.kt
@@ -419,7 +419,7 @@ fun MeepleMeetApp(
       CreateSpaceRenterScreen(
           owner = account!!,
           onBack = { navigationActions.goBack() },
-          onCreated = { navigationActions.goBack()})
+          onCreated = { navigationActions.goBack() })
     }
 
     composable(MeepleMeetScreen.SpaceDetails.name) {
@@ -430,9 +430,7 @@ fun MeepleMeetApp(
             onBack = { navigationActions.goBack() },
             onEdit = {
               spaceRenter = it
-              navigationActions.navigateTo(
-                  MeepleMeetScreen.EditSpaceRenter,
-                  popUpTo = false)
+              navigationActions.navigateTo(MeepleMeetScreen.EditSpaceRenter, popUpTo = false)
             })
       } else {
         LoadingScreen()

--- a/app/src/main/java/com/github/meeplemeet/MainActivity.kt
+++ b/app/src/main/java/com/github/meeplemeet/MainActivity.kt
@@ -64,6 +64,7 @@ import com.github.meeplemeet.ui.shops.CreateShopScreen
 import com.github.meeplemeet.ui.shops.ShopDetailsScreen
 import com.github.meeplemeet.ui.shops.ShopScreen
 import com.github.meeplemeet.ui.space_renter.CreateSpaceRenterScreen
+import com.github.meeplemeet.ui.space_renter.EditSpaceRenterScreen
 import com.github.meeplemeet.ui.space_renter.SpaceRenterScreen
 import com.github.meeplemeet.ui.theme.AppTheme
 import com.google.android.gms.maps.MapsInitializer
@@ -418,7 +419,7 @@ fun MeepleMeetApp(
       CreateSpaceRenterScreen(
           owner = account!!,
           onBack = { navigationActions.goBack() },
-          onCreated = { navigationActions.goBack() /* TODO */ })
+          onCreated = { navigationActions.goBack()})
     }
 
     composable(MeepleMeetScreen.SpaceDetails.name) {
@@ -429,9 +430,21 @@ fun MeepleMeetApp(
             onBack = { navigationActions.goBack() },
             onEdit = {
               spaceRenter = it
-              //              navigationActions.navigateTo(MeepleMeetScreen.EditSpaceRenter, popUpTo
-              // = false) /* TODO: uncomment once EditSpaceRenter is implemented */
+              navigationActions.navigateTo(
+                  MeepleMeetScreen.EditSpaceRenter,
+                  popUpTo = false)
             })
+      } else {
+        LoadingScreen()
+      }
+    }
+    composable(MeepleMeetScreen.EditSpaceRenter.name) {
+      if (spaceRenter != null) {
+        EditSpaceRenterScreen(
+            owner = account!!,
+            spaceRenter = spaceRenter!!,
+            onBack = { navigationActions.goBack() },
+            onUpdated = { navigationActions.goBack() })
       } else {
         LoadingScreen()
       }

--- a/app/src/main/java/com/github/meeplemeet/ui/components/SpaceRenterComponents.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/SpaceRenterComponents.kt
@@ -345,6 +345,7 @@ fun SpaceRow(
     SeatsField(
         seats = space.seats,
         tfColors = tfColors,
+        isEditing = isEditing,
         fieldTag = rowTagBase + SpaceRenterComponentsTestTags.SPACE_ROW_SEATS_FIELD_SUFFIX,
         onCommit = { v -> if (v != space.seats) onChange(space.copy(seats = v)) })
 
@@ -353,6 +354,7 @@ fun SpaceRow(
     PriceField(
         price = space.costPerHour,
         tfColors = tfColors,
+        isEditing = isEditing,
         fieldTag = rowTagBase + SpaceRenterComponentsTestTags.SPACE_ROW_PRICE_FIELD_SUFFIX,
         onCommit = { v -> if (v != space.costPerHour) onChange(space.copy(costPerHour = v)) })
 
@@ -394,6 +396,7 @@ private fun SpaceNumberLabel(index: Int, rowTagBase: String) {
 private fun SeatsField(
     seats: Int,
     tfColors: TextFieldColors,
+    isEditing: Boolean,
     fieldTag: String,
     onCommit: (Int) -> Unit
 ) {
@@ -401,6 +404,7 @@ private fun SeatsField(
 
   OutlinedTextField(
       value = seatsText,
+      enabled = isEditing,
       onValueChange = { raw ->
         val digits = sanitizePositiveIntInput(raw)
         seatsText = digits
@@ -441,6 +445,7 @@ private fun PriceField(
     price: Double,
     tfColors: TextFieldColors,
     fieldTag: String,
+    isEditing: Boolean,
     onCommit: (Double) -> Unit
 ) {
   var priceText by
@@ -450,6 +455,7 @@ private fun PriceField(
 
   OutlinedTextField(
       value = priceText,
+      enabled = isEditing,
       onValueChange = { raw ->
         val filtered = sanitizeDecimalInput(raw)
         priceText = filtered

--- a/app/src/main/java/com/github/meeplemeet/ui/navigation/NavigationSystem.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/navigation/NavigationSystem.kt
@@ -146,6 +146,7 @@ enum class MeepleMeetScreen(
   EditShop("Edit Shop"),
   CreateSpaceRenter("Create Space Renter"),
   SpaceDetails("Space Renter Details"),
+  EditSpaceRenter("Edit Space Renter"),
 }
 
 /**

--- a/app/src/main/java/com/github/meeplemeet/ui/space_renter/EditSpaceRenterScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/space_renter/EditSpaceRenterScreen.kt
@@ -24,6 +24,10 @@ import kotlinx.coroutines.launch
 /* ================================================================================================
  * Test tags
  * ================================================================================================ */
+/**
+ * Contains test tag constants used for identifying UI components in tests
+ * for the Edit Space Renter screen.
+ */
 object EditSpaceRenterScreenTestTags {
   const val SCAFFOLD = "edit_space_renter_scaffold"
   const val TOPBAR = "edit_space_renter_topbar"
@@ -46,6 +50,9 @@ object EditSpaceRenterScreenTestTags {
 /* ================================================================================================
  * UI defaults
  * ================================================================================================ */
+/**
+ * Holds UI-related constants such as string resources used in the Edit Space Renter screen.
+ */
 object EditSpaceRenterUi {
   object Strings {
     const val SCREEN_TITLE = "Edit Space Renter"
@@ -62,6 +69,18 @@ object EditSpaceRenterUi {
 /* ================================================================================================
  * Screen
  * ================================================================================================ */
+/**
+ * Main entry point for the Edit Space Renter screen.
+ *
+ * Displays a screen allowing a space renter to edit their information,
+ * including required info, availability, and available spaces.
+ *
+ * @param spaceRenter The initial [SpaceRenter] data being edited.
+ * @param owner The [Account] of the current owner editing the space renter.
+ * @param onBack Callback invoked when the user navigates back.
+ * @param onUpdated Callback invoked when the renter update completes successfully.
+ * @param viewModel The [EditSpaceRenterViewModel] handling logic and state for this screen.
+ */
 @Composable
 fun EditSpaceRenterScreen(
     spaceRenter: SpaceRenter,
@@ -72,6 +91,8 @@ fun EditSpaceRenterScreen(
 ) {
   val locationUi by viewModel.locationUIState.collectAsState()
 
+  // Automatically initialize the selected location if not already set
+  // when the renter has an existing address.
   LaunchedEffect(spaceRenter.address) {
     if (locationUi.selectedLocation == null && spaceRenter.address != Location()) {
       viewModel.setLocation(spaceRenter.address)
@@ -103,6 +124,20 @@ fun EditSpaceRenterScreen(
 /* ================================================================================================
  * Content
  * ================================================================================================ */
+/**
+ * Core UI content for the Edit Space Renter screen.
+ *
+ * Manages UI state (form fields, dialogs, lists) and validation logic,
+ * and coordinates saving updates to the renter profile.
+ *
+ * @param owner The current [Account] editing the renter.
+ * @param initialRenter The initial state of the [SpaceRenter].
+ * @param onBack Callback for navigation back.
+ * @param onUpdated Callback after successful update.
+ * @param onUpdateSpaceRenter Suspend function performing the update operation.
+ * @param locationUi The [LocationUIState] representing current location selection.
+ * @param viewModel The [EditSpaceRenterViewModel] managing state and events.
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun EditSpaceRenterContent(
@@ -146,6 +181,7 @@ internal fun EditSpaceRenterContent(
         derivedStateOf { locationUi.selectedLocation != null }
       }
 
+  // Determines whether all required fields are filled and valid.
   val isValid by
       remember(name, email, hasLocation, hasOpeningHours, hasAtLeastOneSpace, allSpacesValid) {
         derivedStateOf {
@@ -168,6 +204,7 @@ internal fun EditSpaceRenterContent(
           openingHours = week,
           spaces = spaces)
 
+  // Adds a new default space to the list and expands the section.
   fun addSpace() {
     spaces =
         spaces +
@@ -177,6 +214,7 @@ internal fun EditSpaceRenterContent(
     spacesExpanded = true
   }
 
+  // Scaffold structure for the screen including top bar, snackbar, and main content.
   Scaffold(
       topBar = {
         CenterAlignedTopAppBar(
@@ -202,6 +240,7 @@ internal fun EditSpaceRenterContent(
         ActionBar(
             onDiscard = onBack,
             onPrimary = {
+              // Try to update the space renter and handle any validation or network errors.
               scope.launch {
                 try {
                   onUpdateSpaceRenter(draftRenter)

--- a/app/src/main/java/com/github/meeplemeet/ui/space_renter/EditSpaceRenterScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/space_renter/EditSpaceRenterScreen.kt
@@ -36,6 +36,10 @@ object EditSpaceRenterScreenTestTags {
   const val SECTION_AVAILABILITY = "edit_section_availability"
   const val SECTION_SPACES = "edit_section_spaces"
 
+  // Added for the Spaces header button and label used by tests
+  const val SPACES_ADD_BUTTON = "edit_space_renter_spaces_add_button"
+  const val SPACES_ADD_LABEL = "edit_space_renter_spaces_add_label"
+
   const val BOTTOM_SPACER = "edit_bottom_spacer"
 }
 
@@ -257,7 +261,7 @@ internal fun EditSpaceRenterContent(
               // Spaces
               item {
                 CollapsibleSection(
-                    title = AddSpaceRenterUi.Strings.SECTION_SPACES,
+                    title = EditSpaceRenterUi.Strings.SECTION_SPACES,
                     initiallyExpanded = false,
                     expanded = spacesExpanded,
                     onExpandedChange = { spacesExpanded = it },
@@ -265,14 +269,14 @@ internal fun EditSpaceRenterContent(
                       TextButton(
                           onClick = { addSpace() },
                           modifier =
-                              Modifier.testTag(CreateSpaceRenterScreenTestTags.SPACES_ADD_BUTTON)) {
+                              Modifier.testTag(EditSpaceRenterScreenTestTags.SPACES_ADD_BUTTON)) {
                             Icon(Icons.Filled.Add, contentDescription = null)
                             Spacer(Modifier.width(AddSpaceRenterUi.Dimensions.between))
                             Text(
                                 AddSpaceRenterUi.Strings.BTN_ADD_SPACE,
                                 modifier =
                                     Modifier.testTag(
-                                        CreateSpaceRenterScreenTestTags.SPACES_ADD_LABEL))
+                                        EditSpaceRenterScreenTestTags.SPACES_ADD_LABEL))
                           }
                     },
                     content = {
@@ -284,7 +288,9 @@ internal fun EditSpaceRenterContent(
                           onDelete = { idx -> spaces = spaces.filterIndexed { i, _ -> i != idx } },
                       )
                     },
-                    testTag = CreateSpaceRenterScreenTestTags.SECTION_SPACES)
+                    // Use the Edit\_... test tag so tests searching for "edit\_section\_spaces\_*"
+                    // succeed
+                    testTag = EditSpaceRenterScreenTestTags.SECTION_SPACES)
               }
 
               item {

--- a/app/src/main/java/com/github/meeplemeet/ui/space_renter/EditSpaceRenterScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/space_renter/EditSpaceRenterScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.runtime.Composable
@@ -15,6 +16,7 @@ import com.github.meeplemeet.model.auth.Account
 import com.github.meeplemeet.model.shared.LocationUIState
 import com.github.meeplemeet.model.shared.location.Location
 import com.github.meeplemeet.model.space_renter.EditSpaceRenterViewModel
+import com.github.meeplemeet.model.space_renter.Space
 import com.github.meeplemeet.model.space_renter.SpaceRenter
 import com.github.meeplemeet.ui.components.*
 import kotlinx.coroutines.launch
@@ -162,6 +164,15 @@ internal fun EditSpaceRenterContent(
           openingHours = week,
           spaces = spaces)
 
+  fun addSpace() {
+    spaces =
+        spaces +
+            Space(
+                seats = AddSpaceRenterUi.Numbers.MIN_SEATS_PER_SPACE,
+                costPerHour = AddSpaceRenterUi.Numbers.MIN_COST_PER_HOUR)
+    spacesExpanded = true
+  }
+
   Scaffold(
       topBar = {
         CenterAlignedTopAppBar(
@@ -246,19 +257,34 @@ internal fun EditSpaceRenterContent(
               // Spaces
               item {
                 CollapsibleSection(
-                    title = EditSpaceRenterUi.Strings.SECTION_SPACES,
+                    title = AddSpaceRenterUi.Strings.SECTION_SPACES,
                     initiallyExpanded = false,
                     expanded = spacesExpanded,
                     onExpandedChange = { spacesExpanded = it },
+                    header = {
+                      TextButton(
+                          onClick = { addSpace() },
+                          modifier =
+                              Modifier.testTag(CreateSpaceRenterScreenTestTags.SPACES_ADD_BUTTON)) {
+                            Icon(Icons.Filled.Add, contentDescription = null)
+                            Spacer(Modifier.width(AddSpaceRenterUi.Dimensions.between))
+                            Text(
+                                AddSpaceRenterUi.Strings.BTN_ADD_SPACE,
+                                modifier =
+                                    Modifier.testTag(
+                                        CreateSpaceRenterScreenTestTags.SPACES_ADD_LABEL))
+                          }
+                    },
                     content = {
                       SpacesList(
                           spaces = spaces,
                           onChange = { idx, updated ->
                             spaces = spaces.mapIndexed { i, sp -> if (i == idx) updated else sp }
                           },
-                          onDelete = { idx -> spaces = spaces.filterIndexed { i, _ -> i != idx } })
+                          onDelete = { idx -> spaces = spaces.filterIndexed { i, _ -> i != idx } },
+                      )
                     },
-                    testTag = EditSpaceRenterScreenTestTags.SECTION_SPACES)
+                    testTag = CreateSpaceRenterScreenTestTags.SECTION_SPACES)
               }
 
               item {

--- a/app/src/main/java/com/github/meeplemeet/ui/space_renter/EditSpaceRenterScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/space_renter/EditSpaceRenterScreen.kt
@@ -25,8 +25,8 @@ import kotlinx.coroutines.launch
  * Test tags
  * ================================================================================================ */
 /**
- * Contains test tag constants used for identifying UI components in tests
- * for the Edit Space Renter screen.
+ * Contains test tag constants used for identifying UI components in tests for the Edit Space Renter
+ * screen.
  */
 object EditSpaceRenterScreenTestTags {
   const val SCAFFOLD = "edit_space_renter_scaffold"
@@ -50,9 +50,7 @@ object EditSpaceRenterScreenTestTags {
 /* ================================================================================================
  * UI defaults
  * ================================================================================================ */
-/**
- * Holds UI-related constants such as string resources used in the Edit Space Renter screen.
- */
+/** Holds UI-related constants such as string resources used in the Edit Space Renter screen. */
 object EditSpaceRenterUi {
   object Strings {
     const val SCREEN_TITLE = "Edit Space Renter"
@@ -72,8 +70,8 @@ object EditSpaceRenterUi {
 /**
  * Main entry point for the Edit Space Renter screen.
  *
- * Displays a screen allowing a space renter to edit their information,
- * including required info, availability, and available spaces.
+ * Displays a screen allowing a space renter to edit their information, including required info,
+ * availability, and available spaces.
  *
  * @param spaceRenter The initial [SpaceRenter] data being edited.
  * @param owner The [Account] of the current owner editing the space renter.
@@ -127,8 +125,8 @@ fun EditSpaceRenterScreen(
 /**
  * Core UI content for the Edit Space Renter screen.
  *
- * Manages UI state (form fields, dialogs, lists) and validation logic,
- * and coordinates saving updates to the renter profile.
+ * Manages UI state (form fields, dialogs, lists) and validation logic, and coordinates saving
+ * updates to the renter profile.
  *
  * @param owner The current [Account] editing the renter.
  * @param initialRenter The initial state of the [SpaceRenter].

--- a/app/src/main/java/com/github/meeplemeet/ui/space_renter/EditSpaceRenterScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/space_renter/EditSpaceRenterScreen.kt
@@ -5,22 +5,15 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.*
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.runtime.Composable
-import com.github.meeplemeet.model.space_renter.Space
-import com.github.meeplemeet.ui.theme.AppTheme
-import com.github.meeplemeet.ui.theme.ThemeMode
 import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.testTag
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.meeplemeet.model.auth.Account
 import com.github.meeplemeet.model.shared.LocationUIState
 import com.github.meeplemeet.model.shared.location.Location
-import com.github.meeplemeet.model.shops.OpeningHours
-import com.github.meeplemeet.model.shops.TimeSlot
 import com.github.meeplemeet.model.space_renter.EditSpaceRenterViewModel
 import com.github.meeplemeet.model.space_renter.SpaceRenter
 import com.github.meeplemeet.ui.components.*
@@ -30,34 +23,34 @@ import kotlinx.coroutines.launch
  * Test tags
  * ================================================================================================ */
 object EditSpaceRenterScreenTestTags {
-    const val SCAFFOLD = "edit_space_renter_scaffold"
-    const val TOPBAR = "edit_space_renter_topbar"
-    const val TITLE = "edit_space_renter_title"
-    const val NAV_BACK = "edit_space_renter_nav_back"
-    const val SNACKBAR_HOST = "edit_space_renter_snackbar_host"
-    const val LIST = "edit_space_renter_list"
+  const val SCAFFOLD = "edit_space_renter_scaffold"
+  const val TOPBAR = "edit_space_renter_topbar"
+  const val TITLE = "edit_space_renter_title"
+  const val NAV_BACK = "edit_space_renter_nav_back"
+  const val SNACKBAR_HOST = "edit_space_renter_snackbar_host"
+  const val LIST = "edit_space_renter_list"
 
-    const val SECTION_REQUIRED = "edit_section_required"
-    const val SECTION_AVAILABILITY = "edit_section_availability"
-    const val SECTION_SPACES = "edit_section_spaces"
+  const val SECTION_REQUIRED = "edit_section_required"
+  const val SECTION_AVAILABILITY = "edit_section_availability"
+  const val SECTION_SPACES = "edit_section_spaces"
 
-    const val BOTTOM_SPACER = "edit_bottom_spacer"
+  const val BOTTOM_SPACER = "edit_bottom_spacer"
 }
 
 /* ================================================================================================
  * UI defaults
  * ================================================================================================ */
 object EditSpaceRenterUi {
-    object Strings {
-        const val SCREEN_TITLE = "Edit Space Renter"
-        const val REQUIREMENTS_SECTION = "Required Info"
-        const val SECTION_AVAILABILITY = "Availability"
-        const val SECTION_SPACES = "Available Spaces"
+  object Strings {
+    const val SCREEN_TITLE = "Edit Space Renter"
+    const val REQUIREMENTS_SECTION = "Required Info"
+    const val SECTION_AVAILABILITY = "Availability"
+    const val SECTION_SPACES = "Available Spaces"
 
-        const val BTN_UPDATE = "Update"
-        const val ERROR_VALIDATION = "Validation error"
-        const val ERROR_UPDATE = "Failed to update space renter"
-    }
+    const val BTN_UPDATE = "Update"
+    const val ERROR_VALIDATION = "Validation error"
+    const val ERROR_UPDATE = "Failed to update space renter"
+  }
 }
 
 /* ================================================================================================
@@ -71,36 +64,34 @@ fun EditSpaceRenterScreen(
     onUpdated: () -> Unit,
     viewModel: EditSpaceRenterViewModel = viewModel()
 ) {
-    val locationUi by viewModel.locationUIState.collectAsState()
+  val locationUi by viewModel.locationUIState.collectAsState()
 
-    LaunchedEffect(spaceRenter.address) {
-            if (locationUi.selectedLocation == null && spaceRenter.address != Location()) {
-                viewModel.setLocation(spaceRenter.address)
-            }
-        }
+  LaunchedEffect(spaceRenter.address) {
+    if (locationUi.selectedLocation == null && spaceRenter.address != Location()) {
+      viewModel.setLocation(spaceRenter.address)
+    }
+  }
 
-    EditSpaceRenterContent(
-        owner = owner,
-        initialRenter = spaceRenter,
-        onBack = onBack,
-        onUpdated = onUpdated,
-        onUpdate = { updated ->
-                viewModel.updateSpaceRenter(
-                    spaceRenter = updated,
-                    requester = owner,
-                    owner = updated.owner,
-                    name = updated.name,
-                    phone = updated.phone,
-                    email = updated.email,
-                    website = updated.website,
-                    address = updated.address,
-                    openingHours = updated.openingHours,
-                    spaces = updated.spaces
-                )
-        },
-        locationUi = locationUi,
-        viewModel = viewModel
-    )
+  EditSpaceRenterContent(
+      owner = owner,
+      initialRenter = spaceRenter,
+      onBack = onBack,
+      onUpdated = onUpdated,
+      onUpdateSpaceRenter = { updated ->
+        viewModel.updateSpaceRenter(
+            spaceRenter = updated,
+            requester = owner,
+            owner = updated.owner,
+            name = updated.name,
+            phone = updated.phone,
+            email = updated.email,
+            website = updated.website,
+            address = updated.address,
+            openingHours = updated.openingHours,
+            spaces = updated.spaces)
+      },
+      locationUi = locationUi,
+      viewModel = viewModel)
 }
 
 /* ================================================================================================
@@ -113,184 +104,175 @@ internal fun EditSpaceRenterContent(
     initialRenter: SpaceRenter,
     onBack: () -> Unit,
     onUpdated: () -> Unit,
-    onUpdate: suspend (SpaceRenter) -> Unit,
+    onUpdateSpaceRenter: suspend (SpaceRenter) -> Unit,
     locationUi: LocationUIState,
     viewModel: EditSpaceRenterViewModel
 ) {
-    val snackbarHost = remember { SnackbarHostState() }
-    val scope = rememberCoroutineScope()
+  val snackbarHost = remember { SnackbarHostState() }
+  val scope = rememberCoroutineScope()
 
-    var name by rememberSaveable { mutableStateOf(initialRenter.name) }
-    var email by rememberSaveable { mutableStateOf(initialRenter.email) }
-    var phone by rememberSaveable { mutableStateOf(initialRenter.phone) }
-    var link by rememberSaveable { mutableStateOf(initialRenter.website) }
+  var name by rememberSaveable { mutableStateOf(initialRenter.name) }
+  var email by rememberSaveable { mutableStateOf(initialRenter.email) }
+  var phone by rememberSaveable { mutableStateOf(initialRenter.phone) }
+  var link by rememberSaveable { mutableStateOf(initialRenter.website) }
 
-    var week by remember { mutableStateOf(initialRenter.openingHours) }
-    var editingDay by remember { mutableStateOf<Int?>(null) }
-    var showHoursDialog by remember { mutableStateOf(false) }
+  var week by remember { mutableStateOf(initialRenter.openingHours) }
+  var editingDay by remember { mutableStateOf<Int?>(null) }
+  var showHoursDialog by remember { mutableStateOf(false) }
 
-    var spaces by remember { mutableStateOf(initialRenter.spaces) }
-    var spacesExpanded by rememberSaveable { mutableStateOf(false) }
+  var spaces by remember { mutableStateOf(initialRenter.spaces) }
+  var spacesExpanded by rememberSaveable { mutableStateOf(false) }
 
-    val hasOpeningHours by remember(week) { derivedStateOf { week.any { it.hours.isNotEmpty() } } }
-    val hasAtLeastOneSpace by remember(spaces) { derivedStateOf { spaces.isNotEmpty() } }
-    val allSpacesValid by remember(spaces) {
+  val hasOpeningHours by remember(week) { derivedStateOf { week.any { it.hours.isNotEmpty() } } }
+  val hasAtLeastOneSpace by remember(spaces) { derivedStateOf { spaces.isNotEmpty() } }
+  val allSpacesValid by
+      remember(spaces) {
         derivedStateOf {
-            spaces.all {
-                it.seats >= AddSpaceRenterUi.Numbers.MIN_SEATS_PER_SPACE &&
-                        it.costPerHour >= AddSpaceRenterUi.Numbers.MIN_COST_PER_HOUR
-            }
+          spaces.all {
+            it.seats >= AddSpaceRenterUi.Numbers.MIN_SEATS_PER_SPACE &&
+                it.costPerHour >= AddSpaceRenterUi.Numbers.MIN_COST_PER_HOUR
+          }
         }
-    }
+      }
 
-    val hasLocation by remember(locationUi.selectedLocation) {
+  val hasLocation by
+      remember(locationUi.selectedLocation) {
         derivedStateOf { locationUi.selectedLocation != null }
-    }
+      }
 
-    val isValid by remember(name, email, hasLocation, hasOpeningHours, hasAtLeastOneSpace, allSpacesValid) {
+  val isValid by
+      remember(name, email, hasLocation, hasOpeningHours, hasAtLeastOneSpace, allSpacesValid) {
         derivedStateOf {
-            name.isNotBlank() &&
-                    isValidEmail(email) &&
-                    hasLocation &&
-                    hasOpeningHours &&
-                    hasAtLeastOneSpace &&
-                    allSpacesValid
+          name.isNotBlank() &&
+              isValidEmail(email) &&
+              hasLocation &&
+              hasOpeningHours &&
+              hasAtLeastOneSpace &&
+              allSpacesValid
         }
-    }
+      }
 
-    val draftRenter = initialRenter.copy(
-        name = name,
-        phone = phone,
-        email = email,
-        website = link,
-        address = locationUi.selectedLocation ?: initialRenter.address,
-        openingHours = week,
-        spaces = spaces
-    )
+  val draftRenter =
+      initialRenter.copy(
+          name = name,
+          phone = phone,
+          email = email,
+          website = link,
+          address = locationUi.selectedLocation ?: initialRenter.address,
+          openingHours = week,
+          spaces = spaces)
 
-    Scaffold(
-        topBar = {
-            CenterAlignedTopAppBar(
-                title = {
-                    Text(
-                        EditSpaceRenterUi.Strings.SCREEN_TITLE,
-                        modifier = Modifier.testTag(EditSpaceRenterScreenTestTags.TITLE)
-                    )
-                },
-                navigationIcon = {
-                    IconButton(
-                        onClick = onBack,
-                        modifier = Modifier.testTag(EditSpaceRenterScreenTestTags.NAV_BACK)
-                    ) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
-                    }
-                },
-                modifier = Modifier.testTag(EditSpaceRenterScreenTestTags.TOPBAR)
-            )
-        },
-        snackbarHost = {
-            SnackbarHost(snackbarHost, modifier = Modifier.testTag(EditSpaceRenterScreenTestTags.SNACKBAR_HOST))
-        },
-        bottomBar = {
-            ActionBar(
-                onDiscard = onBack,
-                onPrimary = {
-                    scope.launch {
-                        try {
-                            onUpdate(draftRenter)
-                            onUpdated()
-                        } catch (e: IllegalArgumentException) {
-                            snackbarHost.showSnackbar(e.message ?: EditSpaceRenterUi.Strings.ERROR_VALIDATION)
-                        } catch (e: Exception) {
-                            snackbarHost.showSnackbar(EditSpaceRenterUi.Strings.ERROR_UPDATE)
-                        }
-                    }
-                },
-                enabled = isValid,
-            )
-        },
-        modifier = Modifier.testTag(EditSpaceRenterScreenTestTags.SCAFFOLD)
-    ) { padding ->
+  Scaffold(
+      topBar = {
+        CenterAlignedTopAppBar(
+            title = {
+              Text(
+                  EditSpaceRenterUi.Strings.SCREEN_TITLE,
+                  modifier = Modifier.testTag(EditSpaceRenterScreenTestTags.TITLE))
+            },
+            navigationIcon = {
+              IconButton(
+                  onClick = onBack,
+                  modifier = Modifier.testTag(EditSpaceRenterScreenTestTags.NAV_BACK)) {
+                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                  }
+            },
+            modifier = Modifier.testTag(EditSpaceRenterScreenTestTags.TOPBAR))
+      },
+      snackbarHost = {
+        SnackbarHost(
+            snackbarHost, modifier = Modifier.testTag(EditSpaceRenterScreenTestTags.SNACKBAR_HOST))
+      },
+      bottomBar = {
+        ActionBar(
+            onDiscard = onBack,
+            onPrimary = {
+              scope.launch {
+                try {
+                  onUpdateSpaceRenter(draftRenter)
+                  onUpdated()
+                } catch (e: IllegalArgumentException) {
+                  snackbarHost.showSnackbar(e.message ?: EditSpaceRenterUi.Strings.ERROR_VALIDATION)
+                } catch (e: Exception) {
+                  snackbarHost.showSnackbar(EditSpaceRenterUi.Strings.ERROR_UPDATE)
+                }
+              }
+            },
+            enabled = isValid,
+            primaryButtonText = ShopUiDefaults.StringsMagicNumbers.BTN_SAVE)
+      },
+      modifier = Modifier.testTag(EditSpaceRenterScreenTestTags.SCAFFOLD)) { padding ->
         LazyColumn(
             modifier = Modifier.padding(padding).testTag(EditSpaceRenterScreenTestTags.LIST),
-            contentPadding = PaddingValues(
-                horizontal = AddSpaceRenterUi.Dimensions.contentHPadding,
-                vertical = AddSpaceRenterUi.Dimensions.contentVPadding
-            )
-        ) {
-            // Required Info
-            item {
+            contentPadding =
+                PaddingValues(
+                    horizontal = AddSpaceRenterUi.Dimensions.contentHPadding,
+                    vertical = AddSpaceRenterUi.Dimensions.contentVPadding)) {
+              // Required Info
+              item {
                 CollapsibleSection(
                     title = EditSpaceRenterUi.Strings.REQUIREMENTS_SECTION,
                     initiallyExpanded = true,
                     content = {
-                        SpaceRenterRequiredInfoSection(
-                            spaceRenter = draftRenter,
-                            onSpaceName = { name = it },
-                            onEmail = { email = it },
-                            onPhone = { phone = it },
-                            onLink = { link = it },
-                            onPickLocation = { loc -> viewModel.setLocation(loc) },
-                            viewModel = viewModel,
-                            owner = owner
-                        )
+                      SpaceRenterRequiredInfoSection(
+                          spaceRenter = draftRenter,
+                          onSpaceName = { name = it },
+                          onEmail = { email = it },
+                          onPhone = { phone = it },
+                          onLink = { link = it },
+                          onPickLocation = { loc -> viewModel.setLocation(loc) },
+                          viewModel = viewModel,
+                          owner = owner)
                     },
-                    testTag = EditSpaceRenterScreenTestTags.SECTION_REQUIRED
-                )
-            }
+                    testTag = EditSpaceRenterScreenTestTags.SECTION_REQUIRED)
+              }
 
-            // Availability
-            item {
+              // Availability
+              item {
                 CollapsibleSection(
                     title = EditSpaceRenterUi.Strings.SECTION_AVAILABILITY,
                     initiallyExpanded = false,
                     content = {
-                        AvailabilitySection(
-                            week = week,
-                            onEdit = { day ->
-                                editingDay = day
-                                showHoursDialog = true
-                            }
-                        )
+                      AvailabilitySection(
+                          week = week,
+                          onEdit = { day ->
+                            editingDay = day
+                            showHoursDialog = true
+                          })
                     },
-                    testTag = EditSpaceRenterScreenTestTags.SECTION_AVAILABILITY
-                )
-            }
+                    testTag = EditSpaceRenterScreenTestTags.SECTION_AVAILABILITY)
+              }
 
-            // Spaces
-            item {
+              // Spaces
+              item {
                 CollapsibleSection(
                     title = EditSpaceRenterUi.Strings.SECTION_SPACES,
                     initiallyExpanded = false,
                     expanded = spacesExpanded,
                     onExpandedChange = { spacesExpanded = it },
                     content = {
-                        SpacesList(
-                            spaces = spaces,
-                            onChange = { idx, updated ->
-                                spaces = spaces.mapIndexed { i, sp -> if (i == idx) updated else sp }
-                            },
-                            onDelete = { idx -> spaces = spaces.filterIndexed { i, _ -> i != idx } }
-                        )
+                      SpacesList(
+                          spaces = spaces,
+                          onChange = { idx, updated ->
+                            spaces = spaces.mapIndexed { i, sp -> if (i == idx) updated else sp }
+                          },
+                          onDelete = { idx -> spaces = spaces.filterIndexed { i, _ -> i != idx } })
                     },
-                    testTag = EditSpaceRenterScreenTestTags.SECTION_SPACES
-                )
-            }
+                    testTag = EditSpaceRenterScreenTestTags.SECTION_SPACES)
+              }
 
-            item {
+              item {
                 Spacer(
                     Modifier.height(AddSpaceRenterUi.Dimensions.bottomSpacer)
-                        .testTag(EditSpaceRenterScreenTestTags.BOTTOM_SPACER)
-                )
+                        .testTag(EditSpaceRenterScreenTestTags.BOTTOM_SPACER))
+              }
             }
-        }
-    }
+      }
 
-    OpeningHoursEditor(
-        show = showHoursDialog,
-        day = editingDay,
-        week = week,
-        onWeekChange = { week = it },
-        onDismiss = { showHoursDialog = false }
-    )
+  OpeningHoursEditor(
+      show = showHoursDialog,
+      day = editingDay,
+      week = week,
+      onWeekChange = { week = it },
+      onDismiss = { showHoursDialog = false })
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/space_renter/EditSpaceRenterScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/space_renter/EditSpaceRenterScreen.kt
@@ -1,0 +1,296 @@
+package com.github.meeplemeet.ui.space_renter
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.runtime.Composable
+import com.github.meeplemeet.model.space_renter.Space
+import com.github.meeplemeet.ui.theme.AppTheme
+import com.github.meeplemeet.ui.theme.ThemeMode
+import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.platform.testTag
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.github.meeplemeet.model.auth.Account
+import com.github.meeplemeet.model.shared.LocationUIState
+import com.github.meeplemeet.model.shared.location.Location
+import com.github.meeplemeet.model.shops.OpeningHours
+import com.github.meeplemeet.model.shops.TimeSlot
+import com.github.meeplemeet.model.space_renter.EditSpaceRenterViewModel
+import com.github.meeplemeet.model.space_renter.SpaceRenter
+import com.github.meeplemeet.ui.components.*
+import kotlinx.coroutines.launch
+
+/* ================================================================================================
+ * Test tags
+ * ================================================================================================ */
+object EditSpaceRenterScreenTestTags {
+    const val SCAFFOLD = "edit_space_renter_scaffold"
+    const val TOPBAR = "edit_space_renter_topbar"
+    const val TITLE = "edit_space_renter_title"
+    const val NAV_BACK = "edit_space_renter_nav_back"
+    const val SNACKBAR_HOST = "edit_space_renter_snackbar_host"
+    const val LIST = "edit_space_renter_list"
+
+    const val SECTION_REQUIRED = "edit_section_required"
+    const val SECTION_AVAILABILITY = "edit_section_availability"
+    const val SECTION_SPACES = "edit_section_spaces"
+
+    const val BOTTOM_SPACER = "edit_bottom_spacer"
+}
+
+/* ================================================================================================
+ * UI defaults
+ * ================================================================================================ */
+object EditSpaceRenterUi {
+    object Strings {
+        const val SCREEN_TITLE = "Edit Space Renter"
+        const val REQUIREMENTS_SECTION = "Required Info"
+        const val SECTION_AVAILABILITY = "Availability"
+        const val SECTION_SPACES = "Available Spaces"
+
+        const val BTN_UPDATE = "Update"
+        const val ERROR_VALIDATION = "Validation error"
+        const val ERROR_UPDATE = "Failed to update space renter"
+    }
+}
+
+/* ================================================================================================
+ * Screen
+ * ================================================================================================ */
+@Composable
+fun EditSpaceRenterScreen(
+    spaceRenter: SpaceRenter,
+    owner: Account,
+    onBack: () -> Unit,
+    onUpdated: () -> Unit,
+    viewModel: EditSpaceRenterViewModel = viewModel()
+) {
+    val locationUi by viewModel.locationUIState.collectAsState()
+
+    LaunchedEffect(spaceRenter.address) {
+            if (locationUi.selectedLocation == null && spaceRenter.address != Location()) {
+                viewModel.setLocation(spaceRenter.address)
+            }
+        }
+
+    EditSpaceRenterContent(
+        owner = owner,
+        initialRenter = spaceRenter,
+        onBack = onBack,
+        onUpdated = onUpdated,
+        onUpdate = { updated ->
+                viewModel.updateSpaceRenter(
+                    spaceRenter = updated,
+                    requester = owner,
+                    owner = updated.owner,
+                    name = updated.name,
+                    phone = updated.phone,
+                    email = updated.email,
+                    website = updated.website,
+                    address = updated.address,
+                    openingHours = updated.openingHours,
+                    spaces = updated.spaces
+                )
+        },
+        locationUi = locationUi,
+        viewModel = viewModel
+    )
+}
+
+/* ================================================================================================
+ * Content
+ * ================================================================================================ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun EditSpaceRenterContent(
+    owner: Account,
+    initialRenter: SpaceRenter,
+    onBack: () -> Unit,
+    onUpdated: () -> Unit,
+    onUpdate: suspend (SpaceRenter) -> Unit,
+    locationUi: LocationUIState,
+    viewModel: EditSpaceRenterViewModel
+) {
+    val snackbarHost = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+
+    var name by rememberSaveable { mutableStateOf(initialRenter.name) }
+    var email by rememberSaveable { mutableStateOf(initialRenter.email) }
+    var phone by rememberSaveable { mutableStateOf(initialRenter.phone) }
+    var link by rememberSaveable { mutableStateOf(initialRenter.website) }
+
+    var week by remember { mutableStateOf(initialRenter.openingHours) }
+    var editingDay by remember { mutableStateOf<Int?>(null) }
+    var showHoursDialog by remember { mutableStateOf(false) }
+
+    var spaces by remember { mutableStateOf(initialRenter.spaces) }
+    var spacesExpanded by rememberSaveable { mutableStateOf(false) }
+
+    val hasOpeningHours by remember(week) { derivedStateOf { week.any { it.hours.isNotEmpty() } } }
+    val hasAtLeastOneSpace by remember(spaces) { derivedStateOf { spaces.isNotEmpty() } }
+    val allSpacesValid by remember(spaces) {
+        derivedStateOf {
+            spaces.all {
+                it.seats >= AddSpaceRenterUi.Numbers.MIN_SEATS_PER_SPACE &&
+                        it.costPerHour >= AddSpaceRenterUi.Numbers.MIN_COST_PER_HOUR
+            }
+        }
+    }
+
+    val hasLocation by remember(locationUi.selectedLocation) {
+        derivedStateOf { locationUi.selectedLocation != null }
+    }
+
+    val isValid by remember(name, email, hasLocation, hasOpeningHours, hasAtLeastOneSpace, allSpacesValid) {
+        derivedStateOf {
+            name.isNotBlank() &&
+                    isValidEmail(email) &&
+                    hasLocation &&
+                    hasOpeningHours &&
+                    hasAtLeastOneSpace &&
+                    allSpacesValid
+        }
+    }
+
+    val draftRenter = initialRenter.copy(
+        name = name,
+        phone = phone,
+        email = email,
+        website = link,
+        address = locationUi.selectedLocation ?: initialRenter.address,
+        openingHours = week,
+        spaces = spaces
+    )
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = {
+                    Text(
+                        EditSpaceRenterUi.Strings.SCREEN_TITLE,
+                        modifier = Modifier.testTag(EditSpaceRenterScreenTestTags.TITLE)
+                    )
+                },
+                navigationIcon = {
+                    IconButton(
+                        onClick = onBack,
+                        modifier = Modifier.testTag(EditSpaceRenterScreenTestTags.NAV_BACK)
+                    ) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                modifier = Modifier.testTag(EditSpaceRenterScreenTestTags.TOPBAR)
+            )
+        },
+        snackbarHost = {
+            SnackbarHost(snackbarHost, modifier = Modifier.testTag(EditSpaceRenterScreenTestTags.SNACKBAR_HOST))
+        },
+        bottomBar = {
+            ActionBar(
+                onDiscard = onBack,
+                onPrimary = {
+                    scope.launch {
+                        try {
+                            onUpdate(draftRenter)
+                            onUpdated()
+                        } catch (e: IllegalArgumentException) {
+                            snackbarHost.showSnackbar(e.message ?: EditSpaceRenterUi.Strings.ERROR_VALIDATION)
+                        } catch (e: Exception) {
+                            snackbarHost.showSnackbar(EditSpaceRenterUi.Strings.ERROR_UPDATE)
+                        }
+                    }
+                },
+                enabled = isValid,
+            )
+        },
+        modifier = Modifier.testTag(EditSpaceRenterScreenTestTags.SCAFFOLD)
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier.padding(padding).testTag(EditSpaceRenterScreenTestTags.LIST),
+            contentPadding = PaddingValues(
+                horizontal = AddSpaceRenterUi.Dimensions.contentHPadding,
+                vertical = AddSpaceRenterUi.Dimensions.contentVPadding
+            )
+        ) {
+            // Required Info
+            item {
+                CollapsibleSection(
+                    title = EditSpaceRenterUi.Strings.REQUIREMENTS_SECTION,
+                    initiallyExpanded = true,
+                    content = {
+                        SpaceRenterRequiredInfoSection(
+                            spaceRenter = draftRenter,
+                            onSpaceName = { name = it },
+                            onEmail = { email = it },
+                            onPhone = { phone = it },
+                            onLink = { link = it },
+                            onPickLocation = { loc -> viewModel.setLocation(loc) },
+                            viewModel = viewModel,
+                            owner = owner
+                        )
+                    },
+                    testTag = EditSpaceRenterScreenTestTags.SECTION_REQUIRED
+                )
+            }
+
+            // Availability
+            item {
+                CollapsibleSection(
+                    title = EditSpaceRenterUi.Strings.SECTION_AVAILABILITY,
+                    initiallyExpanded = false,
+                    content = {
+                        AvailabilitySection(
+                            week = week,
+                            onEdit = { day ->
+                                editingDay = day
+                                showHoursDialog = true
+                            }
+                        )
+                    },
+                    testTag = EditSpaceRenterScreenTestTags.SECTION_AVAILABILITY
+                )
+            }
+
+            // Spaces
+            item {
+                CollapsibleSection(
+                    title = EditSpaceRenterUi.Strings.SECTION_SPACES,
+                    initiallyExpanded = false,
+                    expanded = spacesExpanded,
+                    onExpandedChange = { spacesExpanded = it },
+                    content = {
+                        SpacesList(
+                            spaces = spaces,
+                            onChange = { idx, updated ->
+                                spaces = spaces.mapIndexed { i, sp -> if (i == idx) updated else sp }
+                            },
+                            onDelete = { idx -> spaces = spaces.filterIndexed { i, _ -> i != idx } }
+                        )
+                    },
+                    testTag = EditSpaceRenterScreenTestTags.SECTION_SPACES
+                )
+            }
+
+            item {
+                Spacer(
+                    Modifier.height(AddSpaceRenterUi.Dimensions.bottomSpacer)
+                        .testTag(EditSpaceRenterScreenTestTags.BOTTOM_SPACER)
+                )
+            }
+        }
+    }
+
+    OpeningHoursEditor(
+        show = showHoursDialog,
+        day = editingDay,
+        week = week,
+        onWeekChange = { week = it },
+        onDismiss = { showHoursDialog = false }
+    )
+}


### PR DESCRIPTION
# PR: Implement EditSpaceRenter Screen with Navigation and Tests

## Summary

This PR introduces the **EditSpaceRenterScreen** to the Meeple Meet app, allowing users to edit an existing space renter's information, including required info, availability, and spaces. It integrates the screen into the app's navigation system and adds UI tests for robust verification.

## Changes

### Screen Implementation

- Added `EditSpaceRenterScreen` composable with:
  - Top bar showing screen title and back button.
  - Collapsible sections for:
    - **Required Info:** name, email, phone, website, and location selection.
    - **Availability:** weekly opening hours with editable time slots.
    - **Spaces:** list of spaces with seats and cost per hour, editable and deletable.
  - Validation logic to enable/disable save button based on completeness and correctness of data.
  - Snackbar feedback for validation errors and failed updates.
- Defined `EditSpaceRenterScreenTestTags` for UI testing.

### Navigation

- Integrated `EditSpaceRenterScreen` into `MainActivity` navigation flow.
- Added `EditSpaceRenter` to `MeepleMeetScreen` enum.
- Enabled navigation from `SpaceDetailsScreen` to `EditSpaceRenterScreen` for space renter owners.

### Tests

- Added `EditSpaceRenterScreenTest` to verify:
  - Prefilling of existing space renter data.
  - Editing and saving of fields.
  - Back navigation.

## Motivation

This PR sets up the foundation for a fully functional **space renter editing feature**, ensuring:

- Users can edit space renter info intuitively.
- The app navigation supports future extensions (e.g., create and edit flows).
- UI components are fully testable with meaningful test tags.

## Visuals

<video src="https://github.com/user-attachments/assets/4bcda0d1-b23f-43fa-9e88-bfc0bd3f308f" controls></video>

