### PR TITLE
Feat/game info popup

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/ui/components/GameDetailsCardTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/components/GameDetailsCardTest.kt
@@ -12,64 +12,57 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class GameDetailsCardTest {
 
-    @get:Rule
-    val composeTestRule = createComposeRule()
+  @get:Rule val composeTestRule = createComposeRule()
 
-    private val fakeGame = Game(
-        uid = "demo",
-        name = "Test Game",
-        description = "This is a very long description intended to test the expandable overview feature of the composable. It should initially show a collapsed view and a Read more button.",
-        imageURL = "https://via.placeholder.com/600x400",
-        minPlayers = 2,
-        maxPlayers = 6,
-        recommendedPlayers = 4,
-        averagePlayTime = 90,
-        minAge = 8,
-        genres = listOf("economy", "trading", "negotiation")
-    )
+  private val fakeGame =
+      Game(
+          uid = "demo",
+          name = "Test Game",
+          description =
+              "This is a very long description intended to test the expandable overview feature of the composable. It should initially show a collapsed view and a Read more button.",
+          imageURL = "https://via.placeholder.com/600x400",
+          minPlayers = 2,
+          maxPlayers = 6,
+          recommendedPlayers = 4,
+          averagePlayTime = 90,
+          minAge = 8,
+          genres = listOf("economy", "trading", "negotiation"))
 
-    @Test
-    fun gameDetailsCard_displaysAllElements() {
-        composeTestRule.setContent {
-            AppTheme {
-                GameDetailsCard(game = fakeGame)
-            }
-        }
+  @Test
+  fun gameDetailsCard_displaysAllElements() {
+    composeTestRule.setContent { AppTheme { GameDetailsCard(game = fakeGame) } }
 
-        // Check if title is displayed
-        composeTestRule.onNodeWithText("Test Game").assertIsDisplayed()
+    // Check if title is displayed
+    composeTestRule.onNodeWithText("Test Game").assertIsDisplayed()
 
-        // Check if overview label is displayed
-        composeTestRule.onNodeWithText("Overview:").assertIsDisplayed()
+    // Check if overview label is displayed
+    composeTestRule.onNodeWithText("Overview:").assertIsDisplayed()
 
-        // Check if initial description is displayed (collapsed)
-        composeTestRule.onNodeWithText(fakeGame.description.substring(0, 20), substring = true)
-            .assertIsDisplayed()
+    // Check if initial description is displayed (collapsed)
+    composeTestRule
+        .onNodeWithText(fakeGame.description.substring(0, 20), substring = true)
+        .assertIsDisplayed()
 
-        // Check if genre chips are displayed
-        fakeGame.genres.forEach { genre ->
-            composeTestRule.onNodeWithText("#$genre").assertIsDisplayed()
-        }
-
-        // Check if the X button is displayed
-        composeTestRule.onNodeWithContentDescription("Close").assertIsDisplayed()
+    // Check if genre chips are displayed
+    fakeGame.genres.forEach { genre ->
+      composeTestRule.onNodeWithText("#$genre").assertIsDisplayed()
     }
 
-    @Test
-    fun gameDescription_expandsAndCollapses() {
-        composeTestRule.setContent {
-            AppTheme {
-                GameDetailsCard(game = fakeGame)
-            }
-        }
+    // Check if the X button is displayed
+    composeTestRule.onNodeWithContentDescription("Close").assertIsDisplayed()
+  }
 
-        val readMoreButton = composeTestRule.onNodeWithText("Read more…")
-        readMoreButton.assertExists().assertIsDisplayed()
+  @Test
+  fun gameDescription_expandsAndCollapses() {
+    composeTestRule.setContent { AppTheme { GameDetailsCard(game = fakeGame) } }
 
-        // Click "Read more…" to expand
-        readMoreButton.performClick()
+    val readMoreButton = composeTestRule.onNodeWithText("Read more…")
+    readMoreButton.assertExists().assertIsDisplayed()
 
-        // Now button should show "Read less"
-        composeTestRule.onNodeWithText("Read less").assertIsDisplayed()
-    }
+    // Click "Read more…" to expand
+    readMoreButton.performClick()
+
+    // Now button should show "Read less"
+    composeTestRule.onNodeWithText("Read less").assertIsDisplayed()
+  }
 }

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/components/GameDetailsCardTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/components/GameDetailsCardTest.kt
@@ -1,0 +1,75 @@
+package com.github.meeplemeet.ui.components
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.meeplemeet.model.shared.game.Game
+import com.github.meeplemeet.ui.theme.AppTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class GameDetailsCardTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val fakeGame = Game(
+        uid = "demo",
+        name = "Test Game",
+        description = "This is a very long description intended to test the expandable overview feature of the composable. It should initially show a collapsed view and a Read more button.",
+        imageURL = "https://via.placeholder.com/600x400",
+        minPlayers = 2,
+        maxPlayers = 6,
+        recommendedPlayers = 4,
+        averagePlayTime = 90,
+        minAge = 8,
+        genres = listOf("economy", "trading", "negotiation")
+    )
+
+    @Test
+    fun gameDetailsCard_displaysAllElements() {
+        composeTestRule.setContent {
+            AppTheme {
+                GameDetailsCard(game = fakeGame)
+            }
+        }
+
+        // Check if title is displayed
+        composeTestRule.onNodeWithText("Test Game").assertIsDisplayed()
+
+        // Check if overview label is displayed
+        composeTestRule.onNodeWithText("Overview:").assertIsDisplayed()
+
+        // Check if initial description is displayed (collapsed)
+        composeTestRule.onNodeWithText(fakeGame.description.substring(0, 20), substring = true)
+            .assertIsDisplayed()
+
+        // Check if genre chips are displayed
+        fakeGame.genres.forEach { genre ->
+            composeTestRule.onNodeWithText("#$genre").assertIsDisplayed()
+        }
+
+        // Check if the X button is displayed
+        composeTestRule.onNodeWithContentDescription("Close").assertIsDisplayed()
+    }
+
+    @Test
+    fun gameDescription_expandsAndCollapses() {
+        composeTestRule.setContent {
+            AppTheme {
+                GameDetailsCard(game = fakeGame)
+            }
+        }
+
+        val readMoreButton = composeTestRule.onNodeWithText("Read more…")
+        readMoreButton.assertExists().assertIsDisplayed()
+
+        // Click "Read more…" to expand
+        readMoreButton.performClick()
+
+        // Now button should show "Read less"
+        composeTestRule.onNodeWithText("Read less").assertIsDisplayed()
+    }
+}

