### PR TITLE
Feat/session overview

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/integration/SessionOverviewViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/SessionOverviewViewModelTest.kt
@@ -1,0 +1,101 @@
+package com.github.meeplemeet.integration
+
+import com.github.meeplemeet.model.auth.Account
+import com.github.meeplemeet.model.sessions.SessionOverviewViewModel
+import com.github.meeplemeet.model.shared.game.GAMES_COLLECTION_PATH
+import com.github.meeplemeet.model.shared.game.GameNoUid
+import com.github.meeplemeet.model.shared.location.Location
+import com.github.meeplemeet.utils.FirestoreTests
+import com.google.firebase.Timestamp
+import junit.framework.TestCase.*
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.tasks.await
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Integration test for SessionOverviewViewModel.
+ *
+ * Uses real Firestore repositories (no mocks) and verifies that sessionMapFlow emits the correct
+ * live map of discussion-id → Session when sessions are created / updated / deleted.
+ */
+class SessionOverviewViewModelTest : FirestoreTests() {
+
+  private lateinit var viewModel: SessionOverviewViewModel
+  private lateinit var account: Account
+  private lateinit var existingGameId: String
+  private val testLocation = Location(46.5197, 6.5665, "EPFL")
+
+  @Before
+  fun setup() = runBlocking {
+    viewModel = SessionOverviewViewModel()
+    account =
+        accountRepository.createAccount(
+            "sessionTestUser", "Session Tester", "session@test.com", photoUrl = null)
+    addGameDoc("g_chess", "Chess", genres = listOf(1, 2))
+    existingGameId = "g_chess"
+  }
+
+  @Test
+  fun sessionMapFlow_emitsEmptyMap_whenNoSessions() = runBlocking {
+    val map = viewModel.sessionMapFlow(account.uid).first()
+    assertTrue(map.isEmpty())
+  }
+
+  @Test
+  fun sessionMapFlow_emitsMapWithNewSession() = runBlocking {
+    // create a discussion + session
+    val discussion = discussionRepository.createDiscussion("Game Night", "Let's play", account.uid)
+    val game = gameRepository.getGameById(existingGameId)
+
+    sessionRepository.createSession(
+        discussion.uid, "Chess Night", game.uid, Timestamp.now(), testLocation, account.uid)
+
+    delay(100) // wait for Firestore snapshot
+
+    val map = viewModel.sessionMapFlow(account.uid).first()
+    assertEquals(1, map.size)
+    assertEquals("Chess Night", map[discussion.uid]?.name)
+  }
+
+  @Test
+  fun sessionMapFlow_removesEntry_whenSessionDeleted() = runBlocking {
+    // create
+    val discussion =
+        discussionRepository.createDiscussion("To Be Deleted", "Will disappear", account.uid)
+    val game = gameRepository.getGameById(existingGameId)
+
+    sessionRepository.createSession(
+        discussion.uid, "Delete Me", game.uid, Timestamp.now(), testLocation, account.uid)
+    delay(100)
+    assertEquals(1, viewModel.sessionMapFlow(account.uid).first().size)
+
+    // delete
+    sessionRepository.deleteSession(discussion.uid)
+    delay(100)
+
+    val map = viewModel.sessionMapFlow(account.uid).first()
+    assertTrue(map.isEmpty())
+  }
+
+  @Test
+  fun getGameNameByGameId_returnsName_whenGameExists() = runBlocking {
+    val name = viewModel.getGameNameByGameId(existingGameId)
+    assertEquals("Chess", name)
+  }
+
+  @Test
+  fun getGameNameByGameId_returnsNull_whenGameMissing() = runBlocking {
+    val name = viewModel.getGameNameByGameId("nonexistent")
+    assertNull(name)
+  }
+
+  private fun addGameDoc(id: String, name: String, genres: List<Int> = emptyList()) = runBlocking {
+    db.collection(GAMES_COLLECTION_PATH)
+        .document(id)
+        .set(GameNoUid(name = name, genres = genres))
+        .await()
+  }
+}

