### PR TITLE
fix(ui): correct usage of max bubble count

### DIFF
--- a/app/src/main/java/com/github/meeplemeet/ui/shops/ShopScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/shops/ShopScreen.kt
@@ -254,7 +254,7 @@ fun GameItemImage(
         if (count > ShopScreenDefaults.Stock.NOT_SHOWING_STOCK_MIN_VALUE) {
           val label =
               if (count > ShopScreenDefaults.Stock.MAX_STOCK_SHOWED)
-                  "$ShopScreenDefaults.Pager.MAX_STOCK_SHOWED+"
+                  "${ShopScreenDefaults.Stock.MAX_STOCK_SHOWED}+"
               else count.toString()
 
           Box(


### PR DESCRIPTION
This PR corrects a small bug that was found in ShopScreen. In fact, the maximum defined stock number to be displayed was not being correctly called.

Ref: issue https://github.com/Meeple-Meet/Meeple-Meet/issues/154