### PR TITLE
Refactor/space renter screen

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/ui/ShopDetailsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/ShopDetailsScreenTest.kt
@@ -33,7 +33,6 @@ import com.github.meeplemeet.ui.theme.ThemeMode
 import com.github.meeplemeet.utils.Checkpoint
 import com.github.meeplemeet.utils.FirestoreTests
 import com.google.firebase.firestore.FirebaseFirestore
-import java.util.Calendar
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.tasks.await
 import org.junit.Before
@@ -95,6 +94,8 @@ class ShopDetailsScreenTest : FirestoreTests() {
     return allTextsOnScreen().filter { it.startsWith("Game Name ") }.toSet()
   }
 
+  private fun availabilityHeader() = compose.onNodeWithTag("AVAILABILITY_HEADER")
+
   // Helper to seed Firestore
   private fun seedGamesForTest(db: FirebaseFirestore, games: List<Game>) = runBlocking {
     games.forEach { game ->
@@ -125,7 +126,6 @@ class ShopDetailsScreenTest : FirestoreTests() {
               maxPlayers = 4,
               recommendedPlayers = 4,
               averagePlayTime = 60,
-              minAge = null,
               genres = emptyList())
         }
 
@@ -210,24 +210,18 @@ class ShopDetailsScreenTest : FirestoreTests() {
 
     /* 2  availability section integration ------------------------------------------ */
     checkpoint("Availability section visible and weekly dialog can be opened") {
-      val todayIndex = Calendar.getInstance().get(Calendar.DAY_OF_WEEK) - 1
+      availabilityHeader().assertExists()
 
-      // Availability header
-      compose.onNodeWithText("Availability").assertExists()
+      availabilityHeader().performClick()
 
       // Today row exists (component-level formatting is covered in ShopComponentsTest)
-      compose
-          .onNodeWithTag("${ShopComponentsTestTags.SHOP_DAY_PREFIX}${todayIndex}_HOURS")
-          .assertExists()
-
-      // Open weekly dialog via navigate icon
-      compose
-          .onNodeWithTag("${ShopComponentsTestTags.SHOP_DAY_PREFIX}NAVIGATE")
-          .assertExists()
-          .performClick()
-      compose.waitForIdle()
+      dummyOpeningHours.forEach { entry ->
+        val tag = ShopComponentsTestTags.SHOP_DAY_PREFIX + entry.day
+        checkpoint("Availability day exists: $tag") { compose.onNodeWithTag(tag).assertExists() }
+      }
 
       // Bottom sheet shows the Close button from the component
+      compose.waitForIdle()
       compose.onNodeWithText("Close").assertExists().performClick()
     }
 

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/ShopDetailsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/ShopDetailsScreenTest.kt
@@ -126,6 +126,7 @@ class ShopDetailsScreenTest : FirestoreTests() {
               maxPlayers = 4,
               recommendedPlayers = 4,
               averagePlayTime = 60,
+              minAge = 6,
               genres = emptyList())
         }
 

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/SpaceRenterDetailsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/SpaceRenterDetailsScreenTest.kt
@@ -17,6 +17,7 @@ import com.github.meeplemeet.model.shops.TimeSlot
 import com.github.meeplemeet.model.space_renter.Space
 import com.github.meeplemeet.model.space_renter.SpaceRenter
 import com.github.meeplemeet.model.space_renter.SpaceRenterViewModel
+import com.github.meeplemeet.ui.components.ShopComponentsTestTags
 import com.github.meeplemeet.ui.components.SpaceRenterComponentsTestTags
 import com.github.meeplemeet.ui.space_renter.SpaceRenterScreen
 import com.github.meeplemeet.ui.space_renter.SpaceRenterTestTags
@@ -45,28 +46,28 @@ class SpaceRenterDetailsScreenTest : FirestoreTests() {
 
   /* ------- semantic helpers ------- */
   private fun phoneText() =
-      compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_PHONE_TEXT, useUnmergedTree = true)
+      compose.onNodeWithTag(ShopComponentsTestTags.SHOP_PHONE_TEXT, useUnmergedTree = true)
 
   private fun emailText() =
-      compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_EMAIL_TEXT, useUnmergedTree = true)
+      compose.onNodeWithTag(ShopComponentsTestTags.SHOP_EMAIL_TEXT, useUnmergedTree = true)
 
   private fun addressText() =
-      compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_ADDRESS_TEXT, useUnmergedTree = true)
+      compose.onNodeWithTag(ShopComponentsTestTags.SHOP_ADDRESS_TEXT, useUnmergedTree = true)
 
   private fun websiteText() =
-      compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_WEBSITE_TEXT, useUnmergedTree = true)
+      compose.onNodeWithTag(ShopComponentsTestTags.SHOP_WEBSITE_TEXT, useUnmergedTree = true)
 
   private fun phoneBtn() =
-      compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_PHONE_BUTTON, useUnmergedTree = true)
+      compose.onNodeWithTag(ShopComponentsTestTags.SHOP_PHONE_BUTTON, useUnmergedTree = true)
 
   private fun emailBtn() =
-      compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_EMAIL_BUTTON, useUnmergedTree = true)
+      compose.onNodeWithTag(ShopComponentsTestTags.SHOP_EMAIL_BUTTON, useUnmergedTree = true)
 
   private fun addressBtn() =
-      compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_ADDRESS_BUTTON, useUnmergedTree = true)
+      compose.onNodeWithTag(ShopComponentsTestTags.SHOP_ADDRESS_BUTTON, useUnmergedTree = true)
 
   private fun websiteBtn() =
-      compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_WEBSITE_BUTTON, useUnmergedTree = true)
+      compose.onNodeWithTag(ShopComponentsTestTags.SHOP_WEBSITE_BUTTON, useUnmergedTree = true)
 
   private fun spaceRow(i: Int) =
       compose.onNodeWithTag(

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/SpaceRenterDetailsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/SpaceRenterDetailsScreenTest.kt
@@ -20,7 +20,6 @@ import com.github.meeplemeet.model.space_renter.SpaceRenterViewModel
 import com.github.meeplemeet.ui.components.SpaceRenterComponentsTestTags
 import com.github.meeplemeet.ui.space_renter.SpaceRenterScreen
 import com.github.meeplemeet.ui.space_renter.SpaceRenterTestTags
-import com.github.meeplemeet.ui.space_renter.SpaceRenterUi
 import com.github.meeplemeet.ui.theme.AppTheme
 import com.github.meeplemeet.ui.theme.ThemeMode
 import com.github.meeplemeet.utils.Checkpoint

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/SpaceRenterDetailsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/SpaceRenterDetailsScreenTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.platform.ClipboardManager
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.text.AnnotatedString
 import androidx.test.espresso.Espresso
 import com.github.meeplemeet.model.auth.Account
 import com.github.meeplemeet.model.shared.location.Location
@@ -135,6 +136,18 @@ class SpaceRenterDetailsScreenTest : FirestoreTests() {
     renter = spaceRenterRepository.getSpaceRenter(created.id)
     currentUser = accountRepository.getAccount(currentUser.uid)
     owner = accountRepository.getAccount(owner.uid)
+  }
+
+  class FakeClipboardManager : androidx.compose.ui.platform.ClipboardManager {
+    var copiedText: String? = null
+
+    override fun getText(): AnnotatedString? {
+      return copiedText?.let { AnnotatedString(it) }
+    }
+
+    override fun setText(text: androidx.compose.ui.text.AnnotatedString) {
+      copiedText = text.text
+    }
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/SpaceRenterDetailsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/SpaceRenterDetailsScreenTest.kt
@@ -78,18 +78,6 @@ class SpaceRenterDetailsScreenTest : FirestoreTests() {
 
   private fun reservationSelected() = compose.onNodeWithTag("RESERVATION_WITH_SELECTION")
 
-  private class FakeClipboardManager : ClipboardManager {
-    var copiedText: String? = null
-
-    override fun getText(): AnnotatedString? {
-      return copiedText?.let { AnnotatedString(it) }
-    }
-
-    override fun setText(annotatedString: AnnotatedString) {
-      copiedText = annotatedString.text
-    }
-  }
-
   /* -------------------------------- */
 
   private val address = Location(0.0, 0.0, "123 Meeple St, Boardgame City")

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/SpaceRenterDetailsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/SpaceRenterDetailsScreenTest.kt
@@ -190,6 +190,13 @@ class SpaceRenterDetailsScreenTest : FirestoreTests() {
 
     Espresso.pressBack()
 
+    checkpoint("Availability popup dismissed") {
+      availabilityHeader().performClick()
+      compose.onNodeWithText("Close").assertExists().performClick()
+    }
+
+    /* Spaces section */
+
     compose.onRoot().performTouchInput { swipeUp() }
     compose.waitForIdle()
 

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/SpaceRenterDetailsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/SpaceRenterDetailsScreenTest.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.platform.ClipboardManager
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.text.AnnotatedString
+import androidx.test.espresso.Espresso
 import com.github.meeplemeet.model.auth.Account
 import com.github.meeplemeet.model.shared.location.Location
 import com.github.meeplemeet.model.shops.OpeningHours
@@ -26,7 +26,6 @@ import com.github.meeplemeet.utils.Checkpoint
 import com.github.meeplemeet.utils.FirestoreTests
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
@@ -45,27 +44,39 @@ class SpaceRenterDetailsScreenTest : FirestoreTests() {
   private var theme by mutableStateOf(ThemeMode.LIGHT)
 
   /* ------- semantic helpers ------- */
-  private fun title() = compose.onNodeWithText(renter.name)
+  private fun phoneText() =
+      compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_PHONE_TEXT, useUnmergedTree = true)
 
-  private fun phoneText() = compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_PHONE_TEXT)
+  private fun emailText() =
+      compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_EMAIL_TEXT, useUnmergedTree = true)
 
-  private fun emailText() = compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_EMAIL_TEXT)
+  private fun addressText() =
+      compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_ADDRESS_TEXT, useUnmergedTree = true)
 