--- a/app/src/main/java/com/github/meeplemeet/ui/components/GameDetailsCard.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/GameDetailsCard.kt
@@ -1,6 +1,7 @@
 package com.github.meeplemeet.ui.components
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.rememberScrollState
@@ -35,69 +36,87 @@ import com.github.meeplemeet.ui.theme.MessagingColors
 
 @Composable
 fun GameDetailsCard(game: Game, modifier: Modifier = Modifier, onClose: () -> Unit = {}) {
-  Column(modifier = modifier.fillMaxWidth()) {
-    Image(
-        painter = rememberAsyncImagePainter(game.imageURL),
-        contentDescription = game.name,
-        modifier =
-            Modifier.fillMaxWidth().height(180.dp).padding(0.dp).clip(RoundedCornerShape(12.dp)),
-        contentScale = ContentScale.Crop)
-    Column(modifier = modifier.fillMaxWidth().padding(16.dp)) {
-      Spacer(modifier = Modifier.height(16.dp))
+    Box(modifier = Modifier.background(color = AppColors.primary)) {
+        Column(modifier = modifier.fillMaxWidth()) {
+            Image(
+                painter = rememberAsyncImagePainter(game.imageURL),
+                contentDescription = game.name,
+                modifier =
+                    Modifier.fillMaxWidth().height(180.dp).padding(0.dp)
+                        .clip(RoundedCornerShape(12.dp)),
+                contentScale = ContentScale.Crop
+            )
+            Column(modifier = modifier.fillMaxWidth().padding(16.dp)) {
+                Spacer(modifier = Modifier.height(16.dp))
 
-      Box(
-          modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
-      ) {
-        Text(
-            text = game.name,
-            style = MaterialTheme.typography.headlineSmall,
-            fontWeight = FontWeight.Bold,
-            modifier = Modifier.align(Alignment.Center))
+                Box(
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                ) {
+                    Text(
+                        text = game.name,
+                        style = MaterialTheme.typography.headlineSmall,
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier.align(Alignment.Center)
+                    )
 
-        IconButton(onClick = { onClose() }, modifier = Modifier.align(Alignment.CenterEnd)) {
-          Icon(imageVector = Icons.Default.Close, contentDescription = "Close")
+                    IconButton(
+                        onClick = { onClose() },
+                        modifier = Modifier.align(Alignment.CenterEnd)
+                    ) {
+                        Icon(imageVector = Icons.Default.Close, contentDescription = "Close")
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+                HorizontalDivider(
+                    modifier = Modifier.fillMaxWidth(0.7F).align(Alignment.CenterHorizontally),
+                    thickness = 1.dp,
+                    color = AppColors.divider
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceEvenly,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    InfoChip(
+                        text = "${game.minPlayers}-${game.maxPlayers} Players",
+                        Icons.Default.People
+                    )
+                    game.averagePlayTime?.let {
+                        InfoChip(
+                            "$it min",
+                            iconVector = Icons.Default.AccessTime
+                        )
+                    }
+                    game.minAge?.let { InfoChip("Age: $it+") }
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                if (game.genres.isNotEmpty()) {
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        game.genres.forEach { genre ->
+                            AssistChip(
+                                colors =
+                                    AssistChipDefaults.assistChipColors(
+                                        containerColor = MessagingColors.redditBlueBg,
+                                        labelColor = MessagingColors.redditBlue,
+                                    ),
+                                border = null,
+                                onClick = {},
+                                label = { Text(text = "#$genre") })
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                GameDescription(game.description)
+            }
         }
-      }
-
-      Spacer(modifier = Modifier.height(8.dp))
-      HorizontalDivider(
-          modifier = Modifier.fillMaxWidth(0.7F).align(Alignment.CenterHorizontally),
-          thickness = 1.dp,
-          color = AppColors.divider)
-      Spacer(modifier = Modifier.height(8.dp))
-
-      Row(
-          modifier = Modifier.fillMaxWidth(),
-          horizontalArrangement = Arrangement.SpaceEvenly,
-          verticalAlignment = Alignment.CenterVertically) {
-            InfoChip(text = "${game.minPlayers}-${game.maxPlayers} Players", Icons.Default.People)
-            game.averagePlayTime?.let { InfoChip("$it min", iconVector = Icons.Default.AccessTime) }
-            game.minAge?.let { InfoChip("Age: $it+") }
-          }
-
-      Spacer(modifier = Modifier.height(12.dp))
-
-      if (game.genres.isNotEmpty()) {
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-          game.genres.forEach { genre ->
-            AssistChip(
-                colors =
-                    AssistChipDefaults.assistChipColors(
-                        containerColor = MessagingColors.redditBlueBg,
-                        labelColor = MessagingColors.redditBlue,
-                    ),
-                border = null,
-                onClick = {},
-                label = { Text(text = "#$genre") })
-          }
-        }
-      }
-
-      Spacer(modifier = Modifier.height(16.dp))
-
-      GameDescription(game.description)
     }
-  }
 }
 
 @Composable
@@ -138,6 +157,7 @@ fun GameDescription(description: String) {
     }
   }
 }
+
 
 @Composable
 fun InfoChip(text: String, iconVector: ImageVector? = null) {

--- a/app/src/main/java/com/github/meeplemeet/ui/components/GameDetailsCard.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/GameDetailsCard.kt
@@ -1,0 +1,205 @@
+package com.github.meeplemeet.ui.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccessTime
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.People
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil.compose.rememberAsyncImagePainter
+import com.github.meeplemeet.model.shared.game.Game
+import com.github.meeplemeet.ui.theme.AppColors
+import com.github.meeplemeet.ui.theme.Dimensions
+import com.github.meeplemeet.ui.theme.MessagingColors
+
+@Composable
+fun GameDetailsCard(
+    game: Game,
+    modifier: Modifier = Modifier,
+    onClose : () -> Unit = {}
+) {
+    Column(
+        modifier = modifier.fillMaxWidth()
+    ) {
+        Image(
+            painter = rememberAsyncImagePainter(game.imageURL),
+            contentDescription = game.name,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(180.dp).padding(0.dp)
+                .clip(RoundedCornerShape(12.dp)),
+            contentScale = ContentScale.Crop
+        )
+        Column(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        ) {
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+            ) {
+                Text(
+                    text = game.name,
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.align(Alignment.Center)
+                )
+
+                IconButton(
+                    onClick = { onClose() },
+                    modifier = Modifier.align(Alignment.CenterEnd)
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = "Close"
+                    )
+                }
+            }
+
+
+
+            Spacer(modifier = Modifier.height(8.dp))
+            HorizontalDivider(modifier = Modifier.fillMaxWidth( 0.7F).align(Alignment.CenterHorizontally), thickness = 1.dp, color = AppColors.divider)
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceEvenly,
+                verticalAlignment = Alignment.CenterVertically
+
+            ) {
+                InfoChip(text = "${game.minPlayers}-${game.maxPlayers} Players", Icons.Default.People)
+                game.averagePlayTime?.let {
+                    InfoChip("$it min", iconVector = Icons.Default.AccessTime)
+                }
+                game.minAge?.let {
+                    InfoChip("Age: $it+")
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            if (game.genres.isNotEmpty()) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    game.genres.forEach { genre ->
+                        AssistChip(
+                            colors = AssistChipDefaults.assistChipColors(
+                                containerColor = MessagingColors.redditBlueBg,
+                                labelColor = MessagingColors.redditBlue,
+                            ),
+                            border = null,
+                            onClick = {},
+                            label = { Text(text = "#$genre") }
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            GameDescription(game.description)
+        }
+    }
+}
+
+@Composable
+fun GameDescription(description: String) {
+    var expanded by remember { mutableStateOf(false) }
+    var textHeight by remember { mutableStateOf(0) }
+    val collapsedHeight = 70.dp
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = "Overview:",
+            style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+            modifier = Modifier.padding(horizontal = 16.dp)
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(max = if (expanded) Dp.Infinity else collapsedHeight)
+                .clipToBounds()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp)
+        ) {
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.onGloballyPositioned { coords ->
+                    textHeight = coords.size.height
+                }
+            )
+        }
+
+        // If text is taller than collapsedHeight, show Read more button
+        if (textHeight > with(LocalDensity.current) { collapsedHeight.toPx() } || expanded) {
+            TextButton(
+                onClick = { expanded = !expanded },
+                colors = ButtonDefaults.textButtonColors(
+                    contentColor = AppColors.textIcons
+                ),
+                modifier = Modifier.padding(start = 16.dp)
+            ) {
+                Text(if (expanded) "Read less" else "Read more…")
+            }
+        }
+    }
+}
+
+
+
+
+
+
+
+@Composable
+fun InfoChip(text: String, iconVector : ImageVector? = null) {
+    Surface(
+        shape = RoundedCornerShape(Dimensions.CornerRadius.medium),
+        shadowElevation = Dimensions.Elevation.low,
+        color = AppColors.secondary
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center
+        ) {
+            if (iconVector != null) Icon(imageVector = iconVector, contentDescription = null, modifier = Modifier.padding(start = 6.dp))
+                Text(
+                    text = text,
+                    modifier = if (iconVector != null) Modifier.padding(vertical = 12.dp).padding(start = 7.dp, end = 13.dp) else Modifier.padding(vertical = 12.dp, horizontal = 13.dp),
+                    style = MaterialTheme.typography.labelLarge,
+                    fontSize = MaterialTheme.typography.titleMedium.fontSize,
+                )
+        }
+    }
+}

--- a/app/src/main/java/com/github/meeplemeet/ui/components/GameDetailsCard.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/GameDetailsCard.kt
@@ -34,172 +34,134 @@ import com.github.meeplemeet.ui.theme.Dimensions
 import com.github.meeplemeet.ui.theme.MessagingColors
 
 @Composable
-fun GameDetailsCard(
-    game: Game,
-    modifier: Modifier = Modifier,
-    onClose : () -> Unit = {}
-) {
-    Column(
-        modifier = modifier.fillMaxWidth()
-    ) {
-        Image(
-            painter = rememberAsyncImagePainter(game.imageURL),
-            contentDescription = game.name,
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(180.dp).padding(0.dp)
-                .clip(RoundedCornerShape(12.dp)),
-            contentScale = ContentScale.Crop
-        )
-        Column(
-            modifier = modifier
-                .fillMaxWidth()
-                .padding(16.dp)
-        ) {
+fun GameDetailsCard(game: Game, modifier: Modifier = Modifier, onClose: () -> Unit = {}) {
+  Column(modifier = modifier.fillMaxWidth()) {
+    Image(
+        painter = rememberAsyncImagePainter(game.imageURL),
+        contentDescription = game.name,
+        modifier =
+            Modifier.fillMaxWidth().height(180.dp).padding(0.dp).clip(RoundedCornerShape(12.dp)),
+        contentScale = ContentScale.Crop)
+    Column(modifier = modifier.fillMaxWidth().padding(16.dp)) {
+      Spacer(modifier = Modifier.height(16.dp))
 
-            Spacer(modifier = Modifier.height(16.dp))
+      Box(
+          modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+      ) {
+        Text(
+            text = game.name,
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.align(Alignment.Center))
 
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
-            ) {
-                Text(
-                    text = game.name,
-                    style = MaterialTheme.typography.headlineSmall,
-                    fontWeight = FontWeight.Bold,
-                    modifier = Modifier.align(Alignment.Center)
-                )
-
-                IconButton(
-                    onClick = { onClose() },
-                    modifier = Modifier.align(Alignment.CenterEnd)
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.Close,
-                        contentDescription = "Close"
-                    )
-                }
-            }
-
-
-
-            Spacer(modifier = Modifier.height(8.dp))
-            HorizontalDivider(modifier = Modifier.fillMaxWidth( 0.7F).align(Alignment.CenterHorizontally), thickness = 1.dp, color = AppColors.divider)
-            Spacer(modifier = Modifier.height(8.dp))
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceEvenly,
-                verticalAlignment = Alignment.CenterVertically
-
-            ) {
-                InfoChip(text = "${game.minPlayers}-${game.maxPlayers} Players", Icons.Default.People)
-                game.averagePlayTime?.let {
-                    InfoChip("$it min", iconVector = Icons.Default.AccessTime)
-                }
-                game.minAge?.let {
-                    InfoChip("Age: $it+")
-                }
-            }
-
-            Spacer(modifier = Modifier.height(12.dp))
-
-            if (game.genres.isNotEmpty()) {
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    game.genres.forEach { genre ->
-                        AssistChip(
-                            colors = AssistChipDefaults.assistChipColors(
-                                containerColor = MessagingColors.redditBlueBg,
-                                labelColor = MessagingColors.redditBlue,
-                            ),
-                            border = null,
-                            onClick = {},
-                            label = { Text(text = "#$genre") }
-                        )
-                    }
-                }
-            }
-
-            Spacer(modifier = Modifier.height(16.dp))
-
-            GameDescription(game.description)
+        IconButton(onClick = { onClose() }, modifier = Modifier.align(Alignment.CenterEnd)) {
+          Icon(imageVector = Icons.Default.Close, contentDescription = "Close")
         }
+      }
+
+      Spacer(modifier = Modifier.height(8.dp))
+      HorizontalDivider(
+          modifier = Modifier.fillMaxWidth(0.7F).align(Alignment.CenterHorizontally),
+          thickness = 1.dp,
+          color = AppColors.divider)
+      Spacer(modifier = Modifier.height(8.dp))
+
+      Row(
+          modifier = Modifier.fillMaxWidth(),
+          horizontalArrangement = Arrangement.SpaceEvenly,
+          verticalAlignment = Alignment.CenterVertically) {
+            InfoChip(text = "${game.minPlayers}-${game.maxPlayers} Players", Icons.Default.People)
+            game.averagePlayTime?.let { InfoChip("$it min", iconVector = Icons.Default.AccessTime) }
+            game.minAge?.let { InfoChip("Age: $it+") }
+          }
+
+      Spacer(modifier = Modifier.height(12.dp))
+
+      if (game.genres.isNotEmpty()) {
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+          game.genres.forEach { genre ->
+            AssistChip(
+                colors =
+                    AssistChipDefaults.assistChipColors(
+                        containerColor = MessagingColors.redditBlueBg,
+                        labelColor = MessagingColors.redditBlue,
+                    ),
+                border = null,
+                onClick = {},
+                label = { Text(text = "#$genre") })
+          }
+        }
+      }
+
+      Spacer(modifier = Modifier.height(16.dp))
+
+      GameDescription(game.description)
     }
+  }
 }
 
 @Composable
 fun GameDescription(description: String) {
-    var expanded by remember { mutableStateOf(false) }
-    var textHeight by remember { mutableStateOf(0) }
-    val collapsedHeight = 70.dp
+  var expanded by remember { mutableStateOf(false) }
+  var textHeight by remember { mutableStateOf(0) }
+  val collapsedHeight = 70.dp
 
-    Column(modifier = Modifier.fillMaxWidth()) {
-        Text(
-            text = "Overview:",
-            style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
-            modifier = Modifier.padding(horizontal = 16.dp)
-        )
-        Spacer(modifier = Modifier.height(4.dp))
+  Column(modifier = Modifier.fillMaxWidth()) {
+    Text(
+        text = "Overview:",
+        style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+        modifier = Modifier.padding(horizontal = 16.dp))
+    Spacer(modifier = Modifier.height(4.dp))
 
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
+    Box(
+        modifier =
+            Modifier.fillMaxWidth()
                 .heightIn(max = if (expanded) Dp.Infinity else collapsedHeight)
                 .clipToBounds()
                 .verticalScroll(rememberScrollState())
-                .padding(horizontal = 16.dp)
-        ) {
-            Text(
-                text = description,
-                style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier.onGloballyPositioned { coords ->
-                    textHeight = coords.size.height
-                }
-            )
+                .padding(horizontal = 16.dp)) {
+          Text(
+              text = description,
+              style = MaterialTheme.typography.bodyMedium,
+              modifier =
+                  Modifier.onGloballyPositioned { coords -> textHeight = coords.size.height })
         }
 
-        // If text is taller than collapsedHeight, show Read more button
-        if (textHeight > with(LocalDensity.current) { collapsedHeight.toPx() } || expanded) {
-            TextButton(
-                onClick = { expanded = !expanded },
-                colors = ButtonDefaults.textButtonColors(
-                    contentColor = AppColors.textIcons
-                ),
-                modifier = Modifier.padding(start = 16.dp)
-            ) {
-                Text(if (expanded) "Read less" else "Read more…")
-            }
-        }
+    // If text is taller than collapsedHeight, show Read more button
+    if (textHeight > with(LocalDensity.current) { collapsedHeight.toPx() } || expanded) {
+      TextButton(
+          onClick = { expanded = !expanded },
+          colors = ButtonDefaults.textButtonColors(contentColor = AppColors.textIcons),
+          modifier = Modifier.padding(start = 16.dp)) {
+            Text(if (expanded) "Read less" else "Read more…")
+          }
     }
+  }
 }
 
-
-
-
-
-
-
 @Composable
-fun InfoChip(text: String, iconVector : ImageVector? = null) {
-    Surface(
-        shape = RoundedCornerShape(Dimensions.CornerRadius.medium),
-        shadowElevation = Dimensions.Elevation.low,
-        color = AppColors.secondary
-    ) {
+fun InfoChip(text: String, iconVector: ImageVector? = null) {
+  Surface(
+      shape = RoundedCornerShape(Dimensions.CornerRadius.medium),
+      shadowElevation = Dimensions.Elevation.low,
+      color = AppColors.secondary) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.Center
-        ) {
-            if (iconVector != null) Icon(imageVector = iconVector, contentDescription = null, modifier = Modifier.padding(start = 6.dp))
-                Text(
-                    text = text,
-                    modifier = if (iconVector != null) Modifier.padding(vertical = 12.dp).padding(start = 7.dp, end = 13.dp) else Modifier.padding(vertical = 12.dp, horizontal = 13.dp),
-                    style = MaterialTheme.typography.labelLarge,
-                    fontSize = MaterialTheme.typography.titleMedium.fontSize,
-                )
-        }
-    }
+            horizontalArrangement = Arrangement.Center) {
+              if (iconVector != null)
+                  Icon(
+                      imageVector = iconVector,
+                      contentDescription = null,
+                      modifier = Modifier.padding(start = 6.dp))
+              Text(
+                  text = text,
+                  modifier =
+                      if (iconVector != null)
+                          Modifier.padding(vertical = 12.dp).padding(start = 7.dp, end = 13.dp)
+                      else Modifier.padding(vertical = 12.dp, horizontal = 13.dp),
+                  style = MaterialTheme.typography.labelLarge,
+                  fontSize = MaterialTheme.typography.titleMedium.fontSize,
+              )
+            }
+      }
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/components/GameDetailsCard.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/GameDetailsCard.kt
@@ -37,6 +37,7 @@ import com.github.meeplemeet.ui.theme.MessagingColors
 private val CUSTOM_PADDING_START = 7.dp
 private val CUSTOM_PADDING_END = 13.dp
 private val CUSTOM_IMAGE_HEIGHT = 180.dp
