### PR TITLE
190 bug location lost when updating item

### DIFF
--- a/app/src/main/java/com/github/meeplemeet/model/map/GeoFirestoreOperations.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/map/GeoFirestoreOperations.kt
@@ -1,0 +1,42 @@
+package com.github.meeplemeet.model.map
+
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.GeoPoint
+import org.imperiumlabs.geofirestore.GeoFirestore
+import org.imperiumlabs.geofirestore.extension.removeLocation
+import org.imperiumlabs.geofirestore.extension.setLocation
+
+/** Wrapper interface around GeoFirestore operations to allow testing. */
+interface GeoFirestoreOperations {
+  /**
+   * Sets the location for a document.
+   *
+   * @param uid Document ID
+   * @param geoPoint Location to set
+   * @param callback Completion callback
+   */
+  fun setLocation(uid: String, geoPoint: GeoPoint, callback: (Exception?) -> Unit)
+
+  /**
+   * Removes the location for a document.
+   *
+   * @param uid Document ID
+   * @param callback Completion callback
+   */
+  fun removeLocation(uid: String, callback: (Exception?) -> Unit)
+}
+
+/** Default implementation that delegates to the real GeoFirestore library. */
+class DefaultGeoFirestoreOperations(private val collectionReference: CollectionReference) :
+    GeoFirestoreOperations {
+
+  override fun setLocation(uid: String, geoPoint: GeoPoint, callback: (Exception?) -> Unit) {
+    val geoFirestore = GeoFirestore(collectionReference)
+    geoFirestore.setLocation(uid, geoPoint, callback)
+  }
+
+  override fun removeLocation(uid: String, callback: (Exception?) -> Unit) {
+    val geoFirestore = GeoFirestore(collectionReference)
+    geoFirestore.removeLocation(uid, callback)
+  }
+}

--- a/app/src/main/java/com/github/meeplemeet/model/map/StorableGeoPinRepository.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/map/StorableGeoPinRepository.kt
@@ -3,9 +3,11 @@ package com.github.meeplemeet.model.map
 import com.github.meeplemeet.model.FirestoreRepository
 import com.github.meeplemeet.model.shared.location.Location
 import com.google.firebase.firestore.GeoPoint
+import com.google.firebase.firestore.SetOptions
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.tasks.await
 import org.imperiumlabs.geofirestore.GeoFirestore
 import org.imperiumlabs.geofirestore.extension.removeLocation
@@ -18,24 +20,33 @@ import org.imperiumlabs.geofirestore.extension.setLocation
  * @property db Firestore instance used to access the pins collection.
  */
 class StorableGeoPinRepository : FirestoreRepository("geo_pins") {
+
+  /** Retry parameters for GeoFirestore operations */
+  private companion object {
+
+    const val GEO_RETRY_COUNT = 3
+    const val GEO_RETRY_DELAY = 200L
+  }
+
   /**
    * Creates or replaces a geo-pin document in Firestore using the given ID.
    *
    * This method is idempotent: if a pin with the same ID already exists, it will be overwritten.
-   * The pin is stored with metadata and geolocation, allowing it to be displayed on the map and
-   * referenced later by its UID (which matches the linked entity's ID).
+   * Metadata is stored with merge semantics to avoid overwriting geolocation fields. Geolocation is
+   * then set via GeoFirestore with retry logic to handle transient failures.
    *
    * @param ref ID of the external object this pin is linked to (e.g. the shop or session it
    *   represents).
    * @param type Updated pin type. See [PinType]
    * @param location Updated location.
    * @return The created or updated [StorableGeoPin] instance.
+   * @throws Exception if geolocation cannot be set after all retries.
    */
   suspend fun upsertGeoPin(ref: String, type: PinType, location: Location): StorableGeoPin {
     val pin = StorableGeoPin(uid = ref, type = type)
 
-    collection.document(pin.uid).set(toNoUid(pin)).await()
-    setGeoLocation(pin.uid, location)
+    collection.document(pin.uid).set(toNoUid(pin), SetOptions.merge()).await()
+    retry("set geolocation for $ref") { setGeoLocation(pin.uid, location) }
 
     return pin
   }
@@ -43,12 +54,44 @@ class StorableGeoPinRepository : FirestoreRepository("geo_pins") {
   /**
    * Deletes a geo-pin document and removes its geolocation data.
    *
+   * Geolocation removal is attempted with retry logic to handle transient failures. The Firestore
+   * document is then deleted. Deletion is idempotent: if the document does not exist, no error is
+   * thrown.
+   *
    * @param ref ID of the external object this pin is linked to (e.g. the shop or session it
    *   represents).
+   * @throws Exception if geolocation removal fails after all retries or if document deletion fails.
    */
   suspend fun deleteGeoPin(ref: String) {
-    removeGeoLocation(ref)
+    retry("remove geolocation for $ref") { removeGeoLocation(ref) }
     collection.document(ref).delete().await()
+  }
+
+  /**
+   * Executes a suspendable block with retry logic.
+   *
+   * The block is executed up to [GEO_RETRY_COUNT] times. If it throws an exception, the error is
+   * captured and the block retried after [GEO_RETRY_DELAY] milliseconds. If all attempts fail, the
+   * last captured exception is rethrown. If no exception was captured (unexpected case), an
+   * [IllegalStateException] is thrown.
+   *
+   * @param action A human-readable description of the action, used in error messages.
+   * @param block The suspendable operation to execute.
+   * @throws Exception if the block fails after all retries.
+   */
+  private suspend fun retry(action: String, block: suspend () -> Unit) {
+    var lastError: Exception? = null
+    repeat(GEO_RETRY_COUNT) { attempt ->
+      try {
+        block()
+        lastError = null
+        return
+      } catch (e: Exception) {
+        lastError = e
+        if (attempt < GEO_RETRY_COUNT - 1) delay(GEO_RETRY_DELAY)
+      }
+    }
+    throw lastError ?: IllegalStateException("Unknown error during $action")
   }
 
   /**

--- a/app/src/main/java/com/github/meeplemeet/model/map/StorableGeoPinRepository.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/map/StorableGeoPinRepository.kt
@@ -87,7 +87,6 @@ class StorableGeoPinRepository(private val geoOps: GeoFirestoreOperations? = nul
     repeat(GEO_RETRY_COUNT) { attempt ->
       try {
         block()
-        lastError = null
         return
       } catch (e: Exception) {
         lastError = e


### PR DESCRIPTION
**Fixes location pins disappearing from the map when updating items (shops, spaces, sessions).**

Related to #190

The issue was caused by two problems:
1. **Race condition**: Firestore `set()` could overwrite GeoFirestore fields (`g`, `l`) if geolocation write completed first
2. **Transient failures**: GeoFirestore write failures were not being retried, causing silent data loss

**Solution:**
- Changed `set()` to `set(data, SetOptions.merge())` to prevent field overwrites
- Added retry logic (3 attempts with 200ms delay) for all GeoFirestore operations

To properly test the retry behavior, I've added a `GeoFirestoreOperations` interface that wraps GeoFirestore calls. The repository uses a default implementation in production (zero behavior change), but tests can inject fake implementations to simulate failures and verify retry logic.

Tests added:
- Retry succeeds after 1-2 transient failures
- Fails correctly after 3 exhausted attempts  
- Covers both upsertGeoPin and deleteGeoPin operations

No impact on public API - `StorableGeoPinRepository()` works exactly as before.

_Generated by ClaudeAI_