-  private fun addressText() = compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_ADDRESS_TEXT)
+  private fun websiteText() =
+      compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_WEBSITE_TEXT, useUnmergedTree = true)
 
-  private fun websiteText() = compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_WEBSITE_TEXT)
+  private fun phoneBtn() =
+      compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_PHONE_BUTTON, useUnmergedTree = true)
 
-  private fun phoneBtn() = compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_PHONE_BUTTON)
+  private fun emailBtn() =
+      compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_EMAIL_BUTTON, useUnmergedTree = true)
 
-  private fun emailBtn() = compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_EMAIL_BUTTON)
+  private fun addressBtn() =
+      compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_ADDRESS_BUTTON, useUnmergedTree = true)
 
-  private fun addressBtn() = compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_ADDRESS_BUTTON)
+  private fun websiteBtn() =
+      compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_WEBSITE_BUTTON, useUnmergedTree = true)
 
-  private fun websiteBtn() = compose.onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_WEBSITE_BUTTON)
+  private fun spaceRow(i: Int) =
+      compose.onNodeWithTag(
+          SpaceRenterComponentsTestTags.SPACE_ROW_PREFIX + i, useUnmergedTree = true)
 
-  private fun dayTag(day: Int) = SpaceRenterTestTags.SPACE_RENTER_DAY_PREFIX + day
+  private fun availabilityHeader() = compose.onNodeWithTag("AVAILABILITY_HEADER")
 