+private val CUSTOM_COLLAPSED_DESCRIPTION_HEIGHT = 70.dp
 
 @Composable
 fun GameDetailsCard(game: Game, modifier: Modifier = Modifier, onClose: () -> Unit = {}) {
@@ -117,7 +118,7 @@ fun GameDetailsCard(game: Game, modifier: Modifier = Modifier, onClose: () -> Un
 fun GameDescription(description: String) {
   var expanded by remember { mutableStateOf(false) }
   var textHeight by remember { mutableStateOf(0) }
-  val collapsedHeight = 70.dp
+  val collapsedHeight = CUSTOM_COLLAPSED_DESCRIPTION_HEIGHT
 
   Column(modifier = Modifier.fillMaxWidth()) {
     Text(

--- a/app/src/main/java/com/github/meeplemeet/ui/components/GameDetailsCard.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/GameDetailsCard.kt
@@ -31,6 +31,7 @@ import com.github.meeplemeet.ui.theme.MessagingColors
 private val CUSTOM_PADDING_START = 7.dp
 private val CUSTOM_PADDING_END = 13.dp
 private val CUSTOM_IMAGE_HEIGHT = 180.dp
+private val CUSTOM_COLLAPSED_HEIGHT = 300.dp
 
 /**
  * A detailed card displaying information about a [Game].
@@ -167,7 +168,7 @@ fun GameDescription(description: String) {
       Box(
           modifier =
               Modifier.fillMaxWidth()
-                  .heightIn(max = 300.dp) // You can adjust height
+                  .heightIn(max = CUSTOM_COLLAPSED_HEIGHT) // You can adjust height
                   .verticalScroll(rememberScrollState())) {
             Text(
                 text = description,

--- a/app/src/main/java/com/github/meeplemeet/ui/components/GameDetailsCard.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/GameDetailsCard.kt
@@ -34,89 +34,83 @@ import com.github.meeplemeet.ui.theme.AppColors
 import com.github.meeplemeet.ui.theme.Dimensions
 import com.github.meeplemeet.ui.theme.MessagingColors
 
+private val CUSTOM_PADDING_START = 7.dp
+private val CUSTOM_PADDING_END = 13.dp
+private val CUSTOM_IMAGE_HEIGHT = 180.dp
+
 @Composable
 fun GameDetailsCard(game: Game, modifier: Modifier = Modifier, onClose: () -> Unit = {}) {
-    Box(modifier = Modifier.background(color = AppColors.primary)) {
-        Column(modifier = modifier.fillMaxWidth()) {
-            Image(
-                painter = rememberAsyncImagePainter(game.imageURL),
-                contentDescription = game.name,
-                modifier =
-                    Modifier.fillMaxWidth().height(180.dp).padding(0.dp)
-                        .clip(RoundedCornerShape(12.dp)),
-                contentScale = ContentScale.Crop
-            )
-            Column(modifier = modifier.fillMaxWidth().padding(16.dp)) {
-                Spacer(modifier = Modifier.height(16.dp))
+  Box(modifier = Modifier.background(color = AppColors.primary)) {
+    Column(modifier = modifier.fillMaxWidth()) {
+      Image(
+          painter = rememberAsyncImagePainter(game.imageURL),
+          contentDescription = game.name,
+          modifier =
+              Modifier.fillMaxWidth()
+                  .height(CUSTOM_IMAGE_HEIGHT)
+                  .clip(RoundedCornerShape(Dimensions.CornerRadius.large)),
+          contentScale = ContentScale.Crop)
+      Column(modifier = modifier.fillMaxWidth().padding(Dimensions.Padding.extraLarge)) {
+        Spacer(modifier = Modifier.height(Dimensions.Padding.extraLarge))
 
-                Box(
-                    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
-                ) {
-                    Text(
-                        text = game.name,
-                        style = MaterialTheme.typography.headlineSmall,
-                        fontWeight = FontWeight.Bold,
-                        modifier = Modifier.align(Alignment.Center)
-                    )
+        Box(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = Dimensions.Padding.extraLarge),
+        ) {
+          Text(
+              text = game.name,
+              style = MaterialTheme.typography.headlineSmall,
+              fontWeight = FontWeight.Bold,
+              modifier = Modifier.align(Alignment.Center))
 
-                    IconButton(
-                        onClick = { onClose() },
-                        modifier = Modifier.align(Alignment.CenterEnd)
-                    ) {
-                        Icon(imageVector = Icons.Default.Close, contentDescription = "Close")
-                    }
-                }
-
-                Spacer(modifier = Modifier.height(8.dp))
-                HorizontalDivider(
-                    modifier = Modifier.fillMaxWidth(0.7F).align(Alignment.CenterHorizontally),
-                    thickness = 1.dp,
-                    color = AppColors.divider
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceEvenly,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    InfoChip(
-                        text = "${game.minPlayers}-${game.maxPlayers} Players",
-                        Icons.Default.People
-                    )
-                    game.averagePlayTime?.let {
-                        InfoChip(
-                            "$it min",
-                            iconVector = Icons.Default.AccessTime
-                        )
-                    }
-                    game.minAge?.let { InfoChip("Age: $it+") }
-                }
-
-                Spacer(modifier = Modifier.height(12.dp))
-
-                if (game.genres.isNotEmpty()) {
-                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                        game.genres.forEach { genre ->
-                            AssistChip(
-                                colors =
-                                    AssistChipDefaults.assistChipColors(
-                                        containerColor = MessagingColors.redditBlueBg,
-                                        labelColor = MessagingColors.redditBlue,
-                                    ),
-                                border = null,
-                                onClick = {},
-                                label = { Text(text = "#$genre") })
-                        }
-                    }
-                }
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                GameDescription(game.description)
-            }
+          IconButton(onClick = { onClose() }, modifier = Modifier.align(Alignment.CenterEnd)) {
+            Icon(imageVector = Icons.Default.Close, contentDescription = "Close")
+          }
         }
+
+        Spacer(modifier = Modifier.height(Dimensions.Spacing.medium))
+        HorizontalDivider(
+            modifier =
+                Modifier.fillMaxWidth(Dimensions.Fractions.topBarDivider)
+                    .align(Alignment.CenterHorizontally),
+            thickness = Dimensions.DividerThickness.standard,
+            color = AppColors.divider)
+        Spacer(modifier = Modifier.height(Dimensions.Spacing.medium))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceEvenly,
+            verticalAlignment = Alignment.CenterVertically) {
+              InfoChip(text = "${game.minPlayers}-${game.maxPlayers} Players", Icons.Default.People)
+              game.averagePlayTime?.let {
+                InfoChip("$it min", iconVector = Icons.Default.AccessTime)
+              }
+              game.minAge?.let { InfoChip("Age: $it+") }
+            }
+
+        Spacer(modifier = Modifier.height(Dimensions.Spacing.large))
+
+        if (game.genres.isNotEmpty()) {
+          Row(horizontalArrangement = Arrangement.spacedBy(Dimensions.Spacing.medium)) {
+            game.genres.forEach { genre ->
+              AssistChip(
+                  colors =
+                      AssistChipDefaults.assistChipColors(
+                          containerColor = MessagingColors.redditBlueBg,
+                          labelColor = MessagingColors.redditBlue,
+                      ),
+                  border = null,
+                  onClick = {},
+                  label = { Text(text = "#$genre") })
+            }
+          }
+        }
+
+        Spacer(modifier = Modifier.height(Dimensions.Padding.extraLarge))
+
+        GameDescription(game.description)
+      }
     }
+  }
 }
 
 @Composable
@@ -129,8 +123,8 @@ fun GameDescription(description: String) {
     Text(
         text = "Overview:",
         style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
-        modifier = Modifier.padding(horizontal = 16.dp))
-    Spacer(modifier = Modifier.height(4.dp))
+        modifier = Modifier.padding(horizontal = Dimensions.Padding.extraLarge))
+    Spacer(modifier = Modifier.height(Dimensions.Spacing.small))
 
     Box(
         modifier =
@@ -138,7 +132,7 @@ fun GameDescription(description: String) {
                 .heightIn(max = if (expanded) Dp.Infinity else collapsedHeight)
                 .clipToBounds()
                 .verticalScroll(rememberScrollState())
-                .padding(horizontal = 16.dp)) {
+                .padding(horizontal = Dimensions.Padding.extraLarge)) {
           Text(
               text = description,
               style = MaterialTheme.typography.bodyMedium,
@@ -151,13 +145,12 @@ fun GameDescription(description: String) {
       TextButton(
           onClick = { expanded = !expanded },
           colors = ButtonDefaults.textButtonColors(contentColor = AppColors.textIcons),
-          modifier = Modifier.padding(start = 16.dp)) {
+          modifier = Modifier.padding(start = Dimensions.Padding.extraLarge)) {
             Text(if (expanded) "Read less" else "Read more…")
           }
     }
   }
 }
-
 
 @Composable
 fun InfoChip(text: String, iconVector: ImageVector? = null) {
@@ -172,13 +165,16 @@ fun InfoChip(text: String, iconVector: ImageVector? = null) {
                   Icon(
                       imageVector = iconVector,
                       contentDescription = null,
-                      modifier = Modifier.padding(start = 6.dp))
+                      modifier = Modifier.padding(start = Dimensions.Padding.mediumSmall))
               Text(
                   text = text,
                   modifier =
                       if (iconVector != null)
-                          Modifier.padding(vertical = 12.dp).padding(start = 7.dp, end = 13.dp)
-                      else Modifier.padding(vertical = 12.dp, horizontal = 13.dp),
+                          Modifier.padding(vertical = Dimensions.Padding.large)
+                              .padding(start = CUSTOM_PADDING_START, end = CUSTOM_PADDING_END)
+                      else
+                          Modifier.padding(
+                              vertical = Dimensions.Padding.large, horizontal = CUSTOM_PADDING_END),
                   style = MaterialTheme.typography.labelLarge,
                   fontSize = MaterialTheme.typography.titleMedium.fontSize,
               )

--- a/app/src/main/java/com/github/meeplemeet/ui/components/GameDetailsCard.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/GameDetailsCard.kt
@@ -2,8 +2,9 @@ package com.github.meeplemeet.ui.components
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -12,21 +13,14 @@ import androidx.compose.material.icons.filled.AccessTime
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.People
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
 import com.github.meeplemeet.model.shared.game.Game
@@ -37,122 +31,166 @@ import com.github.meeplemeet.ui.theme.MessagingColors
 private val CUSTOM_PADDING_START = 7.dp
 private val CUSTOM_PADDING_END = 13.dp
 private val CUSTOM_IMAGE_HEIGHT = 180.dp
-private val CUSTOM_COLLAPSED_DESCRIPTION_HEIGHT = 70.dp
 
+/**
+ * A detailed card displaying information about a [Game].
+ *
+ * Shows the game title, an image, info chips for players, time, and age, genres, and a description
+ * that can be expanded/collapsed.
+ *
+ * @param game The [Game] object containing all information to display.
+ * @param modifier Optional [Modifier] for the card container.
+ * @param onClose Lambda invoked when the close button is pressed.
+ */
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun GameDetailsCard(game: Game, modifier: Modifier = Modifier, onClose: () -> Unit = {}) {
-  Box(modifier = Modifier.background(color = AppColors.primary)) {
-    Column(modifier = modifier.fillMaxWidth()) {
-      Image(
-          painter = rememberAsyncImagePainter(game.imageURL),
-          contentDescription = game.name,
-          modifier =
-              Modifier.fillMaxWidth()
-                  .height(CUSTOM_IMAGE_HEIGHT)
-                  .clip(RoundedCornerShape(Dimensions.CornerRadius.large)),
-          contentScale = ContentScale.Crop)
-      Column(modifier = modifier.fillMaxWidth().padding(Dimensions.Padding.extraLarge)) {
-        Spacer(modifier = Modifier.height(Dimensions.Padding.extraLarge))
 
-        Box(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = Dimensions.Padding.extraLarge),
-        ) {
-          Text(
-              text = game.name,
-              style = MaterialTheme.typography.headlineSmall,
-              fontWeight = FontWeight.Bold,
-              modifier = Modifier.align(Alignment.Center))
-
-          IconButton(onClick = { onClose() }, modifier = Modifier.align(Alignment.CenterEnd)) {
-            Icon(imageVector = Icons.Default.Close, contentDescription = "Close")
-          }
-        }
-
-        Spacer(modifier = Modifier.height(Dimensions.Spacing.medium))
-        HorizontalDivider(
+  Box(
+      modifier =
+          modifier
+              .fillMaxWidth() // optional width limitation
+              .border(
+                  width = Dimensions.Padding.tiny,
+                  color = AppColors.secondary, // border color
+                  shape = RoundedCornerShape(Dimensions.CornerRadius.large))
+              .clip(
+                  RoundedCornerShape(
+                      Dimensions.CornerRadius.large)) // rounded corners for the whole card
+              .background(AppColors.primary), // card background
+      contentAlignment = Alignment.Center) {
+        Column(
             modifier =
-                Modifier.fillMaxWidth(Dimensions.Fractions.topBarDivider)
-                    .align(Alignment.CenterHorizontally),
-            thickness = Dimensions.DividerThickness.standard,
-            color = AppColors.divider)
-        Spacer(modifier = Modifier.height(Dimensions.Spacing.medium))
+                Modifier.widthIn(max = Dimensions.ContainerSize.maxListHeight)
+                    .padding(Dimensions.Padding.extraLarge)) {
 
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceEvenly,
-            verticalAlignment = Alignment.CenterVertically) {
-              InfoChip(text = "${game.minPlayers}-${game.maxPlayers} Players", Icons.Default.People)
-              game.averagePlayTime?.let {
-                InfoChip("$it min", iconVector = Icons.Default.AccessTime)
+              // TITLE + CLOSE
+              Box(modifier = Modifier.fillMaxWidth()) {
+                Text(
+                    text = game.name,
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.align(Alignment.Center))
+
+                IconButton(onClick = onClose, modifier = Modifier.align(Alignment.CenterEnd)) {
+                  Icon(Icons.Default.Close, contentDescription = "Close")
+                }
               }
-              game.minAge?.let { InfoChip("Age: $it+") }
+
+              Spacer(modifier = Modifier.height(Dimensions.Spacing.medium))
+              // IMAGE
+              Image(
+                  painter = rememberAsyncImagePainter(game.imageURL),
+                  contentDescription = game.name,
+                  contentScale = ContentScale.Fit, // preserves natural aspect ratio
+                  modifier =
+                      Modifier.fillMaxWidth() // expand to available width
+                          .heightIn(max = CUSTOM_IMAGE_HEIGHT) // limit height
+                          .clip(RoundedCornerShape(Dimensions.CornerRadius.large)))
+
+              Spacer(modifier = Modifier.height(Dimensions.Padding.extraLarge))
+
+              HorizontalDivider(
+                  modifier =
+                      Modifier.fillMaxWidth(Dimensions.Fractions.topBarDivider)
+                          .align(Alignment.CenterHorizontally),
+                  thickness = Dimensions.DividerThickness.standard,
+                  color = AppColors.divider)
+
+              Spacer(modifier = Modifier.height(Dimensions.Spacing.medium))
+
+              // INFO CHIPS
+              Row(
+                  modifier = Modifier.fillMaxWidth(),
+                  horizontalArrangement = Arrangement.SpaceEvenly,
+                  verticalAlignment = Alignment.CenterVertically) {
+                    InfoChip("${game.minPlayers}-${game.maxPlayers} Players", Icons.Default.People)
+                    game.averagePlayTime?.let { InfoChip("$it min", Icons.Default.AccessTime) }
+                    game.minAge?.let { InfoChip("Age: $it+") }
+                  }
+
+              Spacer(modifier = Modifier.height(Dimensions.Spacing.large))
+
+              // GENRES
+              if (game.genres.isNotEmpty()) {
+                FlowRow(
+                    maxLines = 2,
+                    horizontalArrangement = Arrangement.spacedBy(Dimensions.Spacing.medium),
+                    modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState())) {
+                      game.genres.forEach { genre ->
+                        AssistChip(
+                            colors =
+                                AssistChipDefaults.assistChipColors(
+                                    containerColor = MessagingColors.redditBlueBg,
+                                    labelColor = MessagingColors.redditBlue,
+                                ),
+                            border = null,
+                            onClick = {},
+                            label = { Text("#$genre") })
+                      }
+                    }
+              }
+
+              Spacer(modifier = Modifier.height(Dimensions.Padding.extraLarge))
+
+              // DESCRIPTION
+              GameDescription(game.description)
             }
-
-        Spacer(modifier = Modifier.height(Dimensions.Spacing.large))
-
-        if (game.genres.isNotEmpty()) {
-          Row(horizontalArrangement = Arrangement.spacedBy(Dimensions.Spacing.medium)) {
-            game.genres.forEach { genre ->
-              AssistChip(
-                  colors =
-                      AssistChipDefaults.assistChipColors(
-                          containerColor = MessagingColors.redditBlueBg,
-                          labelColor = MessagingColors.redditBlue,
-                      ),
-                  border = null,
-                  onClick = {},
-                  label = { Text(text = "#$genre") })
-            }
-          }
-        }
-
-        Spacer(modifier = Modifier.height(Dimensions.Padding.extraLarge))
-
-        GameDescription(game.description)
       }
-    }
-  }
 }
 
+/**
+ * A composable showing a collapsible/expandable description text.
+ *
+ * @param description The text to display in the description box.
+ */
 @Composable
 fun GameDescription(description: String) {
   var expanded by remember { mutableStateOf(false) }
-  var textHeight by remember { mutableStateOf(0) }
-  val collapsedHeight = CUSTOM_COLLAPSED_DESCRIPTION_HEIGHT
 
   Column(modifier = Modifier.fillMaxWidth()) {
     Text(
         text = "Overview:",
-        style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
-        modifier = Modifier.padding(horizontal = Dimensions.Padding.extraLarge))
+        style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold))
+
     Spacer(modifier = Modifier.height(Dimensions.Spacing.small))
 
-    Box(
-        modifier =
-            Modifier.fillMaxWidth()
-                .heightIn(max = if (expanded) Dp.Infinity else collapsedHeight)
-                .clipToBounds()
-                .verticalScroll(rememberScrollState())
-                .padding(horizontal = Dimensions.Padding.extraLarge)) {
-          Text(
-              text = description,
-              style = MaterialTheme.typography.bodyMedium,
-              modifier =
-                  Modifier.onGloballyPositioned { coords -> textHeight = coords.size.height })
-        }
-
-    // If text is taller than collapsedHeight, show Read more button
-    if (textHeight > with(LocalDensity.current) { collapsedHeight.toPx() } || expanded) {
-      TextButton(
-          onClick = { expanded = !expanded },
-          colors = ButtonDefaults.textButtonColors(contentColor = AppColors.textIcons),
-          modifier = Modifier.padding(start = Dimensions.Padding.extraLarge)) {
-            Text(if (expanded) "Read less" else "Read more…")
+    if (!expanded) {
+      // COLLAPSED VERSION (ellipsis)
+      Text(
+          text = description,
+          style = MaterialTheme.typography.bodyMedium,
+          maxLines = 3,
+          overflow = TextOverflow.Ellipsis)
+    } else {
+      // EXPANDED VERSION (scrollable)
+      Box(
+          modifier =
+              Modifier.fillMaxWidth()
+                  .heightIn(max = 300.dp) // You can adjust height
+                  .verticalScroll(rememberScrollState())) {
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodyMedium,
+            )
           }
     }
+
+    TextButton(
+        onClick = { expanded = !expanded },
+        modifier = Modifier.align(Alignment.End),
+        colors = ButtonDefaults.textButtonColors(contentColor = AppColors.textIcons)) {
+          Text(if (expanded) "Read less" else "Read more…")
+        }
   }
 }
 
+/**
+ * A small chip displaying a short text with an optional leading icon.
+ *
+ * @param text The text to display inside the chip.
+ * @param iconVector Optional leading icon to show before the text.
+ */
 @Composable
 fun InfoChip(text: String, iconVector: ImageVector? = null) {
   Surface(
@@ -167,6 +205,7 @@ fun InfoChip(text: String, iconVector: ImageVector? = null) {
                       imageVector = iconVector,
                       contentDescription = null,
                       modifier = Modifier.padding(start = Dimensions.Padding.mediumSmall))
+
               Text(
                   text = text,
                   modifier =

--- a/app/src/main/java/com/github/meeplemeet/ui/shops/ShopScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/shops/ShopScreen.kt
@@ -153,7 +153,7 @@ fun ShopScreen(
  */
 @Composable
 fun ShopDetails(shop: Shop, modifier: Modifier = Modifier) {
-    var popupGame by remember { mutableStateOf<Game?>(null) }
+  var popupGame by remember { mutableStateOf<Game?>(null) }
   LazyColumn(
       modifier = modifier.fillMaxSize(),
       verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.xxLarge),
@@ -178,18 +178,10 @@ fun ShopDetails(shop: Shop, modifier: Modifier = Modifier) {
               modifier = Modifier.fillMaxWidth(),
               clickableGames = true,
               title = ShopScreenDefaults.Game.GAME_SECTION_TITLE,
-              onClick = { game ->
-                  popupGame = game
-              }
-          )
+              onClick = { game -> popupGame = game })
         }
       }
-    popupGame?.let { game ->
-        GameDetailsCard(
-            game = game,
-            onClose = { popupGame = null }
-        )
-    }
+  popupGame?.let { game -> GameDetailsCard(game = game, onClose = { popupGame = null }) }
 }
 
 // -------------------- GAME ITEM --------------------

--- a/app/src/main/java/com/github/meeplemeet/ui/shops/ShopScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/shops/ShopScreen.kt
@@ -7,6 +7,7 @@ import android.annotation.SuppressLint
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.lazy.LazyColumn
@@ -108,40 +109,74 @@ fun ShopScreen(
     onBack: () -> Unit = {},
     onEdit: (Shop?) -> Unit = {},
 ) {
-  // Collect the current shop state from the ViewModel
   val shopState by viewModel.shop.collectAsStateWithLifecycle()
-  // Trigger loading of shop data when shopId changes
   LaunchedEffect(shopId) { viewModel.getShop(shopId) }
 
-  Scaffold(
-      topBar = {
-        TopBarWithDivider(
-            text = "Shop",
-            onReturn = { onBack() },
-            trailingIcons = {
-              // Show edit button only if current account is the shop owner
-              if (account.uid == (shopState?.owner?.uid)) {
-                IconButton(
-                    onClick = { onEdit(shopState) },
-                    modifier = Modifier.testTag(ShopTestTags.SHOP_EDIT_BUTTON)) {
-                      Icon(Icons.Default.Edit, contentDescription = "Edit")
-                    }
+  var popupGame by remember { mutableStateOf<Game?>(null) }
+
+  Box(modifier = Modifier.fillMaxSize()) {
+
+    // ────────────────────────────────────────────
+    // SCAFFOLD WITH TOPBAR & MAIN CONTENT
+    // ────────────────────────────────────────────
+    Scaffold(
+        topBar = {
+          TopBarWithDivider(
+              text = "Shop",
+              onReturn = { if (popupGame == null) onBack() },
+              trailingIcons = {
+                if (account.uid == shopState?.owner?.uid) {
+                  IconButton(
+                      onClick = { if (popupGame == null) onEdit(shopState) },
+                      modifier = Modifier.testTag(ShopTestTags.SHOP_EDIT_BUTTON)) {
+                        Icon(Icons.Default.Edit, contentDescription = "Edit")
+                      }
+                }
+              })
+        }) { innerPadding ->
+          shopState?.let { shop ->
+            ShopDetails(
+                shop = shop,
+                modifier =
+                    Modifier.padding(innerPadding)
+                        .padding(Dimensions.Padding.extraLarge)
+                        .fillMaxSize(),
+                onGameClick = { game -> popupGame = game },
+            )
+          }
+              ?: Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
               }
-            })
-      }) { innerPadding ->
-        // Show shop details if loaded, otherwise show a loading indicator
-        shopState?.let { shop ->
-          ShopDetails(
-              shop = shop,
-              modifier =
-                  Modifier.padding(innerPadding)
-                      .padding(Dimensions.Padding.extraLarge)
-                      .fillMaxSize())
         }
-            ?: Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-              CircularProgressIndicator()
-            }
+
+    // ────────────────────────────────────────────
+    // SCRIM BLOCKING ALL TOUCHES WHEN POPUP OPEN
+    // ────────────────────────────────────────────
+    if (popupGame != null) {
+      Box(
+          modifier =
+              Modifier.fillMaxSize()
+                  .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.65f))
+                  .clickable(
+                      enabled = true,
+                      indication = null,
+                      interactionSource =
+                          remember { MutableInteractionSource() }) {} // block everything behind
+          )
+    }
+
+    // ────────────────────────────────────────────
+    // CENTERED POPUP WITH BORDER
+    // ────────────────────────────────────────────
+    popupGame?.let { game ->
+      Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        GameDetailsCard(
+            game = game,
+            onClose = { popupGame = null },
+            modifier = Modifier.wrapContentSize().padding(16.dp))
       }
+    }
+  }
 }
 
 /**
@@ -152,15 +187,13 @@ fun ShopScreen(
  * @param modifier Modifier to be applied to the layout.
  */
 @Composable
-fun ShopDetails(shop: Shop, modifier: Modifier = Modifier) {
-  var popupGame by remember { mutableStateOf<Game?>(null) }
+fun ShopDetails(shop: Shop, modifier: Modifier = Modifier, onGameClick: (Game) -> Unit) {
   LazyColumn(
       modifier = modifier.fillMaxSize(),
       verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.xxLarge),
       contentPadding = PaddingValues(bottom = Dimensions.Spacing.xxLarge)) {
 
-        /* TODO: Add here shop images composable (pager) when done */
-
+        // Contact info
         item {
           ContactSection(
               name = shop.name,
@@ -170,18 +203,19 @@ fun ShopDetails(shop: Shop, modifier: Modifier = Modifier) {
               website = shop.website)
         }
 
+        // Opening hours
         item { AvailabilitySection(shop.openingHours) }
 
+        // Game list
         item {
           GameImageListSection(
               games = shop.gameCollection,
               modifier = Modifier.fillMaxWidth(),
               clickableGames = true,
               title = ShopScreenDefaults.Game.GAME_SECTION_TITLE,
-              onClick = { game -> popupGame = game })
+              onClick = onGameClick)
         }
       }
-  popupGame?.let { game -> GameDetailsCard(game = game, onClose = { popupGame = null }) }
 }
 
 // -------------------- GAME ITEM --------------------

--- a/app/src/main/java/com/github/meeplemeet/ui/shops/ShopScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/shops/ShopScreen.kt
@@ -173,7 +173,7 @@ fun ShopScreen(
         GameDetailsCard(
             game = game,
             onClose = { popupGame = null },
-            modifier = Modifier.wrapContentSize().padding(16.dp))
+            modifier = Modifier.wrapContentSize().padding(Dimensions.Padding.extraLarge))
       }
     }
   }

