### PR TITLE
Fix release APK build and CI workflow

### DIFF
--- a/.github/workflows/apk-builder.yml
+++ b/.github/workflows/apk-builder.yml
@@ -56,7 +56,7 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-        run: ./gradlew clean assembleRelease --no-daemon --stacktrace
+        run: ./gradlew clean assembleRelease --no-daemon
 
       - name: Rename APK
         run: |

--- a/.github/workflows/apk-builder.yml
+++ b/.github/workflows/apk-builder.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feat/apk-build-workflow
   workflow_dispatch:
 
 jobs:
@@ -27,7 +26,7 @@ jobs:
         run: |
           mkdir -p app
           echo "${{ secrets.KEYSTORE_FILE }}" | base64 --decode > app/key-store.keystore
-          echo "KEYSTORE_PATH=$PWD/app/key-store.keystore" >> $GITHUB_ENV
+          echo "KEYSTORE_PATH=${{ github.workspace }}/app/key-store.keystore" >> $GITHUB_ENV
         env:
           KEYSTORE_PATH: ${{ github.workspace }}/app/key-store.keystore
 
@@ -53,11 +52,11 @@ jobs:
 
       - name: Build Signed Release APK
         env:
-          KEYSTORE_PATH: key-store.keystore
+          KEYSTORE_PATH: ${{ env.KEYSTORE_PATH }}
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-        run: ./gradlew clean assembleRelease
+        run: ./gradlew clean assembleRelease --no-daemon --stacktrace
 
       - name: Rename APK
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ app/google-services.json
 firebase-debug.log
 firestore-debug.log
 app/*.jks
+*.dpapi

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ local.properties
 app/google-services.json
 firebase-debug.log
 firestore-debug.log
+app/*.jks

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -47,3 +47,13 @@
 # R classes
 # --------------------------
 -keepclassmembers class **.R$* { public static <fields>; }
+
+# --------------------------
+# Full keep test (temporary)
+# --------------------------
+# Uncomment the following lines to disable all minification/obfuscation for debugging
+-keep class * { *; }
+-keep interface * { *; }
+-keep enum * { *; }
+-keepattributes *Annotation*, Signature, InnerClasses, EnclosingMethod
+-dontwarn **

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,21 +1,49 @@
-# Add project specific ProGuard rules here.
-# You can control the set of applied configuration files using the
-# proguardFiles setting in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+# --------------------------
+# Kotlin metadata & serialization
+# --------------------------
+-keepclassmembers class kotlin.Metadata { *; }
+-keepclassmembers class com.github.meeplemeet.model.** {
+    @kotlinx.serialization.Serializable *;
+}
+-keepattributes Signature, *Annotation*
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+# --------------------------
+# Google Maps (principaux packages seulement)
+# --------------------------
+-keep class com.google.android.gms.maps.** { *; }
+-keep class com.google.maps.android.** { *; }
+-dontwarn com.google.android.gms.maps.**
+-dontwarn com.google.maps.android.**
 
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+# --------------------------
+# Firebase Auth
+# --------------------------
+-keep class com.google.firebase.auth.** { *; }
 
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
+# --------------------------
+# Firebase Firestore
+# --------------------------
+-keep class com.google.firebase.firestore.** { *; }
+-keep class com.google.firebase.Timestamp { *; }
+-dontwarn com.google.firebase.firestore.**
+
+# --------------------------
+# Google Sign-In / credentials
+# --------------------------
+-keep class com.google.android.gms.auth.api.signin.** { *; }
+-dontwarn com.google.android.gms.auth.api.signin.**
+
+# --------------------------
+# Compose essentials
+# --------------------------
+-keep class androidx.compose.runtime.** { *; }
+
+# --------------------------
+# Kotlin stdlib reflection
+# --------------------------
+-keepclassmembers class kotlin.jvm.internal.Intrinsics { *; }
+
+# --------------------------
+# R classes
+# --------------------------
+-keepclassmembers class **.R$* { public static <fields>; }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,24 +1,8 @@
 # --------------------------
-# Kotlin metadata & serialization
+# Keep Kotlin metadata for reflection and serialization
 # --------------------------
--keepclassmembers class kotlin.Metadata { *; }
--keepclassmembers class com.github.meeplemeet.model.** {
-    @kotlinx.serialization.Serializable *;
-}
+-keep class kotlin.Metadata { *; }
 -keepattributes Signature, *Annotation*
-
-# --------------------------
-# Google Maps (principaux packages seulement)
-# --------------------------
--keep class com.google.android.gms.maps.** { *; }
--keep class com.google.maps.android.** { *; }
--dontwarn com.google.android.gms.maps.**
--dontwarn com.google.maps.android.**
-
-# --------------------------
-# Firebase Auth
-# --------------------------
--keep class com.google.firebase.auth.** { *; }
 
 # --------------------------
 # Firebase Firestore
@@ -28,18 +12,32 @@
 -dontwarn com.google.firebase.firestore.**
 
 # --------------------------
-# Google Sign-In / credentials
+# Firestore / Serializable models
 # --------------------------
--keep class com.google.android.gms.auth.api.signin.** { *; }
--dontwarn com.google.android.gms.auth.api.signin.**
+# Keep all classes in your model package intact, including fields and constructors
+-keep class com.github.meeplemeet.model.** { *; }
+-keepclassmembers class com.github.meeplemeet.model.** {
+    public <init>(...);
+}
+-keepclassmembernames class com.github.meeplemeet.model.** { <fields>; }
+
+# --------------------------
+# Maps
+# --------------------------
+-keep class com.google.android.gms.** { *; }
+-keep class com.google.maps.android.** { *; }
+-dontwarn com.google.android.gms.**
+-dontwarn com.google.maps.android.**
 
 # --------------------------
 # Compose essentials
 # --------------------------
 -keep class androidx.compose.runtime.** { *; }
+-keep class androidx.activity.** { *; }
+-keep class androidx.savedstate.** { *; }
 
 # --------------------------
-# Kotlin stdlib reflection
+# Kotlin runtime essentials
 # --------------------------
 -keepclassmembers class kotlin.jvm.internal.Intrinsics { *; }
 
@@ -47,13 +45,3 @@
 # R classes
 # --------------------------
 -keepclassmembers class **.R$* { public static <fields>; }
-
-# --------------------------
-# Full keep test (temporary)
-# --------------------------
-# Uncomment the following lines to disable all minification/obfuscation for debugging
--keep class * { *; }
--keep interface * { *; }
--keep enum * { *; }
--keepattributes *Annotation*, Signature, InnerClasses, EnclosingMethod
--dontwarn **


### PR DESCRIPTION
Reactivated minification and fixed ProGuard/CI setup to produce a compact release APK while keeping Firestore models fully functional.

## ProGuard rules
- Kept all Firestore model classes and their fields to prevent obfuscation issues
- Preserved default constructors for all models
- Retained Kotlin metadata and essential runtime classes
- Kept Google Maps, Compose, and saved state classes from obfuscation

## App build
- Fix `signingConfigs` to correctly use environment variables or `local.properties` values
- Adjust `buildTypes.release` to re-enable minification and resource shrinking safely
- Ensure `signingConfig` is only applied if the release keystore exists

## CI workflow
- Ensured `gradlew assembleRelease --no-daemon` uses the proper environment variables
- Minor cleanup of duplicate environment variable assignments

## Notes
- No functional changes to the app logic

_This PR was reformulated with Copilot to improve readability._