-  private fun spaceRow(i: Int) = SpaceRenterComponentsTestTags.SPACE_ROW_PREFIX + i
+  private fun reservationNoSelection() = compose.onNodeWithTag("RESERVATION_NO_SELECTION")
+
+  private fun reservationSelected() = compose.onNodeWithTag("RESERVATION_WITH_SELECTION")
 
   private class FakeClipboardManager : ClipboardManager {
     var copiedText: String? = null
@@ -81,9 +92,9 @@ class SpaceRenterDetailsScreenTest : FirestoreTests() {
 
   /* -------------------------------- */
 
-  val address = Location(0.0, 0.0, "123 Meeple St, Boardgame City")
+  private val address = Location(0.0, 0.0, "123 Meeple St, Boardgame City")
 
-  val dummyOpeningHours =
+  private val dummyOpeningHours =
       listOf(
           OpeningHours(0, listOf(TimeSlot("09:00", "18:00"), TimeSlot("19:00", "21:00"))),
           OpeningHours(1, listOf(TimeSlot("09:00", "18:00"))),
@@ -93,7 +104,15 @@ class SpaceRenterDetailsScreenTest : FirestoreTests() {
           OpeningHours(5, listOf(TimeSlot("10:00", "16:00"))),
           OpeningHours(6, emptyList()))
 
-  private val dummySpaces = listOf(Space(4, 10.0), Space(8, 20.0))
+  private val dummySpaces =
+      listOf(
+          Space(4, 10.0),
+          Space(8, 20.0),
+          Space(1, 50.0),
+          Space(1, 0.0),
+          Space(3, 2.0),
+          Space(5, 21.0),
+          Space(6, 15.0))
 
   @Before
   fun setup() = runBlocking {
@@ -118,7 +137,6 @@ class SpaceRenterDetailsScreenTest : FirestoreTests() {
     owner = accountRepository.getAccount(owner.uid)
   }
 
-  @Ignore
   @Test
   fun all_space_renter_details_tests() {
     val clipboard = FakeClipboardManager()
@@ -139,43 +157,107 @@ class SpaceRenterDetailsScreenTest : FirestoreTests() {
 
     compose.waitUntil(timeoutMillis = 5000) { vm.spaceRenter.value != null }
 
-    checkpoint("Title visible") { title().assertExists() }
+    checkpoint("Title visible") { compose.onNodeWithText(renter.name).assertExists() }
 
-    checkpoint("Phone text") {
-      phoneText().assertTextEquals(SpaceRenterUi.phoneContactRow(renter.phone))
-    }
-    checkpoint("Email text") {
-      emailText().assertTextEquals(SpaceRenterUi.emailContactRow(renter.email))
-    }
-    checkpoint("Address text") {
-      addressText().assertTextEquals("- Address: ${renter.address.name}")
-    }
-    checkpoint("Website text") {
-      websiteText().assertTextEquals(SpaceRenterUi.websiteContactRow(renter.website))
-    }
+    /* CONTACT SECTION */
+    checkpoint("Phone text") { phoneText().assertTextEquals(renter.phone) }
+    checkpoint("Email text") { emailText().assertTextEquals(renter.email) }
+    checkpoint("Address text") { addressText().assertTextEquals(renter.address.name) }
+    checkpoint("Website text") { websiteText().assertTextEquals(renter.website) }
 
     listOf(
-            phoneBtn() to SpaceRenterUi.phoneContactRow(renter.phone),
-            emailBtn() to SpaceRenterUi.emailContactRow(renter.email),
-            addressBtn() to SpaceRenterUi.addressContactRow(renter.address.name),
-            websiteBtn() to SpaceRenterUi.websiteContactRow(renter.website))
+            phoneBtn() to renter.phone,
+            emailBtn() to renter.email,
+            addressBtn() to renter.address.name,
+            websiteBtn() to renter.website)
         .forEach { (btn, expected) ->
-          checkpoint("Copy via $btn") {
+          checkpoint("Copy via ${btn.fetchSemanticsNode().config}") {
             btn.performClick()
             assert(clipboard.copiedText == expected)
           }
         }
 
+    /* AVAILABILITY SECTION POPUP */
+
+    checkpoint("Availability header exists") { availabilityHeader().assertExists() }
+
+    availabilityHeader().performClick()
+
     dummyOpeningHours.forEach { entry ->
-      val tag = dayTag(entry.day)
-      checkpoint("Day label exists: $tag") { compose.onNodeWithTag(tag).assertExists() }
+      val tag = SpaceRenterTestTags.SPACE_RENTER_DAY_PREFIX + entry.day
+      checkpoint("Availability day exists: $tag") { compose.onNodeWithTag(tag).assertExists() }
     }
 
-    dummySpaces.forEachIndexed { i, sp ->
-      val row = spaceRow(i)
-      checkpoint("Space row exists: $row") { compose.onNodeWithTag(row).assertExists() }
+    Espresso.pressBack()
+
+    compose.onRoot().performTouchInput { swipeUp() }
+    compose.waitForIdle()
+
+    var currentPageStart = 0
+
+    dummySpaces.forEachIndexed { index, _ ->
+      val i = index + 1
+
+      // If the index is not on the current page, swipe to the next one
+      if (index < currentPageStart || index >= currentPageStart + 3) {
+        // Swipe from any visible space on the current page
+        spaceRow(currentPageStart).performTouchInput { swipeLeft() }
+        compose.waitForIdle()
+        currentPageStart += 3
+      }
+
+      checkpoint("Space row exists: $i") { spaceRow(index).assertExists() }
     }
 
+    currentPageStart = (dummySpaces.size / 3) * 3
+    if (currentPageStart >= dummySpaces.size) currentPageStart -= 3
+
+    // Loop backward: last index → 0
+    for (index in dummySpaces.indices.reversed()) {
+
+      // If the index is not in the current visible page, swipe back (right)
+      if (index < currentPageStart || index >= currentPageStart + 3) {
+
+        // Swipe from any visible row on the current page (use the start index)
+        spaceRow(currentPageStart).performTouchInput { swipeRight() }
+        compose.waitForIdle()
+
+        currentPageStart -= 3
+        if (currentPageStart < 0) currentPageStart = 0
+      }
+
+      val i = index + 1
+      checkpoint("Space row exists (reverse): $i") { spaceRow(index).assertExists() }
+    }
+
+    /* RESERVATION BAR — NO SELECTION */
+    checkpoint("Reservation bar shows 'select a space' state") {
+      reservationNoSelection().assertExists()
+    }
+
+    /* SELECT FIRST SPACE */
+    spaceRow(0).performClick()
+
+    checkpoint("Reservation bar shows selected state") { reservationSelected().assertExists() }
+  }
+
+  @Test
+  fun edit_button_visible_for_owner() {
+    var fired = false
+
+    compose.setContent {
+      SpaceRenterScreen(
+          spaceId = renter.id, account = owner, viewModel = vm, onEdit = { fired = true })
+    }
+
+    compose.waitUntil(timeoutMillis = 5000) { vm.spaceRenter.value != null }
+
+    compose
+        .onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_EDIT_BUTTON)
+        .assertExists()
+        .performClick()
+
+    assert(fired)
     checkpoint("edit_button_visible_for_owner") {
       compose
           .onNodeWithTag(SpaceRenterTestTags.SPACE_RENTER_EDIT_BUTTON)

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/components/ShopComponentsTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/components/ShopComponentsTest.kt
@@ -49,7 +49,6 @@ import java.time.format.DateTimeFormatter
 import java.util.Calendar
 import kotlin.text.get
 import kotlinx.coroutines.flow.MutableStateFlow
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/components/ShopComponentsTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/components/ShopComponentsTest.kt
@@ -49,6 +49,7 @@ import java.time.format.DateTimeFormatter
 import java.util.Calendar
 import kotlin.text.get
 import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -361,6 +362,7 @@ class ShopComponentsTest : FirestoreTests() {
   }
 
   /** 4) GameStockDialog */
+  @Ignore("Test uses mocking and is a mess")
   @Test
   fun gameStockDialog_search_filter_duplicate_quantity_singleComposition() {
     val owner = Account(uid = "owner1", handle = "owner", name = "Owner", email = "owner@test")
@@ -745,7 +747,7 @@ class ShopComponentsTest : FirestoreTests() {
     // Backing state for the composable - only call setContent once
     val openingState = mutableStateOf(week)
 
-    setContentThemed { AvailabilitySection(openingHours = openingState.value) }
+    setContentThemed { AvailabilitySectionWithChevron(openingHours = openingState.value) }
 
     val prefix = ShopComponentsTestTags.SHOP_DAY_PREFIX
 

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/components/ShopComponentsTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/components/ShopComponentsTest.kt
@@ -78,9 +78,9 @@ class ShopComponentsTest : FirestoreTests() {
     val t12_00 = LocalTime.of(12, 0)!!
     val openingDefault = OpeningHours(0, listOf(TimeSlot("07:30", "12:00")))
     val openingOpen24 = OpeningHours(0, listOf(TimeSlot("00:00", "23:59")))
-    val game1 = Game("1", "Catan", "", "", 3, 4, null, 60, emptyList())
-    val game2 = Game("2", "Carcassonne", "", "", 2, 5, null, 35, emptyList())
-    val game3 = Game("3", "Azul", "", "", 2, 4, null, 30, emptyList())
+    val game1 = Game("1", "Catan", "", "", 3, 4, null, 60, genres = emptyList())
+    val game2 = Game("2", "Carcassonne", "", "", 2, 5, null, 35, genres = emptyList())
+    val game3 = Game("3", "Azul", "", "", 2, 4, null, 30, genres = emptyList())
   }
 
   private class FakeClipboardManager : ClipboardManager {
@@ -612,7 +612,7 @@ class ShopComponentsTest : FirestoreTests() {
     lateinit var stage: MutableIntState
     lateinit var setter: (List<Pair<Game, Int>>) -> Unit
 
-    val g4 = Game("4", "7 Wonders", "", "", 3, 7, null, 45, emptyList())
+    val g4 = Game("4", "7 Wonders", "", "", 3, 7, null, 45, genres = emptyList())
     val input = listOf(Fx.game1 to 1, Fx.game2 to 2, Fx.game3 to 3, g4 to 4)
 
     setContentThemed {

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/components/ShopComponentsTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/components/ShopComponentsTest.kt
@@ -37,6 +37,7 @@ import com.github.meeplemeet.model.shared.game.Game
 import com.github.meeplemeet.model.shops.OpeningHours
 import com.github.meeplemeet.model.shops.ShopSearchViewModel
 import com.github.meeplemeet.model.shops.TimeSlot
+import com.github.meeplemeet.ui.space_renter.SpaceRenterTestTags
 import com.github.meeplemeet.ui.theme.AppTheme
 import com.github.meeplemeet.ui.theme.ThemeMode
 import com.github.meeplemeet.utils.Checkpoint
@@ -46,6 +47,7 @@ import io.mockk.mockk
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import java.util.Calendar
+import kotlin.text.get
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Ignore
 import org.junit.Rule
@@ -77,9 +79,9 @@ class ShopComponentsTest : FirestoreTests() {
     val t12_00 = LocalTime.of(12, 0)!!
     val openingDefault = OpeningHours(0, listOf(TimeSlot("07:30", "12:00")))
     val openingOpen24 = OpeningHours(0, listOf(TimeSlot("00:00", "23:59")))
-    val game1 = Game("1", "Catan", "", "", 3, 4, null, 60, null, emptyList())
-    val game2 = Game("2", "Carcassonne", "", "", 2, 5, null, 35, null, emptyList())
-    val game3 = Game("3", "Azul", "", "", 2, 4, null, 30, null, emptyList())
+    val game1 = Game("1", "Catan", "", "", 3, 4, null, 60, emptyList())
+    val game2 = Game("2", "Carcassonne", "", "", 2, 5, null, 35, emptyList())
+    val game3 = Game("3", "Azul", "", "", 2, 4, null, 30, emptyList())
   }
 
   private class FakeClipboardManager : ClipboardManager {
@@ -360,7 +362,6 @@ class ShopComponentsTest : FirestoreTests() {
   }
 
   /** 4) GameStockDialog */
-  @Ignore
   @Test
   fun gameStockDialog_search_filter_duplicate_quantity_singleComposition() {
     val owner = Account(uid = "owner1", handle = "owner", name = "Owner", email = "owner@test")
@@ -612,7 +613,7 @@ class ShopComponentsTest : FirestoreTests() {
     lateinit var stage: MutableIntState
     lateinit var setter: (List<Pair<Game, Int>>) -> Unit
 
-    val g4 = Game("4", "7 Wonders", "", "", 3, 7, null, 45, null, emptyList())
+    val g4 = Game("4", "7 Wonders", "", "", 3, 7, null, 45, emptyList())
     val input = listOf(Fx.game1 to 1, Fx.game2 to 2, Fx.game3 to 3, g4 to 4)
 
     setContentThemed {
@@ -732,111 +733,66 @@ class ShopComponentsTest : FirestoreTests() {
   /** 7) AvailabilitySection */
   @Test
   fun availabilitySection_shopDetails_behaviours_todayAndMissingToday() {
-    // Compute "today" index exactly like AvailabilitySection does
-    val todayCalendarValue = Calendar.getInstance().get(Calendar.DAY_OF_WEEK)
-    val todayIndex = todayCalendarValue - 1
+    val today = Calendar.getInstance()[Calendar.DAY_OF_WEEK] - 1
 
-    // Full week of opening hours with same interval
+    // Full week with a single simple interval
     val week: List<OpeningHours> =
-        (0..6).map { day ->
-          OpeningHours(
-              day = day,
-              hours = listOf(TimeSlot(open = "09:00", close = "12:00")),
-          )
+        (0..6).map { d ->
+          OpeningHours(day = d, hours = listOf(TimeSlot(open = "09:00", close = "17:00")))
         }
 
-    val todayLines = humanize(week.first { it.day == todayIndex }.hours).split("\n")
+    val weekWithoutToday: List<OpeningHours> = week.filter { it.day != today }
 
-    // Week WITHOUT an entry for today's index
-    val weekWithoutToday: List<OpeningHours> =
-        (0..6)
-            .filter { it != todayIndex }
-            .map { day ->
-              OpeningHours(
-                  day = day,
-                  hours = listOf(TimeSlot(open = "09:00", close = "12:00")),
-              )
-            }
+    // Backing state for the composable - only call setContent once
+    val openingState = mutableStateOf(week)
 
-    lateinit var stage: MutableIntState
+    setContentThemed { AvailabilitySection(openingHours = openingState.value) }
 
-    setContentThemed {
-      val s = remember { mutableIntStateOf(0) }
-      stage = s
-      when (s.intValue) {
-        // 0: full week with today
-        0 ->
-            AvailabilitySection(
-                openingHours = week, dayTagPrefix = ShopComponentsTestTags.SHOP_DAY_PREFIX)
-        // 1: week without today's entry
-        1 ->
-            AvailabilitySection(
-                openingHours = weekWithoutToday,
-                dayTagPrefix = ShopComponentsTestTags.SHOP_DAY_PREFIX)
+    val prefix = ShopComponentsTestTags.SHOP_DAY_PREFIX
+
+    // Open sheet and wait until at least one day row is mounted inside the sheet
+    compose.onNodeWithTag(SpaceRenterTestTags.AVAILABILITY_HEADER).assertExists().performClick()
+    compose.waitForIdle()
+    val anotherDay = if (today == 0) 1 else 0
+    compose.waitUntil(timeoutMillis = 5_000) {
+      runCatching {
+            compose.onNodeWithTag("${prefix}${anotherDay}", useUnmergedTree = true).assertExists()
+            true
+          }
+          .isSuccess
+    }
+
+    // Assert all expected day rows exist for the full week
+    week.forEach { entry ->
+      val tag = "${prefix}${entry.day}"
+      checkpoint("Availability day exists: $tag") {
+        compose.onNodeWithTag(tag, useUnmergedTree = true).assertExists()
       }
     }
 
-    checkpoint("AvailabilitySection shows today and opens weekly dialog") {
-      compose.runOnUiThread { stage.intValue = 0 }
-      compose.waitForIdle()
+    // Close sheet (button text is "Close" per strings)
+    compose
+        .onNodeWithText(ShopUiDefaults.StringsMagicNumbers.BOTTOM_SHEET_CONFIRM_BUTTON_TEXT)
+        .performClick()
+    compose.waitForIdle()
 
-      // Header title
-      compose
-          .onText(ShopUiDefaults.StringsMagicNumbers.AVAILABILITY_SECTION_TEXT)
-          .assertExists()
-          .assertIsDisplayed()
+    // Update the backing state on the UI thread to remove today's entry (no second setContent)
+    compose.runOnIdle { openingState.value = weekWithoutToday }
 
-      // "Today:" label
-      compose
-          .onText(ShopUiDefaults.StringsMagicNumbers.TODAY_TEXT)
-          .assertExists()
-          .assertIsDisplayed()
-
-      // Today row tag
-      val todayTag = "${ShopComponentsTestTags.SHOP_DAY_PREFIX}${todayIndex}_HOURS"
-      compose.onTag(todayTag).assertExists().assertIsDisplayed()
-
-      // All humanized lines for today visible
-      todayLines.forEach { line -> compose.onText(line).assertExists() }
-
-      // Open weekly dialog via header row
-      val navigateTag = "${ShopComponentsTestTags.SHOP_DAY_PREFIX}NAVIGATE"
-      compose.onTag(navigateTag).assertExists().performClick()
-
-      // Bottom sheet confirm button ("Close")
-      compose
-          .onText(ShopUiDefaults.StringsMagicNumbers.BOTTOM_SHEET_CONFIRM_BUTTON_TEXT)
-          .assertExists()
-          .assertIsDisplayed()
-
-      // All 7 day rows present
-      (0..6).forEach { day ->
-        val dayTag = "${ShopComponentsTestTags.SHOP_DAY_PREFIX}$day"
-        compose.onTag(dayTag).assertExists()
-      }
-
-      // Close the dialog
-      compose
-          .onText(ShopUiDefaults.StringsMagicNumbers.BOTTOM_SHEET_CONFIRM_BUTTON_TEXT)
-          .performClick()
+    // Re-open sheet and wait until it is mounted again
+    compose.onNodeWithTag(SpaceRenterTestTags.AVAILABILITY_HEADER).performClick()
+    compose.waitForIdle()
+    compose.waitUntil(timeoutMillis = 5_000) {
+      runCatching {
+            compose.onNodeWithTag("${prefix}${anotherDay}", useUnmergedTree = true).assertExists()
+            true
+          }
+          .isSuccess
     }
 
-    checkpoint("AvailabilitySection without today's entry shows 'Closed'") {
-      compose.runOnUiThread { stage.intValue = 1 }
-      compose.waitForIdle()
-
-      // "Today:" label still shown
-      compose
-          .onText(ShopUiDefaults.StringsMagicNumbers.TODAY_TEXT)
-          .assertExists()
-          .assertIsDisplayed()
-
-      // Today row tag still exists
-      val todayTag = "${ShopComponentsTestTags.SHOP_DAY_PREFIX}${todayIndex}_HOURS"
-      compose.onTag(todayTag).assertExists().assertIsDisplayed()
-
-      // Fallback text should be "Closed"
-      compose.onText(ShopUiDefaults.StringsMagicNumbers.CLOSED).assertExists().assertIsDisplayed()
+    // Assert today row does not exist
+    checkpoint("Today missing when not provided") {
+      compose.onNodeWithTag("${prefix}${today}", useUnmergedTree = true).assertDoesNotExist()
     }
   }
 

--- a/app/src/main/java/com/github/meeplemeet/model/shared/game/Game.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/shared/game/Game.kt
@@ -25,7 +25,7 @@ data class Game(
     val maxPlayers: Int,
     val recommendedPlayers: Int?,
     val averagePlayTime: Int?,
-    val minAge: Int?,
+    val minAge: Int? = 3,
     val genres: List<String> = emptyList()
 )
 

--- a/app/src/main/java/com/github/meeplemeet/model/shared/game/Game.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/shared/game/Game.kt
@@ -25,7 +25,7 @@ data class Game(
     val maxPlayers: Int,
     val recommendedPlayers: Int?,
     val averagePlayTime: Int?,
-    val minAge: Int? = 3,
+    val minAge: Int? = 0,
     val genres: List<String> = emptyList()
 )
 

--- a/app/src/main/java/com/github/meeplemeet/ui/components/ShopComponents.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/ShopComponents.kt
@@ -1458,16 +1458,12 @@ fun AvailabilitySectionWithChevron(
   val todayHours = openingHours.firstOrNull { it.day == today }
 
   val todayText =
-      when {
-        todayHours == null || todayHours.hours.isEmpty() -> SpaceRenterUi.Misc.NO_TIME
-        todayHours.hours.size == 1 -> {
-          val (start, end) = todayHours.hours.first()
+      if (todayHours == null || todayHours.hours.isEmpty()) {
+        listOf(SpaceRenterUi.Misc.NO_TIME)
+      } else {
+        todayHours.hours.map { (start, end) ->
           SpaceRenterUi.AvailabilitySection.timeRange(start, end)
         }
-        else ->
-            todayHours.hours.joinToString(" ") { (start, end) ->
-              SpaceRenterUi.AvailabilitySection.timeRange(start, end)
-            }
       }
 
   Column(
@@ -1475,28 +1471,47 @@ fun AvailabilitySectionWithChevron(
           Modifier.fillMaxWidth()
               .padding(horizontal = if (addPadding) Dimensions.Padding.xxLarge else 0.dp)) {
         Row(
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
             modifier =
                 Modifier.fillMaxWidth()
                     .clickable { showSheet = true }
                     .testTag(SpaceRenterTestTags.AVAILABILITY_HEADER)
-                    .padding(vertical = Dimensions.Padding.medium),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically) {
-              Column {
+                    .padding(vertical = Dimensions.Padding.medium)) {
+              Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = SpaceRenterUi.AvailabilitySection.TITLE,
                     style = MaterialTheme.typography.titleLarge,
                     fontWeight = FontWeight.SemiBold)
-                Text(
-                    text = SpaceRenterUi.AvailabilitySection.todayDate(todayText),
-                    modifier = Modifier.testTag(ShopUiDefaults.StringsMagicNumbers.TODAY_TEXT),
-                    style = MaterialTheme.typography.bodyMedium)
+                Row(
+                    modifier =
+                        Modifier.fillMaxWidth()
+                            .padding(top = Dimensions.Padding.small)
+                            .testTag("${dayTagPrefix}${today}_HOURS"),
+                    verticalAlignment = Alignment.Top) {
+                      // Left label
+                      Text(
+                          text = SpaceRenterUi.AvailabilitySection.TODAY,
+                          style = MaterialTheme.typography.bodyMedium)
+
+                      Spacer(modifier = Modifier.width(Dimensions.Padding.medium))
+
+                      // Right – multiline times stacked neatly
+                      Column(
+                          verticalArrangement =
+                              Arrangement.spacedBy(Dimensions.Spacing.extraSmall)) {
+                            todayText.forEach { line ->
+                              Text(text = line, style = MaterialTheme.typography.bodyMedium)
+                            }
+                          }
+                    }
               }
 
               Icon(
                   Icons.Default.ChevronRight, contentDescription = null, tint = AppColors.textIcons)
             }
       }
+
   if (showSheet) {
     WeeklyAvailabilityDialog(
         openingHours = openingHours,
@@ -1534,6 +1549,8 @@ fun ContactSection(
         Text(
             text = name,
             style = MaterialTheme.typography.titleLarge,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
             fontWeight = FontWeight.SemiBold,
         )
 

--- a/app/src/main/java/com/github/meeplemeet/ui/components/ShopComponents.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/ShopComponents.kt
@@ -1447,7 +1447,7 @@ fun WeeklyAvailabilityDialog(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun AvailabilitySection(
+fun AvailabilitySectionWithChevron(
     openingHours: List<OpeningHours>,
     dayTagPrefix: String = ShopComponentsTestTags.SHOP_DAY_PREFIX,
     addPadding: Boolean = false
@@ -1518,10 +1518,19 @@ fun AvailabilitySection(
  * @param website website link to display
  */
 @Composable
-fun ContactSection(name: String, address: String, email: String, phone: String, website: String) {
+fun ContactSection(
+    name: String,
+    address: String,
+    email: String,
+    phone: String,
+    website: String,
+    addPadding: Boolean = false
+) {
   Column(
       verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.medium),
-      modifier = Modifier.fillMaxWidth()) {
+      modifier =
+          Modifier.fillMaxWidth()
+              .padding(horizontal = if (addPadding) Dimensions.Padding.xxLarge else 0.dp)) {
         Text(
             text = name,
             style = MaterialTheme.typography.titleLarge,

--- a/app/src/main/java/com/github/meeplemeet/ui/components/ShopComponents.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/ShopComponents.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.NavigateNext
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.ChevronRight

--- a/app/src/main/java/com/github/meeplemeet/ui/shops/ShopScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/shops/ShopScreen.kt
@@ -40,6 +40,7 @@ import com.github.meeplemeet.model.shared.game.Game
 import com.github.meeplemeet.model.shops.Shop
 import com.github.meeplemeet.model.shops.ShopViewModel
 import com.github.meeplemeet.ui.components.AvailabilitySection
+import com.github.meeplemeet.ui.components.AvailabilitySectionWithChevron
 import com.github.meeplemeet.ui.components.ContactSection
 import com.github.meeplemeet.ui.components.GameDetailsCard
 import com.github.meeplemeet.ui.components.ShopComponentsTestTags
@@ -207,7 +208,7 @@ fun ShopDetails(shop: Shop, modifier: Modifier = Modifier, onGameClick: (Game) -
         }
 
         item {
-          AvailabilitySection(
+          AvailabilitySectionWithChevron(
               shop.openingHours, dayTagPrefix = ShopComponentsTestTags.SHOP_DAY_PREFIX)
         }
 

--- a/app/src/main/java/com/github/meeplemeet/ui/shops/ShopScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/shops/ShopScreen.kt
@@ -109,7 +109,9 @@ fun ShopScreen(
     onBack: () -> Unit = {},
     onEdit: (Shop?) -> Unit = {},
 ) {
+  // Collect the current shop state from the ViewModel
   val shopState by viewModel.shop.collectAsStateWithLifecycle()
+  // Trigger loading of shop data when shopId changes
   LaunchedEffect(shopId) { viewModel.getShop(shopId) }
 
   var popupGame by remember { mutableStateOf<Game?>(null) }
@@ -193,7 +195,8 @@ fun ShopDetails(shop: Shop, modifier: Modifier = Modifier, onGameClick: (Game) -
       verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.xxLarge),
       contentPadding = PaddingValues(bottom = Dimensions.Spacing.xxLarge)) {
 
-        // Contact info
+        /* TODO: Add here shop images composable (pager) when done */
+
         item {
           ContactSection(
               name = shop.name,
@@ -203,8 +206,10 @@ fun ShopDetails(shop: Shop, modifier: Modifier = Modifier, onGameClick: (Game) -
               website = shop.website)
         }
 
-        // Opening hours
-        item { AvailabilitySection(shop.openingHours) }
+        item {
+          AvailabilitySection(
+              shop.openingHours, dayTagPrefix = ShopComponentsTestTags.SHOP_DAY_PREFIX)
+        }
 
         // Game list
         item {

--- a/app/src/main/java/com/github/meeplemeet/ui/shops/ShopScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/shops/ShopScreen.kt
@@ -39,7 +39,6 @@ import com.github.meeplemeet.model.auth.Account
 import com.github.meeplemeet.model.shared.game.Game
 import com.github.meeplemeet.model.shops.Shop
 import com.github.meeplemeet.model.shops.ShopViewModel
-import com.github.meeplemeet.ui.components.AvailabilitySection
 import com.github.meeplemeet.ui.components.AvailabilitySectionWithChevron
 import com.github.meeplemeet.ui.components.ContactSection
 import com.github.meeplemeet.ui.components.GameDetailsCard

--- a/app/src/main/java/com/github/meeplemeet/ui/space_renter/SpaceRenterScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/space_renter/SpaceRenterScreen.kt
@@ -476,7 +476,7 @@ private fun SpaceCard(space: Space, index: Int, isSelected: Boolean, onClick: ()
                     .testTag(SpaceRenterComponentsTestTags.SPACE_ROW_PREFIX + index),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween) {
-              Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+              Column(verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.extraSmall)) {
                 Text(
                     text = SpaceRenterUi.SpaceSection.setSpaceNumber(index),
                     style = MaterialTheme.typography.titleMedium,
@@ -508,14 +508,17 @@ private fun SpaceCard(space: Space, index: Int, isSelected: Boolean, onClick: ()
 private fun PriceRangeChip(minPrice: Double, maxPrice: Double) {
   Row(
       verticalAlignment = Alignment.CenterVertically,
-      horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-        Surface(shape = CircleShape, color = Color.Transparent, modifier = Modifier.size(24.dp)) {
-          Icon(
-              Icons.Default.Info,
-              contentDescription = null,
-              tint = AppColors.textIcons,
-              modifier = Modifier.padding(4.dp))
-        }
+      horizontalArrangement = Arrangement.spacedBy(Dimensions.Spacing.small)) {
+        Surface(
+            shape = CircleShape,
+            color = Color.Transparent,
+            modifier = Modifier.size(Dimensions.Spacing.xxLarge)) {
+              Icon(
+                  Icons.Default.Info,
+                  contentDescription = null,
+                  tint = AppColors.textIcons,
+                  modifier = Modifier.padding(Dimensions.Padding.small))
+            }
 
         Text(
             if (minPrice == maxPrice) "${minPrice}\$" else "${minPrice}-${maxPrice}\$",
@@ -667,6 +670,12 @@ fun ReservationBar(selectedSpace: Space?, selectedIndex: Int?, onApprove: () -> 
 }
 
 // TODO: remove me once the real photo carousel is implemented
+object TempCarouselUI {
+  val HEIGHT = 180.dp
+  val ACTIVE_SIZE = 9.dp
+  val INACTIVE_SIZE = 7.dp
+}
+
 @Composable
 private fun TemporaryPhotoCarousel() {
   val pageCount = 4
@@ -675,9 +684,9 @@ private fun TemporaryPhotoCarousel() {
   Box(
       modifier =
           Modifier.fillMaxWidth()
-              .height(180.dp)
+              .height(TempCarouselUI.HEIGHT)
               .padding(Dimensions.Padding.large)
-              .clip(RoundedCornerShape(16.dp))
+              .clip(RoundedCornerShape(Dimensions.CornerRadius.extraLarge))
               .background(Color(0xFF757575)) // grey placeholder
       ) {
         HorizontalPager(
@@ -686,14 +695,17 @@ private fun TemporaryPhotoCarousel() {
 
         // Dots inside the image
         Row(
-            modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 12.dp),
+            modifier =
+                Modifier.align(Alignment.BottomCenter).padding(bottom = Dimensions.Padding.large),
             horizontalArrangement = Arrangement.Center) {
               repeat(pageCount) { index ->
                 val active = pagerState.currentPage == index
                 Box(
                     modifier =
-                        Modifier.padding(4.dp)
-                            .size(if (active) 9.dp else 7.dp)
+                        Modifier.padding(Dimensions.Padding.small)
+                            .size(
+                                if (active) TempCarouselUI.ACTIVE_SIZE
+                                else TempCarouselUI.INACTIVE_SIZE)
                             .clip(CircleShape)
                             .background(
                                 if (active) AppColors.textIcons else AppColors.textIconsFade))

--- a/app/src/main/java/com/github/meeplemeet/ui/space_renter/SpaceRenterScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/space_renter/SpaceRenterScreen.kt
@@ -39,6 +39,7 @@ import com.github.meeplemeet.model.shops.OpeningHours
 import com.github.meeplemeet.model.space_renter.Space
 import com.github.meeplemeet.model.space_renter.SpaceRenter
 import com.github.meeplemeet.model.space_renter.SpaceRenterViewModel
+import com.github.meeplemeet.ui.components.SpaceRenterComponentsTestTags
 import com.github.meeplemeet.ui.shops.AvailabilitySection
 import com.github.meeplemeet.ui.theme.AppColors
 import com.github.meeplemeet.ui.theme.Dimensions
@@ -59,6 +60,9 @@ object SpaceRenterTestTags {
 
   // Availability section tags
   const val SPACE_RENTER_DAY_PREFIX = "SPACE_RENTER_DAY_"
+  const val RESERVE_NO_SELECTION = "RESERVATION_NO_SELECTION"
+  const val RESERVE_WITH_SELECTION = "RESERVATION_WITH_SELECTION"
+  const val AVAILABILITY_HEADER = "AVAILABILITY_HEADER"
 }
 
 object SpaceRenterUi {
@@ -219,32 +223,40 @@ fun ContactSection(spaceRenter: SpaceRenter) {
       verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.medium),
       modifier = Modifier.fillMaxWidth().padding(horizontal = Dimensions.Padding.xxLarge)) {
         Text(
-            spaceRenter.name,
+            text = spaceRenter.name,
             style = MaterialTheme.typography.titleLarge,
             fontWeight = FontWeight.SemiBold)
 
         // Display address contact row
         ContactRow(
-            Icons.Default.Place,
-            spaceRenter.address.name,
-            SpaceRenterTestTags.SPACE_RENTER_ADDRESS_TEXT)
+            icon = Icons.Default.Place,
+            text = spaceRenter.address.name,
+            testTag = SpaceRenterTestTags.SPACE_RENTER_ADDRESS_TEXT,
+            buttonTestTag = SpaceRenterTestTags.SPACE_RENTER_ADDRESS_BUTTON)
 
         // Display phone contact row if provided
         if (spaceRenter.phone.isNotBlank()) {
           ContactRow(
-              Icons.Default.Phone, spaceRenter.phone, SpaceRenterTestTags.SPACE_RENTER_PHONE_TEXT)
+              icon = Icons.Default.Phone,
+              text = spaceRenter.phone,
+              testTag = SpaceRenterTestTags.SPACE_RENTER_PHONE_TEXT,
+              buttonTestTag = SpaceRenterTestTags.SPACE_RENTER_PHONE_BUTTON)
         }
 
         // Display email contact row
         ContactRow(
-            Icons.Default.Email, spaceRenter.email, SpaceRenterTestTags.SPACE_RENTER_EMAIL_TEXT)
+            icon = Icons.Default.Email,
+            text = spaceRenter.email,
+            testTag = SpaceRenterTestTags.SPACE_RENTER_EMAIL_TEXT,
+            buttonTestTag = SpaceRenterTestTags.SPACE_RENTER_EMAIL_BUTTON)
 
         // Display website contact row if provided
         if (spaceRenter.website.isNotBlank()) {
           ContactRow(
-              Icons.Default.Language,
-              spaceRenter.website,
-              SpaceRenterTestTags.SPACE_RENTER_WEBSITE_TEXT)
+              icon = Icons.Default.Language,
+              text = spaceRenter.website,
+              testTag = SpaceRenterTestTags.SPACE_RENTER_WEBSITE_TEXT,
+              buttonTestTag = SpaceRenterTestTags.SPACE_RENTER_WEBSITE_BUTTON)
         }
       }
 }
@@ -262,6 +274,7 @@ fun ContactRow(
     icon: ImageVector,
     text: String,
     testTag: String,
+    buttonTestTag: String,
 ) {
   val clipboard = LocalClipboardManager.current
   val context = LocalContext.current
@@ -280,7 +293,7 @@ fun ContactRow(
             icon,
             contentDescription = null,
             tint = AppColors.neutral,
-            modifier = Modifier.size(Dimensions.IconSize.standard))
+            modifier = Modifier.size(Dimensions.IconSize.standard).testTag(buttonTestTag))
 
         Text(
             text,
@@ -453,7 +466,10 @@ private fun SpaceCard(space: Space, index: Int, isSelected: Boolean, onClick: ()
           if (isSelected) BorderStroke(Dimensions.DividerThickness.medium, AppColors.neutral)
           else null) {
         Row(
-            modifier = Modifier.fillMaxWidth().padding(Dimensions.Padding.large),
+            modifier =
+                Modifier.fillMaxWidth()
+                    .padding(Dimensions.Padding.large)
+                    .testTag(SpaceRenterComponentsTestTags.SPACE_ROW_PREFIX + index),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween) {
               Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
@@ -535,6 +551,7 @@ fun AvailabilityRowPopup(openingHours: List<OpeningHours>) {
         modifier =
             Modifier.fillMaxWidth()
                 .clickable { showSheet = true }
+                .testTag(SpaceRenterTestTags.AVAILABILITY_HEADER)
                 .padding(vertical = Dimensions.Padding.medium),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically) {
@@ -554,9 +571,7 @@ fun AvailabilityRowPopup(openingHours: List<OpeningHours>) {
 
   if (showSheet) {
     ModalBottomSheet(onDismissRequest = { showSheet = false }, containerColor = AppColors.primary) {
-      AvailabilitySection(
-          openingHours = openingHours, dayTagPrefix = SpaceRenterTestTags.SPACE_RENTER_DAY_PREFIX)
-
+      AvailabilitySection(openingHours, SpaceRenterTestTags.SPACE_RENTER_DAY_PREFIX)
       Spacer(Modifier.height(Dimensions.Spacing.xLarge))
     }
   }
@@ -582,6 +597,7 @@ fun ReservationBar(selectedSpace: Space?, selectedIndex: Int?, onApprove: () -> 
         if (selectedSpace == null) {
 
           Surface(
+              modifier = Modifier.testTag(SpaceRenterTestTags.RESERVE_NO_SELECTION),
               shape = RoundedCornerShape(SpaceRenterUi.BottomBar.SHAPE_PER),
               color = AppColors.secondary,
               shadowElevation = Dimensions.Elevation.extraHigh) {
@@ -599,6 +615,7 @@ fun ReservationBar(selectedSpace: Space?, selectedIndex: Int?, onApprove: () -> 
         } else {
 
           Surface(
+              Modifier.testTag(SpaceRenterTestTags.RESERVE_WITH_SELECTION),
               shape = RoundedCornerShape(SpaceRenterUi.BottomBar.SHAPE_PER),
               color = AppColors.secondary,
               shadowElevation = Dimensions.Elevation.high) {

--- a/app/src/main/java/com/github/meeplemeet/ui/space_renter/SpaceRenterScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/space_renter/SpaceRenterScreen.kt
@@ -320,7 +320,10 @@ fun SpacesSection(
               val end = minOf(start + SpaceRenterUi.SpaceSection.SPACES_PER_PAGE, spaces.size)
               val missing = SpaceRenterUi.SpaceSection.SPACES_PER_PAGE - (end - start)
               Column(
-                  modifier = Modifier.fillMaxWidth().fillMaxHeight().padding(horizontal = Dimensions.Spacing.medium),
+                  modifier =
+                      Modifier.fillMaxWidth()
+                          .fillMaxHeight()
+                          .padding(horizontal = Dimensions.Spacing.medium),
                   verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.large)) {
                     (start until end).forEach { i ->
                       SpaceCard(

--- a/app/src/main/java/com/github/meeplemeet/ui/space_renter/SpaceRenterScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/space_renter/SpaceRenterScreen.kt
@@ -90,9 +90,9 @@ object SpaceRenterUi {
   object AvailabilitySection {
     const val TITLE = "Availability"
 
-    fun todayDate(todayText: String) = "Today: $todayText"
+    const val TODAY = "Today:"
 
-    fun timeRange(start: String?, end: String?) = "$start - $end"
+    fun timeRange(start: String?, end: String?) = "${start}AM - ${end}PM"
   }
 }
 
@@ -311,11 +311,12 @@ fun SpacesSection(
                   modifier = Modifier.fillMaxWidth().fillMaxHeight(),
                   verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.large)) {
                     (start until end).forEach { i ->
+                      val onSelectParam = if (selectedIndex == i) null else i
                       SpaceCard(
                           space = spaces[i],
                           index = i,
                           isSelected = selectedIndex == i,
-                          onClick = { onSelect(if (selectedIndex == i) null else i) })
+                          onClick = { onSelect(onSelectParam) })
                     }
                     // Code needed to fix scrolling issues, otherwise UI looks weird when going from
                     // tab to tab with less than 3 items
@@ -330,15 +331,14 @@ fun SpacesSection(
           Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
             repeat(pageCount) { index ->
               val active = pagerState.currentPage == index
+              val dimensionsActive =
+                  if (active) Dimensions.Padding.extraMedium else Dimensions.Padding.medium
+              val colorsActive = if (active) AppColors.focus else AppColors.textIconsFade
               Box(
                   modifier =
                       Modifier.padding(Dimensions.Padding.small)
-                          .size(
-                              if (active) Dimensions.Padding.extraMedium
-                              else Dimensions.Padding.medium)
-                          .background(
-                              color = if (active) AppColors.focus else AppColors.textIconsFade,
-                              shape = CircleShape))
+                          .size(dimensionsActive)
+                          .background(color = colorsActive, shape = CircleShape))
             }
           }
         }

--- a/app/src/main/java/com/github/meeplemeet/ui/space_renter/SpaceRenterScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/space_renter/SpaceRenterScreen.kt
@@ -320,7 +320,7 @@ fun SpacesSection(
               val end = minOf(start + SpaceRenterUi.SpaceSection.SPACES_PER_PAGE, spaces.size)
               val missing = SpaceRenterUi.SpaceSection.SPACES_PER_PAGE - (end - start)
               Column(
-                  modifier = Modifier.fillMaxWidth().fillMaxHeight(),
+                  modifier = Modifier.fillMaxWidth().fillMaxHeight().padding(horizontal = Dimensions.Spacing.medium),
                   verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.large)) {
                     (start until end).forEach { i ->
                       SpaceCard(

--- a/app/src/main/java/com/github/meeplemeet/ui/space_renter/SpaceRenterScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/space_renter/SpaceRenterScreen.kt
@@ -1,7 +1,6 @@
 // AI was used to help comment this screen
 package com.github.meeplemeet.ui.space_renter
 
-import android.icu.util.Calendar
 import android.widget.Toast
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
@@ -39,10 +38,12 @@ import com.github.meeplemeet.model.shops.OpeningHours
 import com.github.meeplemeet.model.space_renter.Space
 import com.github.meeplemeet.model.space_renter.SpaceRenter
 import com.github.meeplemeet.model.space_renter.SpaceRenterViewModel
+import com.github.meeplemeet.ui.components.AvailabilitySection
 import com.github.meeplemeet.ui.components.SpaceRenterComponentsTestTags
 import com.github.meeplemeet.ui.shops.AvailabilitySection
 import com.github.meeplemeet.ui.theme.AppColors
 import com.github.meeplemeet.ui.theme.Dimensions
+import java.util.Calendar
 import kotlin.math.ceil
 
 /** Object containing test tags used in the Space Renter screen UI for UI testing purposes. */
@@ -197,7 +198,10 @@ fun SpaceRenterDetails(
       verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.xxLarge)) {
         TemporaryPhotoCarousel()
         ContactSection(spaceRenter)
-        AvailabilityRowPopup(openingHours = spaceRenter.openingHours)
+        AvailabilitySection(
+            openingHours = spaceRenter.openingHours,
+            dayTagPrefix = SpaceRenterTestTags.SPACE_RENTER_DAY_PREFIX,
+            addPadding = true)
         Column(
             verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.medium),
             modifier = Modifier.fillMaxWidth().padding(horizontal = Dimensions.Padding.xxLarge)) {
@@ -267,7 +271,8 @@ fun ContactSection(spaceRenter: SpaceRenter) {
  *
  * @param icon The icon to display for the contact method.
  * @param text The contact text to display and copy.
- * @param testTag The test tag for the text element.
+ * @param textTag The test tag for the text element.
+ * @param buttonTag The test tag for the copy button.
  */
 @Composable
 fun ContactRow(

--- a/app/src/main/java/com/github/meeplemeet/ui/space_renter/SpaceRenterScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/space_renter/SpaceRenterScreen.kt
@@ -198,10 +198,12 @@ fun SpaceRenterDetails(
             email = spaceRenter.email,
             website = spaceRenter.website,
             addPadding = true)
+
         AvailabilitySectionWithChevron(
             openingHours = spaceRenter.openingHours,
             dayTagPrefix = SpaceRenterTestTags.SPACE_RENTER_DAY_PREFIX,
             addPadding = true)
+
         Column(
             verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.medium),
             modifier = Modifier.fillMaxWidth().padding(horizontal = Dimensions.Padding.xxLarge)) {
@@ -213,14 +215,6 @@ fun SpaceRenterDetails(
             }
       }
 }
-
-// -------------------- CONTACT SECTION --------------------
-
-/**
- * Composable that displays the contact information section of the space renter.
- *
- * @param spaceRenter The space renter whose contact information is displayed.
- */
 
 /**
  * Composable that replaces material3's TopBarWithDivider The main difference is the text is now
@@ -299,7 +293,7 @@ fun SpacesSection(
   val maxPrice = spaces.maxOf { it.costPerHour }
 
   Column(
-      modifier = modifier.fillMaxWidth(), // Matches Figma spacing
+      modifier = modifier.fillMaxWidth(),
       verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.large)) {
 
         // Header row
@@ -326,7 +320,7 @@ fun SpacesSection(
               Column(
                   modifier = Modifier.fillMaxWidth().fillMaxHeight(),
                   verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.large)) {
-                    for (i in start until end) {
+                    (start until end).forEach { i ->
                       SpaceCard(
                           space = spaces[i],
                           index = i,
@@ -429,14 +423,16 @@ private fun PriceRangeChip(minPrice: Double, maxPrice: Double) {
             color = Color.Transparent,
             modifier = Modifier.size(Dimensions.Spacing.xxLarge)) {
               Icon(
-                  Icons.Default.Info,
+                  imageVector = Icons.Default.Money,
                   contentDescription = null,
                   tint = AppColors.textIcons,
-                  modifier = Modifier.padding(Dimensions.Padding.small))
+                  modifier =
+                      Modifier.padding(Dimensions.Padding.small)
+                          .size(Dimensions.IconSize.extraLarge))
             }
 
         Text(
-            if (minPrice == maxPrice) "${minPrice}\$" else "${minPrice}-${maxPrice}\$",
+            if (minPrice == maxPrice) "${minPrice}\$" else "${minPrice} - ${maxPrice}\$",
             style = MaterialTheme.typography.bodyMedium)
       }
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/space_renter/SpaceRenterScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/space_renter/SpaceRenterScreen.kt
@@ -32,7 +32,6 @@ import com.github.meeplemeet.model.auth.Account
 import com.github.meeplemeet.model.space_renter.Space
 import com.github.meeplemeet.model.space_renter.SpaceRenter
 import com.github.meeplemeet.model.space_renter.SpaceRenterViewModel
-import com.github.meeplemeet.ui.components.AvailabilitySection
 import com.github.meeplemeet.ui.components.AvailabilitySectionWithChevron
 import com.github.meeplemeet.ui.components.ContactSection
 import com.github.meeplemeet.ui.components.SpaceRenterComponentsTestTags
@@ -43,14 +42,6 @@ import kotlin.math.ceil
 /** Object containing test tags used in the Space Renter screen UI for UI testing purposes. */
 object SpaceRenterTestTags {
   // Contact section tags
-  const val SPACE_RENTER_PHONE_TEXT = "SPACE_RENTER_PHONE_TEXT"
-  const val SPACE_RENTER_PHONE_BUTTON = "SPACE_RENTER_PHONE_BUTTON"
-  const val SPACE_RENTER_EMAIL_TEXT = "SPACE_RENTER_EMAIL_TEXT"
-  const val SPACE_RENTER_EMAIL_BUTTON = "SPACE_RENTER_EMAIL_BUTTON"
-  const val SPACE_RENTER_ADDRESS_TEXT = "SPACE_RENTER_ADDRESS_TEXT"
-  const val SPACE_RENTER_ADDRESS_BUTTON = "SPACE_RENTER_ADDRESS_BUTTON"
-  const val SPACE_RENTER_WEBSITE_TEXT = "SPACE_RENTER_WEBSITE_TEXT"
-  const val SPACE_RENTER_WEBSITE_BUTTON = "SPACE_RENTER_WEBSITE_BUTTON"
   const val SPACE_RENTER_EDIT_BUTTON = "EDIT_SPACE_BUTTON"
 
   // Availability section tags
@@ -80,7 +71,6 @@ object SpaceRenterUi {
   }
 
   object Misc {
-    const val TOAST_SUCCESS = "Copied to clipboard"
     const val NO_TIME = "Closed"
     const val TITLE = "Details"
   }
@@ -88,6 +78,7 @@ object SpaceRenterUi {
   object SpaceSection {
     const val TITLE = "Available Spaces"
     val CARD_HEIGHT: Dp = 72.dp
+    val SPACES_PER_PAGE = 3
 
     fun setSpaceNumber(index: Int) = "Space N°${index + 1}"
 
@@ -285,8 +276,7 @@ fun SpacesSection(
 ) {
   if (spaces.isEmpty()) return
 
-  val spacesPerPage = 3
-  val pageCount = ceil(spaces.size / spacesPerPage.toFloat()).toInt()
+  val pageCount = ceil(spaces.size / SpaceRenterUi.SpaceSection.SPACES_PER_PAGE.toFloat()).toInt()
   val pagerState = rememberPagerState(pageCount = { pageCount })
 
   val minPrice = spaces.minOf { it.costPerHour }
@@ -302,7 +292,7 @@ fun SpacesSection(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically) {
               Text(
-                  text = SpaceRenterUi.AvailabilitySection.TITLE,
+                  text = SpaceRenterUi.SpaceSection.TITLE,
                   style = MaterialTheme.typography.titleLarge,
                   fontWeight = FontWeight.SemiBold)
 
@@ -314,9 +304,9 @@ fun SpacesSection(
             verticalAlignment = Alignment.Top,
             state = pagerState,
             modifier = Modifier.fillMaxWidth()) { page ->
-              val start = page * spacesPerPage
-              val end = minOf(start + spacesPerPage, spaces.size)
-              val missing = spacesPerPage - (end - start)
+              val start = page * SpaceRenterUi.SpaceSection.SPACES_PER_PAGE
+              val end = minOf(start + SpaceRenterUi.SpaceSection.SPACES_PER_PAGE, spaces.size)
+              val missing = SpaceRenterUi.SpaceSection.SPACES_PER_PAGE - (end - start)
               Column(
                   modifier = Modifier.fillMaxWidth().fillMaxHeight(),
                   verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.large)) {

--- a/app/src/main/java/com/github/meeplemeet/ui/space_renter/SpaceRenterScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/space_renter/SpaceRenterScreen.kt
@@ -35,6 +35,8 @@ import com.github.meeplemeet.model.space_renter.SpaceRenterViewModel
 import com.github.meeplemeet.ui.components.AvailabilitySectionWithChevron
 import com.github.meeplemeet.ui.components.ContactSection
 import com.github.meeplemeet.ui.components.SpaceRenterComponentsTestTags
+import com.github.meeplemeet.ui.components.TimeUi
+import com.github.meeplemeet.ui.components.tryParseTime
 import com.github.meeplemeet.ui.theme.AppColors
 import com.github.meeplemeet.ui.theme.Dimensions
 import kotlin.math.ceil
@@ -64,6 +66,7 @@ object SpaceRenterUi {
     const val INFO = "Click on a space to setup a reservation!"
     const val APPROVE = "Approve"
     const val SHAPE_PER = 60
+    val BAR_HEIGHT = 58.dp
 
     fun selectSpace(selectedIndex: Int?) = "Space N°${(selectedIndex ?: 0) + 1}"
 
@@ -92,7 +95,16 @@ object SpaceRenterUi {
 
     const val TODAY = "Today:"
 
-    fun timeRange(start: String?, end: String?) = "${start}AM - ${end}PM"
+    private fun formatTime(raw: String?): String {
+      val value = raw ?: return "-"
+      val parsed = value.tryParseTime()
+      return parsed?.format(TimeUi.fmt12()) ?: value
+    }
+
+    fun timeRange(start: String?, end: String?): String {
+      if (start == null && end == null) return SpaceRenterUi.Misc.NO_TIME
+      return "${formatTime(start)} - ${formatTime(end)}"
+    }
   }
 }
 
@@ -338,10 +350,24 @@ fun SpacesSection(
       }
 }
 
+/**
+ * Helper function to determine if the current index is equal to the target index.
+ *
+ * @param curr The current index.
+ * @param target The target index to compare against.
+ * @return Null if curr equals target, otherwise curr.
+ */
 private fun indexEquality(curr: Int, target: Int?): Int? {
   return if (curr == target) null else curr
 }
 
+/**
+ * Composable that displays pager dots indicating which page the user is currently viewing.
+ *
+ * @param pageCount The total number of pages.
+ * @param currentPage The index of the currently viewed page.
+ * @param modifier Modifier to be applied to the layout.
+ */
 @Composable
 private fun PagerDots(
     pageCount: Int,
@@ -455,7 +481,6 @@ private fun PriceRangeChip(minPrice: Double, maxPrice: Double) {
  */
 @Composable
 fun ReservationBar(selectedSpace: Space?, selectedIndex: Int?, onApprove: () -> Unit) {
-  val barHeight = 58.dp
   Box(
       modifier =
           Modifier.fillMaxWidth()
@@ -468,7 +493,8 @@ fun ReservationBar(selectedSpace: Space?, selectedIndex: Int?, onApprove: () -> 
 
           Surface(
               modifier =
-                  Modifier.testTag(SpaceRenterTestTags.RESERVE_NO_SELECTION).height(barHeight),
+                  Modifier.testTag(SpaceRenterTestTags.RESERVE_NO_SELECTION)
+                      .height(SpaceRenterUi.BottomBar.BAR_HEIGHT),
               shape = RoundedCornerShape(SpaceRenterUi.BottomBar.SHAPE_PER),
               color = AppColors.secondary,
               shadowElevation = Dimensions.Elevation.extraHigh) {
@@ -492,7 +518,8 @@ fun ReservationBar(selectedSpace: Space?, selectedIndex: Int?, onApprove: () -> 
 
           Surface(
               modifier =
-                  Modifier.testTag(SpaceRenterTestTags.RESERVE_WITH_SELECTION).height(barHeight),
+                  Modifier.testTag(SpaceRenterTestTags.RESERVE_WITH_SELECTION)
+                      .height(SpaceRenterUi.BottomBar.BAR_HEIGHT),
               shape = RoundedCornerShape(SpaceRenterUi.BottomBar.SHAPE_PER),
               color = AppColors.secondary,
               shadowElevation = Dimensions.Elevation.high) {

--- a/app/src/main/java/com/github/meeplemeet/ui/space_renter/SpaceRenterScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/space_renter/SpaceRenterScreen.kt
@@ -311,12 +311,17 @@ fun SpacesSection(
                   modifier = Modifier.fillMaxWidth().fillMaxHeight(),
                   verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.large)) {
                     (start until end).forEach { i ->
-                      val onSelectParam = if (selectedIndex == i) null else i
                       SpaceCard(
                           space = spaces[i],
                           index = i,
                           isSelected = selectedIndex == i,
-                          onClick = { onSelect(onSelectParam) })
+                          onClick = {
+                            onSelect(
+                                indexEquality(
+                                    curr = i,
+                                    target = selectedIndex,
+                                ))
+                          })
                     }
                     // Code needed to fix scrolling issues, otherwise UI looks weird when going from
                     // tab to tab with less than 3 items
@@ -328,21 +333,34 @@ fun SpacesSection(
 
         // Pager dots
         if (pageCount > 1) {
-          Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
-            repeat(pageCount) { index ->
-              val active = pagerState.currentPage == index
-              val dimensionsActive =
-                  if (active) Dimensions.Padding.extraMedium else Dimensions.Padding.medium
-              val colorsActive = if (active) AppColors.focus else AppColors.textIconsFade
-              Box(
-                  modifier =
-                      Modifier.padding(Dimensions.Padding.small)
-                          .size(dimensionsActive)
-                          .background(color = colorsActive, shape = CircleShape))
-            }
-          }
+          PagerDots(pageCount = pageCount, currentPage = pagerState.currentPage)
         }
       }
+}
+
+private fun indexEquality(curr: Int, target: Int?): Int? {
+  return if (curr == target) null else curr
+}
+
+@Composable
+private fun PagerDots(
+    pageCount: Int,
+    currentPage: Int,
+    modifier: Modifier = Modifier,
+) {
+  Row(modifier = modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
+    repeat(pageCount) { index ->
+      val active = currentPage == index
+      val size = if (active) Dimensions.Padding.extraMedium else Dimensions.Padding.medium
+      val color = if (active) AppColors.focus else AppColors.textIconsFade
+
+      Box(
+          modifier =
+              Modifier.padding(Dimensions.Padding.small)
+                  .size(size)
+                  .background(color = color, shape = CircleShape))
+    }
+  }
 }
 
 /**
@@ -437,41 +455,49 @@ private fun PriceRangeChip(minPrice: Double, maxPrice: Double) {
  */
 @Composable
 fun ReservationBar(selectedSpace: Space?, selectedIndex: Int?, onApprove: () -> Unit) {
+  val barHeight = 58.dp
   Box(
       modifier =
           Modifier.fillMaxWidth()
               .wrapContentHeight()
               .background(Color.Transparent)
               .padding(horizontal = Dimensions.Padding.extraLarge)
-              .padding(end = Dimensions.Padding.large),
+              .padding(bottom = Dimensions.Padding.xxLarge),
       contentAlignment = Alignment.BottomCenter) {
         if (selectedSpace == null) {
 
           Surface(
-              modifier = Modifier.testTag(SpaceRenterTestTags.RESERVE_NO_SELECTION),
+              modifier =
+                  Modifier.testTag(SpaceRenterTestTags.RESERVE_NO_SELECTION).height(barHeight),
               shape = RoundedCornerShape(SpaceRenterUi.BottomBar.SHAPE_PER),
               color = AppColors.secondary,
               shadowElevation = Dimensions.Elevation.extraHigh) {
                 Surface(
+                    modifier = Modifier.align(Alignment.Center),
                     shape = RoundedCornerShape(SpaceRenterUi.BottomBar.SHAPE_PER),
                     color = AppColors.affirmative) {
-                      Text(
-                          text = SpaceRenterUi.BottomBar.INFO,
-                          modifier =
-                              Modifier.padding(
-                                  horizontal = Dimensions.Padding.xLarge,
-                                  vertical = Dimensions.Padding.large))
+                      Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Text(
+                            text = SpaceRenterUi.BottomBar.INFO,
+                            style = MaterialTheme.typography.bodyMedium,
+                            textAlign = TextAlign.Center,
+                            modifier =
+                                Modifier.padding(
+                                    horizontal = Dimensions.Padding.xLarge,
+                                    vertical = Dimensions.Padding.large))
+                      }
                     }
               }
         } else {
 
           Surface(
-              Modifier.testTag(SpaceRenterTestTags.RESERVE_WITH_SELECTION),
+              modifier =
+                  Modifier.testTag(SpaceRenterTestTags.RESERVE_WITH_SELECTION).height(barHeight),
               shape = RoundedCornerShape(SpaceRenterUi.BottomBar.SHAPE_PER),
               color = AppColors.secondary,
               shadowElevation = Dimensions.Elevation.high) {
                 Row(
-                    modifier = Modifier.padding(horizontal = Dimensions.Padding.extraLarge),
+                    modifier = Modifier.padding(horizontal = Dimensions.Padding.xLarge),
                     verticalAlignment = Alignment.CenterVertically) {
                       Box(
                           modifier =
@@ -488,7 +514,8 @@ fun ReservationBar(selectedSpace: Space?, selectedIndex: Int?, onApprove: () -> 
                               Text(
                                   text =
                                       SpaceRenterUi.BottomBar.spaceDetails(
-                                          selectedSpace.seats, selectedSpace.costPerHour))
+                                          selectedSpace.seats, selectedSpace.costPerHour),
+                                  style = MaterialTheme.typography.labelSmall)
                             }
                           }
 

--- a/app/src/main/java/com/github/meeplemeet/ui/space_renter/SpaceRenterScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/space_renter/SpaceRenterScreen.kt
@@ -1,7 +1,6 @@
 // AI was used to help comment this screen
 package com.github.meeplemeet.ui.space_renter
 
-import android.widget.Toast
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -22,11 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalClipboardManager
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
@@ -34,7 +29,6 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.meeplemeet.model.auth.Account
-import com.github.meeplemeet.model.shops.OpeningHours
 import com.github.meeplemeet.model.space_renter.Space
 import com.github.meeplemeet.model.space_renter.SpaceRenter
 import com.github.meeplemeet.model.space_renter.SpaceRenterViewModel
@@ -44,7 +38,6 @@ import com.github.meeplemeet.ui.components.ContactSection
 import com.github.meeplemeet.ui.components.SpaceRenterComponentsTestTags
 import com.github.meeplemeet.ui.theme.AppColors
 import com.github.meeplemeet.ui.theme.Dimensions
-import java.util.Calendar
 import kotlin.math.ceil
 
 /** Object containing test tags used in the Space Renter screen UI for UI testing purposes. */
@@ -205,7 +198,7 @@ fun SpaceRenterDetails(
             email = spaceRenter.email,
             website = spaceRenter.website,
             addPadding = true)
-      AvailabilitySectionWithChevron(
+        AvailabilitySectionWithChevron(
             openingHours = spaceRenter.openingHours,
             dayTagPrefix = SpaceRenterTestTags.SPACE_RENTER_DAY_PREFIX,
             addPadding = true)
@@ -385,6 +378,7 @@ private fun SpaceCard(space: Space, index: Int, isSelected: Boolean, onClick: ()
           Modifier.fillMaxWidth()
               .clickable { onClick() }
               .height(SpaceRenterUi.SpaceSection.CARD_HEIGHT),
+      shadowElevation = Dimensions.Elevation.medium,
       shape = shape,
       color = AppColors.secondary,
       border =
@@ -460,9 +454,10 @@ fun ReservationBar(selectedSpace: Space?, selectedIndex: Int?, onApprove: () -> 
   Box(
       modifier =
           Modifier.fillMaxWidth()
+              .wrapContentHeight()
               .background(Color.Transparent)
-              .padding(
-                  horizontal = Dimensions.Padding.extraLarge, vertical = Dimensions.Padding.large),
+              .padding(horizontal = Dimensions.Padding.extraLarge)
+              .padding(end = Dimensions.Padding.large),
       contentAlignment = Alignment.BottomCenter) {
         if (selectedSpace == null) {
 
@@ -499,7 +494,7 @@ fun ReservationBar(selectedSpace: Space?, selectedIndex: Int?, onApprove: () -> 
                                       RoundedCornerShape(SpaceRenterUi.BottomBar.SHAPE_PER))
                                   .padding(
                                       horizontal = Dimensions.Padding.extraLarge,
-                                      vertical = Dimensions.Padding.extraMedium)) {
+                                      vertical = Dimensions.Padding.medium)) {
                             Column {
                               Text(
                                   text = SpaceRenterUi.BottomBar.selectSpace(selectedIndex),

--- a/app/src/main/java/com/github/meeplemeet/ui/space_renter/SpaceRenterScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/space_renter/SpaceRenterScreen.kt
@@ -40,7 +40,6 @@ import com.github.meeplemeet.model.space_renter.SpaceRenter
 import com.github.meeplemeet.model.space_renter.SpaceRenterViewModel
 import com.github.meeplemeet.ui.components.AvailabilitySection
 import com.github.meeplemeet.ui.components.SpaceRenterComponentsTestTags
-import com.github.meeplemeet.ui.shops.AvailabilitySection
 import com.github.meeplemeet.ui.theme.AppColors
 import com.github.meeplemeet.ui.theme.Dimensions
 import java.util.Calendar

--- a/app/src/main/java/com/github/meeplemeet/ui/theme/Dimensions.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/theme/Dimensions.kt
@@ -133,6 +133,7 @@ object Dimensions {
     val timeFieldHeight: Dp = 56.dp
     val iconButtonTouch: Dp = 40.dp
     val iconButtonSize: Dp = 48.dp
+    val bottomSheetHeight: Dp = 400.dp
   }
 
   // Badge dimensions

--- a/app/src/main/java/com/github/meeplemeet/ui/theme/Dimensions.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/theme/Dimensions.kt
@@ -133,7 +133,6 @@ object Dimensions {
     val timeFieldHeight: Dp = 56.dp
     val iconButtonTouch: Dp = 40.dp
     val iconButtonSize: Dp = 48.dp
-    val bottomSheetHeight: Dp = 400.dp
   }
 
   // Badge dimensions


### PR DESCRIPTION
### Overview
This PR refactors `SpaceRenterScreen.kt`, now being a more modernized and clean UI. 
It introduces the following changes to the composition of the screen:

- Image carousel placeholder
- Contact information is now less invasive
- Page slider for showing 3 different spaces per tab, as well as showing a min-max price range.
- Opening hours now just shows the availability for today. Weekly availability can be accessed through the chevron icon as `ModalBottomSheet`.
- Floating bottom bar for intstructions and reservations. It is **not yet** integrated with the backend, but it is tested such that later modifications should be smooth and easy.

Demo: https://github.com/user-attachments/assets/f822876f-dd13-4960-87ed-437fd65d0e70

### Known Limitations
- Screen does not implement the actual image gallery composable.