--- a/app/src/main/java/com/github/meeplemeet/ui/shops/ShopScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/shops/ShopScreen.kt
@@ -40,6 +40,7 @@ import com.github.meeplemeet.model.shops.Shop
 import com.github.meeplemeet.model.shops.ShopViewModel
 import com.github.meeplemeet.ui.components.AvailabilitySection
 import com.github.meeplemeet.ui.components.ContactSection
+import com.github.meeplemeet.ui.components.GameDetailsCard
 import com.github.meeplemeet.ui.components.ShopComponentsTestTags
 import com.github.meeplemeet.ui.components.TopBarWithDivider
 import com.github.meeplemeet.ui.theme.Dimensions
@@ -152,6 +153,7 @@ fun ShopScreen(
  */
 @Composable
 fun ShopDetails(shop: Shop, modifier: Modifier = Modifier) {
+    var popupGame by remember { mutableStateOf<Game?>(null) }
   LazyColumn(
       modifier = modifier.fillMaxSize(),
       verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.xxLarge),
@@ -176,9 +178,18 @@ fun ShopDetails(shop: Shop, modifier: Modifier = Modifier) {
               modifier = Modifier.fillMaxWidth(),
               clickableGames = true,
               title = ShopScreenDefaults.Game.GAME_SECTION_TITLE,
+              onClick = { game ->
+                  popupGame = game
+              }
           )
         }
       }
+    popupGame?.let { game ->
+        GameDetailsCard(
+            game = game,
+            onClose = { popupGame = null }
+        )
+    }
 }
 
 // -------------------- GAME ITEM --------------------


### PR DESCRIPTION
# Add Game Details Popup Composable

## Summary
This PR introduces a new `GameDetailsPopup` composable that displays detailed game information in a modal-style popup. It is self-contained and not yet connected to any screen logic.

## Changes
- Added `GameDetailsPopup` composable with title, image, overview section, and expandable description.
- Implemented a close button in the header.
- Added automatic detection of overflowing text to show a “Read more…” toggle.

## Result
A reusable popup component is now available for displaying game information. It can be integrated into screens later by providing a `Game` object.


https://github.com/user-attachments/assets/988356ff-8a2e-40de-81b9-fee40ec8e59f