--- a/app/src/androidTest/java/com/github/meeplemeet/integration/SessionOverviewViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/SessionOverviewViewModelTest.kt
@@ -34,7 +34,7 @@ class SessionOverviewViewModelTest : FirestoreTests() {
     account =
         accountRepository.createAccount(
             "sessionTestUser", "Session Tester", "session@test.com", photoUrl = null)
-    addGameDoc("g_chess", "Chess", genres = listOf(1, 2))
+    addGameDoc("g_chess", "Chess", genres = listOf("1", "2"))
     existingGameId = "g_chess"
   }
 
@@ -92,10 +92,11 @@ class SessionOverviewViewModelTest : FirestoreTests() {
     assertNull(name)
   }
 
-  private fun addGameDoc(id: String, name: String, genres: List<Int> = emptyList()) = runBlocking {
-    db.collection(GAMES_COLLECTION_PATH)
-        .document(id)
-        .set(GameNoUid(name = name, genres = genres))
-        .await()
-  }
+  private fun addGameDoc(id: String, name: String, genres: List<String> = emptyList()) =
+      runBlocking {
+        db.collection(GAMES_COLLECTION_PATH)
+            .document(id)
+            .set(GameNoUid(name = name, genres = genres))
+            .await()
+      }
 }

--- a/app/src/main/java/com/github/meeplemeet/MainActivity.kt
+++ b/app/src/main/java/com/github/meeplemeet/MainActivity.kt
@@ -323,7 +323,15 @@ fun MeepleMeetApp(
       }
     }
 
-    composable(MeepleMeetScreen.SessionsOverview.name) { SessionsOverviewScreen(navigationActions) }
+    composable(MeepleMeetScreen.SessionsOverview.name) {
+      SessionsOverviewScreen(
+          navigation = navigationActions,
+          account = account,
+          onSelectSession = {
+            discussionId = it
+            navigationActions.navigateTo(MeepleMeetScreen.Session)
+          })
+    }
 
     composable(MeepleMeetScreen.PostsOverview.name) {
       PostsOverviewScreen(

--- a/app/src/main/java/com/github/meeplemeet/model/sessions/SessionOverviewViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/sessions/SessionOverviewViewModel.kt
@@ -1,0 +1,31 @@
+package com.github.meeplemeet.model.sessions
+
+import com.github.meeplemeet.RepositoryProvider
+import com.github.meeplemeet.model.shared.game.GameRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.*
+
+class SessionOverviewViewModel(
+    private val sessionRepository: SessionRepository = RepositoryProvider.sessions,
+    private val gameRepository: GameRepository = RepositoryProvider.games
+) : CreateSessionViewModel() {
+  suspend fun getGameNameByGameId(gameId: String): String? =
+      kotlin.runCatching { gameRepository.getGameById(gameId).name }.getOrNull()
+  /**
+   * Live map of discussion-id → Session for the given user. Emits a new map on every Firestore
+   * change.
+   */
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun sessionMapFlow(userId: String): Flow<Map<String, Session>> =
+      sessionRepository
+          .getSessionIdsForUserFlow(userId)
+          .mapLatest { ids ->
+            ids.associateWith { id ->
+                  sessionRepository.getSession(id) // <- use the function that IS in the repo
+                }
+                .filterValues { it != null }
+                .mapValues { it.value!! }
+          }
+          .flowOn(Dispatchers.IO)
+}

--- a/app/src/main/java/com/github/meeplemeet/ui/components/SessionComponents.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/SessionComponents.kt
@@ -926,6 +926,13 @@ private fun GameSearchBar(
 
   LaunchedEffect(initial) { if (initial?.name?.isNotBlank() == true) setGame(initial) }
 
+  // Sync text field with ViewModel's gameQuery when it changes (e.g., when game is fetched)
+  LaunchedEffect(results.gameQuery) {
+    if (results.gameQuery.isNotBlank() && text != results.gameQuery) {
+      text = results.gameQuery
+    }
+  }
+
   Column {
     ExposedDropdownMenuBox(
         expanded = menuOpen && hasSuggestions, onExpandedChange = { menuOpen = it }) {

--- a/app/src/main/java/com/github/meeplemeet/ui/sessions/CreateSessionScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/sessions/CreateSessionScreen.kt
@@ -77,7 +77,7 @@ private const val LABEL_DISCARD = "Discard"
 private const val LABEL_EDIT_TITLE = "Edit Title"
 private const val LABEL_DATE = "Date"
 private const val LABEL_TIME = "Time"
-private const val LABEL_UNKNOWN_GAME = "Unknown game"
+const val LABEL_UNKNOWN_GAME = "Unknown game"
 private const val LABEL_PARTICIPANTS = "Participants"
 
 /* =======================================================================

--- a/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionDetailsScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionDetailsScreen.kt
@@ -63,6 +63,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.github.meeplemeet.RepositoryProvider
 import com.github.meeplemeet.model.auth.Account
 import com.github.meeplemeet.model.discussions.Discussion
 import com.github.meeplemeet.model.sessions.SessionViewModel
@@ -172,7 +173,7 @@ fun timestampToLocal(timestamp: Timestamp): Pair<LocalDate, LocalTime> {
 fun SessionDetailsScreen(
     account: Account,
     discussion: Discussion,
-    viewModel: SessionViewModel = viewModel(),
+    viewModel: SessionViewModel = viewModel(key = discussion.uid),
     initial: SessionForm = SessionForm(),
     onBack: () -> Unit = {},
 ) {
@@ -198,21 +199,20 @@ fun SessionDetailsScreen(
   // This LaunchedEffect block updates the form state when the session changes.
   // It fetches participant accounts and updates the UI fields accordingly.
   // If the game info is missing, it triggers a fetch for the proposed game.
-  LaunchedEffect(session.gameId) {
+  LaunchedEffect(discussion.uid) {
     val (date, time) = timestampToLocal(session.date)
 
-    viewModel.getAccounts(session.participants) { accounts ->
-      form =
-          form.copy(
-              title = session.name,
-              date = date,
-              time = time,
-              proposedGameString = session.gameId,
-              participants = accounts,
-              locationText = session.location.name)
+    val accounts = RepositoryProvider.accounts.getAccounts(session.participants)
+    form =
+        form.copy(
+            title = session.name,
+            date = date,
+            time = time,
+            proposedGameString = session.gameId,
+            participants = accounts,
+            locationText = session.location.name)
 
-      if (form.proposedGameString.isNotBlank()) viewModel.getGameFromId(form.proposedGameString)
-    }
+    if (form.proposedGameString.isNotBlank()) viewModel.getGameFromId(form.proposedGameString)
 
     if (session.gameId.isNotBlank() && game == null) viewModel.getGameFromId(session.gameId)
   }

--- a/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionsOverviewScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionsOverviewScreen.kt
@@ -1,38 +1,343 @@
 package com.github.meeplemeet.ui.sessions
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Article
+import androidx.compose.material.icons.filled.Place
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.github.meeplemeet.model.auth.Account
+import com.github.meeplemeet.model.sessions.Session
+import com.github.meeplemeet.model.sessions.SessionOverviewViewModel
 import com.github.meeplemeet.ui.navigation.BottomNavigationMenu
 import com.github.meeplemeet.ui.navigation.MeepleMeetScreen
 import com.github.meeplemeet.ui.navigation.NavigationActions
 import com.github.meeplemeet.ui.navigation.NavigationTestTags
+import com.github.meeplemeet.ui.theme.AppColors
+import com.github.meeplemeet.ui.theme.Dimensions
+import com.github.meeplemeet.ui.theme.MessagingColors
+import java.text.SimpleDateFormat
+import java.util.Locale
 
+/**
+ * Main screen that lists gaming sessions for the logged-in user.
+ * - Collects a real-time list of sessions via [SessionOverviewViewModel.sessionMapFlow].
+ * - Offers a toggle between “Next sessions” (chronological list) and “History” (WIP placeholder).
+ * - Emits [onSelectSession] when the user taps a card.
+ *
+ * @param viewModel Source of truth for sessions – injected by default.
+ * @param navigation Global navigator supplied by the caller.
+ * @param account Currently signed-in user; UID is used to load personal sessions.
+ * @param onSelectSession Callback that receives the [Session] the user tapped.
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SessionsOverviewScreen(navigation: NavigationActions) {
+fun SessionsOverviewScreen(
+    viewModel: SessionOverviewViewModel = viewModel(),
+    navigation: NavigationActions,
+    account: Account?,
+    onSelectSession: (String) -> Unit = {}
+) {
+  val sessionMap by
+      viewModel.sessionMapFlow(account?.uid ?: "").collectAsState(initial = emptyMap())
+
+  /* --------------  NEW: toggle state  -------------- */
+  var showHistory by remember { mutableStateOf(false) }
+
   Scaffold(
       topBar = {
-        CenterAlignedTopAppBar(
-            title = {
-              Text(
-                  text = MeepleMeetScreen.SessionsOverview.title,
-                  style = MaterialTheme.typography.bodyMedium,
-                  color = MaterialTheme.colorScheme.onPrimary,
-                  modifier = Modifier.testTag(NavigationTestTags.SCREEN_TITLE))
-            })
+        Column(Modifier.fillMaxWidth()) {
+          /* 1. original top-bar (kept) */
+          CenterAlignedTopAppBar(
+              title = {
+                Text(
+                    text = MeepleMeetScreen.SessionsOverview.title,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onPrimary,
+                    modifier = Modifier.testTag(NavigationTestTags.SCREEN_TITLE))
+              })
+
+          SessionToggle( // <-- use the same variable
+              showHistory = showHistory,
+              onNext = { showHistory = false },
+              onHistory = { showHistory = true })
+        }
       },
       bottomBar = {
         BottomNavigationMenu(
             currentScreen = MeepleMeetScreen.SessionsOverview,
-            onTabSelected = { screen -> navigation.navigateTo(screen) })
+            onTabSelected = { navigation.navigateTo(it) })
       }) { innerPadding ->
-        Text("WIP", modifier = Modifier.padding(innerPadding))
+        Box(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
+          when {
+            showHistory -> {
+              /* ----------------  HISTORY (WIP)  ---------------- */
+              Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text(
+                    text = "WIP",
+                    style = MaterialTheme.typography.headlineSmall,
+                    color = AppColors.textIconsFade)
+              }
+            }
+            sessionMap.isEmpty() -> EmptySessionsListText()
+            else -> {
+              /* ----------------  NEXT SESSIONS (existing list)  ---------------- */
+              LazyColumn(
+                  modifier = Modifier.fillMaxSize(),
+                  verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.none)) {
+                    items(sessionMap.entries.toList(), key = { it.key }) { (id, session) ->
+                      SessionCard(
+                          session = session,
+                          viewModel = viewModel,
+                          modifier =
+                              Modifier.fillMaxWidth().testTag("sessionCard_${session.hashCode()}"),
+                          onClick = { onSelectSession(id) })
+                    }
+                  }
+            }
+          }
+        }
       }
 }
+
+/** Displays a centred label when the user has no upcoming sessions. */
+@Composable
+private fun EmptySessionsListText() {
+  Box(
+      modifier = Modifier.fillMaxSize().padding(Dimensions.Spacing.xxxLarge),
+      contentAlignment = Alignment.Center) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.medium)) {
+              Icon(
+                  imageVector = Icons.AutoMirrored.Filled.Article,
+                  contentDescription = null,
+                  modifier = Modifier.size(Dimensions.IconSize.giant),
+                  tint = MessagingColors.secondaryText)
+              Spacer(modifier = Modifier.height(Dimensions.Spacing.medium))
+              Text(
+                  text = NO_SESSIONS_DEFAULT_TEXT,
+                  style = MaterialTheme.typography.bodyLarge,
+                  fontSize = Dimensions.TextSize.title,
+                  color = MessagingColors.secondaryText)
+            }
+      }
+}
+
+/**
+ * Visual representation of a single session (Reddit-style card).
+ *
+ * Layout (top → bottom):
+ * - Session title
+ * - Game name (resolved asynchronously)
+ * - Participants: “Alice, Bob and 3 more” (resolved asynchronously)
+ * - Location • date
+ *
+ * @param session Domain object to render.
+ * @param viewModel Used to resolve participant names and game title.
+ * @param modifier Optional [Modifier].
+ * @param onClick Invoked when the card is tapped.
+ */
+@Composable
+private fun SessionCard(
+    session: Session,
+    viewModel: SessionOverviewViewModel,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit = {}
+) {
+  val date =
+      remember(session.date) {
+        SimpleDateFormat("dd/MM/yyyy", Locale.getDefault()).format(session.date.toDate())
+      }
+
+  /* ---------  resolve names via the callback  --------- */
+  val names = remember { mutableStateListOf<String>() }
+
+  LaunchedEffect(session.participants) {
+    names.clear()
+    session.participants.forEach { id ->
+      if (id.isBlank()) {
+        names += "Unknown"
+      } else {
+        viewModel.getOtherAccount(id) { acc ->
+          names += acc.name // re-composition happens on each addition
+        }
+      }
+    }
+  }
+  /* ----------------------------------------------------- */
+
+  val participantText =
+      when {
+        names.size < session.participants.size -> "Loading…"
+        names.isEmpty() -> "No participants"
+        names.size == 1 -> names.first()
+        names.size == 2 -> names.joinToString(", ")
+        else -> {
+          val firstTwo = names.take(2).joinToString(", ")
+          "$firstTwo and ${names.size - 2} more"
+        }
+      }
+
+  /* ----------  UI identical to before  ---------- */
+  Column(modifier = modifier) {
+    Row(
+        modifier =
+            Modifier.fillMaxWidth()
+                .clickable(onClick = onClick)
+                .background(AppColors.primary)
+                .padding(
+                    horizontal = Dimensions.Spacing.large, vertical = Dimensions.Spacing.large),
+        horizontalArrangement = Arrangement.spacedBy(Dimensions.Spacing.large)) {
+          Column(
+              modifier = Modifier.weight(1f),
+              verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.medium)) {
+                Text(
+                    text = session.name,
+                    style = MaterialTheme.typography.titleLarge,
+                    fontSize = Dimensions.TextSize.largeHeading,
+                    fontWeight = FontWeight.Medium,
+                    color = AppColors.textIcons,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis)
+                val gameName by
+                    produceState(
+                        key1 = session.gameId,
+                        initialValue = session.gameId // fallback: show id while loading
+                        ) {
+                          val name =
+                              if (session.gameId == LABEL_UNKNOWN_GAME) null
+                              else viewModel.getGameNameByGameId(session.gameId)
+                          value = name ?: "No game selected" // suspend call
+                    }
+                Text(
+                    text = gameName,
+                    style = MaterialTheme.typography.bodySmall,
+                    fontSize = Dimensions.TextSize.subtitle,
+                    color = AppColors.textIcons,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis)
+
+                Text(
+                    text = participantText,
+                    style = MaterialTheme.typography.bodySmall,
+                    fontSize = Dimensions.TextSize.body,
+                    color = AppColors.textIconsFade,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis)
+
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(Dimensions.Spacing.small)) {
+                      Icon(imageVector = Icons.Default.Place, contentDescription = null)
+                      Text(
+                          text = session.location.name,
+                          style = MaterialTheme.typography.bodySmall,
+                          fontSize = Dimensions.TextSize.small,
+                          color = AppColors.textIconsFade,
+                          maxLines = 1,
+                          overflow = TextOverflow.Ellipsis,
+                          modifier = Modifier.weight(1f, fill = false))
+                      Text(
+                          text = "•",
+                          fontSize = Dimensions.TextSize.small,
+                          color = AppColors.textIconsFade)
+                      Text(
+                          text = date,
+                          style = MaterialTheme.typography.bodySmall,
+                          fontSize = Dimensions.TextSize.small,
+                          color = AppColors.textIconsFade)
+                    }
+              }
+        }
+
+    HorizontalDivider(color = AppColors.divider, thickness = Dimensions.DividerThickness.standard)
+  }
+}
+
+/**
+ * Two-state toggle bar placed directly under the top app bar.
+ *
+ * The bar is split exactly 50/50:
+ * - Left half → “Next sessions”
+ * - Right half → “History”
+ *
+ * The active half uses [AppColors.primary] background and contrasting text.
+ *
+ * @param showHistory Which half is currently active.
+ * @param onNext Called when the left (Next) half is clicked.
+ * @param onHistory Called when the right (History) half is clicked.
+ */
+@Composable
+private fun SessionToggle(onNext: () -> Unit, onHistory: () -> Unit, showHistory: Boolean) {
+  Row(modifier = Modifier.fillMaxWidth().height(Dimensions.Spacing.xxxLarge)) {
+    /* ----  LEFT HALF – Next Sessions  ---- */
+    Box(
+        modifier =
+            Modifier.weight(1f)
+                .fillMaxHeight()
+                .background(if (!showHistory) AppColors.primary else AppColors.divider)
+                .clickable { onNext() },
+        contentAlignment = Alignment.Center) {
+          Text(
+              text = "Next sessions",
+              style = MaterialTheme.typography.bodyMedium,
+              fontWeight = FontWeight.Normal,
+              color = if (!showHistory) AppColors.textIcons else AppColors.textIconsFade)
+        }
+
+    /* ----  RIGHT HALF – History  ---- */
+    Box(
+        modifier =
+            Modifier.weight(1f)
+                .fillMaxHeight()
+                .background(if (showHistory) AppColors.primary else AppColors.divider)
+                .clickable { onHistory() },
+        contentAlignment = Alignment.Center) {
+          Text(
+              text = "History",
+              style = MaterialTheme.typography.bodyMedium,
+              fontWeight = FontWeight.Normal,
+              color = if (showHistory) AppColors.textIcons else AppColors.textIconsFade)
+        }
+  }
+  HorizontalDivider(color = AppColors.divider, thickness = Dimensions.DividerThickness.standard)
+}
+/* ========================================== */
+
+/* ============================================================================================= */
+private const val NO_SESSIONS_DEFAULT_TEXT = "No sessions yet"

--- a/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionsOverviewScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionsOverviewScreen.kt
@@ -1,3 +1,4 @@
+/**Documentation was generated using ChatGPT.*/
 package com.github.meeplemeet.ui.sessions
 
 import androidx.compose.foundation.background

--- a/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionsOverviewScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionsOverviewScreen.kt
@@ -123,8 +123,7 @@ fun SessionsOverviewScreen(
                       SessionCard(
                           session = session,
                           viewModel = viewModel,
-                          modifier =
-                              Modifier.fillMaxWidth().testTag("sessionCard_${session.hashCode()}"),
+                          modifier = Modifier.fillMaxWidth().testTag("sessionCard_$id"),
                           onClick = { onSelectSession(id) })
                     }
                   }
@@ -340,4 +339,4 @@ private fun SessionToggle(onNext: () -> Unit, onHistory: () -> Unit, showHistory
 /* ========================================== */
 
 /* ============================================================================================= */
-private const val NO_SESSIONS_DEFAULT_TEXT = "No sessions yet"
+const val NO_SESSIONS_DEFAULT_TEXT = "No sessions yet"

--- a/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionsOverviewScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionsOverviewScreen.kt
@@ -1,4 +1,4 @@
-/**Documentation was generated using ChatGPT.*/
+/** Documentation was generated using ChatGPT. */
 package com.github.meeplemeet.ui.sessions
 
 import androidx.compose.foundation.background


### PR DESCRIPTION
# PR: Session Overview – complete feature + navigation + tests

## Summary
Introduces a dedicated **Session Overview** screen where users can browse their upcoming board-game sessions, toggle to a history view, and navigate to session details.  
All layers (UI, ViewModel, navigation, integration tests) are included and wired into the existing app graph.

---

## What’s new

### 1. UI – `SessionsOverviewScreen`
- Reddit-style cards showing:
  - Session title  
  - Game name (resolved asynchronously)  
  - Participants (“Alice, Bob and 3 more”)  
  - Location & date
- Live empty-state illustration
- 50/50 coloured toggle bar: **Next sessions** | **History** (WIP placeholder)

### 2. ViewModel – `SessionOverviewViewModel`
- Real-time map keyed by **discussion id** (enables navigation).
- `getGameNameByGameId(gameId): String?` – safe, suspendable.
- Participant name resolution via existing callback API.

### 3. Navigation
- New destination `MeepleMeetScreen.SessionsOverview` added to `NavigationActions`.
- Bottom-bar item visible & wired.
- Tapping a card emits `onSelectSession(discussionId)` so the caller can push the detail screen.

<img width="375" height="777" alt="image" src="https://github.com/user-attachments/assets/6a7512a0-eeb1-4b04-97d7-5a23d4db29a1" />
