### PR TITLE
feat: Implement friend system with relationship management

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/integration/RelationshipsTests.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/RelationshipsTests.kt
@@ -1,0 +1,678 @@
+package com.github.meeplemeet.integration
+
+import com.github.meeplemeet.model.account.Account
+import com.github.meeplemeet.model.account.ProfileScreenViewModel
+import com.github.meeplemeet.model.account.RelationshipStatus
+import com.github.meeplemeet.utils.FirestoreTests
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertNotNull
+import junit.framework.TestCase.assertNull
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Integration tests for relationship management functionality in AccountRepository and
+ * ProfileScreenViewModel.
+ *
+ * These tests verify the complete friend system workflow using real Firestore operations:
+ * - Sending friend requests
+ * - Accepting friend requests
+ * - Blocking users
+ * - Resetting relationships
+ * - Bidirectional relationship consistency
+ * - ViewModel validation logic
+ *
+ * All tests use the Firebase emulator and verify both sides of each relationship to ensure
+ * bidirectional consistency.
+ */
+class RelationshipsTests : FirestoreTests() {
+  private lateinit var alice: Account
+  private lateinit var bob: Account
+  private lateinit var charlie: Account
+  private lateinit var viewModel: ProfileScreenViewModel
+
+  @Before
+  fun setup() {
+    runBlocking {
+      alice =
+          accountRepository.createAccount(
+              "alice_rel", "Alice", email = "alice_rel@example.com", photoUrl = null)
+      bob =
+          accountRepository.createAccount(
+              "bob_rel", "Bob", email = "bob_rel@example.com", photoUrl = null)
+      charlie =
+          accountRepository.createAccount(
+              "charlie_rel", "Charlie", email = "charlie_rel@example.com", photoUrl = null)
+    }
+    viewModel = ProfileScreenViewModel(accountRepository)
+  }
+
+  // ==================== sendFriendRequest Tests ====================
+
+  @Test
+  fun sendFriendRequest_createsBidirectionalRelationshipAndPersists() = runBlocking {
+    accountRepository.sendFriendRequest(alice.uid, bob.uid)
+
+    // Fetch accounts fresh from Firestore to verify persistence
+    val accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    val updatedAlice = accounts[0]
+    val updatedBob = accounts[1]
+
+    assertNotNull(updatedAlice.relationships[bob.uid])
+    assertEquals(RelationshipStatus.Sent, updatedAlice.relationships[bob.uid])
+    assertNotNull(updatedBob.relationships[alice.uid])
+    assertEquals(RelationshipStatus.Pending, updatedBob.relationships[alice.uid])
+  }
+
+  @Test
+  fun sendFriendRequest_multipleUsersCanSendToSameUser() = runBlocking {
+    accountRepository.sendFriendRequest(alice.uid, charlie.uid)
+    accountRepository.sendFriendRequest(bob.uid, charlie.uid)
+
+    val updatedCharlie = accountRepository.getAccount(charlie.uid)
+
+    assertEquals(2, updatedCharlie.relationships.size)
+    assertEquals(RelationshipStatus.Pending, updatedCharlie.relationships[alice.uid])
+    assertEquals(RelationshipStatus.Pending, updatedCharlie.relationships[bob.uid])
+  }
+
+  @Test
+  fun sendFriendRequest_oneUserCanSendToMultipleUsers() = runBlocking {
+    accountRepository.sendFriendRequest(alice.uid, bob.uid)
+    accountRepository.sendFriendRequest(alice.uid, charlie.uid)
+
+    val updatedAlice = accountRepository.getAccount(alice.uid)
+
+    assertEquals(2, updatedAlice.relationships.size)
+    assertEquals(RelationshipStatus.Sent, updatedAlice.relationships[bob.uid])
+    assertEquals(RelationshipStatus.Sent, updatedAlice.relationships[charlie.uid])
+  }
+
+  // ==================== acceptFriendRequest Tests ====================
+
+  @Test
+  fun acceptFriendRequest_createsMutualFriendship() = runBlocking {
+    accountRepository.sendFriendRequest(alice.uid, bob.uid)
+    accountRepository.acceptFriendRequest(bob.uid, alice.uid)
+
+    val accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    val updatedAlice = accounts[0]
+    val updatedBob = accounts[1]
+
+    assertEquals(RelationshipStatus.Friend, updatedAlice.relationships[bob.uid])
+    assertEquals(RelationshipStatus.Friend, updatedBob.relationships[alice.uid])
+  }
+
+  @Test
+  fun acceptFriendRequest_updatesExistingDocuments() = runBlocking {
+    accountRepository.sendFriendRequest(alice.uid, bob.uid)
+
+    // Verify Sent and Pending states exist first
+    val beforeAccept = accountRepository.getAccount(alice.uid)
+    assertEquals(RelationshipStatus.Sent, beforeAccept.relationships[bob.uid])
+
+    accountRepository.acceptFriendRequest(bob.uid, alice.uid)
+
+    // Verify both are now Friend status
+    val afterAccept = accountRepository.getAccount(alice.uid)
+    assertEquals(RelationshipStatus.Friend, afterAccept.relationships[bob.uid])
+  }
+
+  @Test
+  fun acceptFriendRequest_multipleFriendshipsIndependent() = runBlocking {
+    // Alice sends to Bob and Charlie
+    accountRepository.sendFriendRequest(alice.uid, bob.uid)
+    accountRepository.sendFriendRequest(alice.uid, charlie.uid)
+
+    // Only Bob accepts
+    accountRepository.acceptFriendRequest(bob.uid, alice.uid)
+
+    val accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid, charlie.uid))
+    val updatedAlice = accounts[0]
+    val updatedBob = accounts[1]
+    val updatedCharlie = accounts[2]
+
+    // Alice and Bob are friends
+    assertEquals(RelationshipStatus.Friend, updatedAlice.relationships[bob.uid])
+    assertEquals(RelationshipStatus.Friend, updatedBob.relationships[alice.uid])
+
+    // Alice and Charlie still have pending request
+    assertEquals(RelationshipStatus.Sent, updatedAlice.relationships[charlie.uid])
+    assertEquals(RelationshipStatus.Pending, updatedCharlie.relationships[alice.uid])
+  }
+
+  // ==================== blockUser Tests ====================
+
+  @Test
+  fun blockUser_setsBlockedStatusAndRemovesFromBlockedUser() = runBlocking {
+    accountRepository.blockUser(alice.uid, bob.uid, false)
+
+    val accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    val updatedAlice = accounts[0]
+    val updatedBob = accounts[1]
+
+    assertEquals(RelationshipStatus.Blocked, updatedAlice.relationships[bob.uid])
+    assertNull(updatedBob.relationships[alice.uid])
+    assertFalse(updatedBob.relationships.containsKey(alice.uid))
+  }
+
+  @Test
+  fun blockUser_whenMutualBlock_preservesBothBlockStatuses() = runBlocking {
+    // Bob blocks Alice first
+    accountRepository.blockUser(bob.uid, alice.uid, false)
+
+    // Alice blocks Bob (Bob has already blocked Alice)
+    accountRepository.blockUser(alice.uid, bob.uid, true)
+
+    val accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    val updatedAlice = accounts[0]
+    val updatedBob = accounts[1]
+
+    // Both should have Blocked status
+    assertEquals(RelationshipStatus.Blocked, updatedAlice.relationships[bob.uid])
+    assertEquals(RelationshipStatus.Blocked, updatedBob.relationships[alice.uid])
+  }
+
+  @Test
+  fun blockUser_afterFriendshipEstablished() = runBlocking {
+    // Establish friendship
+    accountRepository.sendFriendRequest(alice.uid, bob.uid)
+    accountRepository.acceptFriendRequest(bob.uid, alice.uid)
+
+    // Alice blocks Bob
+    accountRepository.blockUser(alice.uid, bob.uid, false)
+
+    val accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    val updatedAlice = accounts[0]
+    val updatedBob = accounts[1]
+
+    // Alice has Bob blocked
+    assertEquals(RelationshipStatus.Blocked, updatedAlice.relationships[bob.uid])
+    // Bob has no relationship with Alice
+    assertNull(updatedBob.relationships[alice.uid])
+  }
+
+  @Test
+  fun blockUser_afterPendingRequest() = runBlocking {
+    // Alice sends friend request to Bob
+    accountRepository.sendFriendRequest(alice.uid, bob.uid)
+
+    // Bob blocks Alice instead of accepting
+    accountRepository.blockUser(bob.uid, alice.uid, false)
+
+    val accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    val updatedAlice = accounts[0]
+    val updatedBob = accounts[1]
+
+    // Bob has Alice blocked
+    assertEquals(RelationshipStatus.Blocked, updatedBob.relationships[alice.uid])
+    // Alice has no relationship (her Sent status was deleted)
+    assertNull(updatedAlice.relationships[bob.uid])
+  }
+
+  // ==================== resetRelationship Tests ====================
+
+  @Test
+  fun resetRelationship_removesBothSidesInAllScenarios() = runBlocking {
+    // Test 1: Remove friendship
+    accountRepository.sendFriendRequest(alice.uid, bob.uid)
+    accountRepository.acceptFriendRequest(bob.uid, alice.uid)
+    accountRepository.resetRelationship(alice.uid, bob.uid)
+
+    var accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    assertNull(accounts[0].relationships[bob.uid])
+    assertNull(accounts[1].relationships[alice.uid])
+
+    // Test 2: Cancel sent friend request (Alice cancels)
+    accountRepository.sendFriendRequest(alice.uid, bob.uid)
+    accountRepository.resetRelationship(alice.uid, bob.uid)
+
+    accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    assertNull(accounts[0].relationships[bob.uid])
+    assertNull(accounts[1].relationships[alice.uid])
+
+    // Test 3: Deny received friend request (Bob denies)
+    accountRepository.sendFriendRequest(alice.uid, bob.uid)
+    accountRepository.resetRelationship(bob.uid, alice.uid)
+
+    accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    assertNull(accounts[0].relationships[bob.uid])
+    assertNull(accounts[1].relationships[alice.uid])
+
+    // Test 4: Unblock user
+    accountRepository.blockUser(alice.uid, bob.uid, false)
+    accountRepository.resetRelationship(alice.uid, bob.uid)
+
+    accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    assertNull(accounts[0].relationships[bob.uid])
+    assertNull(accounts[1].relationships[alice.uid])
+
+    // Test 5: Reset with no existing relationship - should not throw
+    accountRepository.resetRelationship(alice.uid, charlie.uid)
+    accountRepository.resetRelationship(bob.uid, charlie.uid)
+
+    accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid, charlie.uid))
+    assertNull(accounts[0].relationships[charlie.uid])
+    assertNull(accounts[1].relationships[charlie.uid])
+  }
+
+  // ==================== Complex Workflow Tests ====================
+
+  @Test
+  fun completeRelationshipLifecycle_sendAcceptRemove() = runBlocking {
+    // Send request
+    accountRepository.sendFriendRequest(alice.uid, bob.uid)
+
+    var accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    var updatedAlice = accounts[0]
+    var updatedBob = accounts[1]
+    assertEquals(RelationshipStatus.Sent, updatedAlice.relationships[bob.uid])
+    assertEquals(RelationshipStatus.Pending, updatedBob.relationships[alice.uid])
+
+    // Accept request
+    accountRepository.acceptFriendRequest(bob.uid, alice.uid)
+
+    accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    updatedAlice = accounts[0]
+    updatedBob = accounts[1]
+    assertEquals(RelationshipStatus.Friend, updatedAlice.relationships[bob.uid])
+    assertEquals(RelationshipStatus.Friend, updatedBob.relationships[alice.uid])
+
+    // Remove friendship
+    accountRepository.resetRelationship(alice.uid, bob.uid)
+
+    accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    updatedAlice = accounts[0]
+    updatedBob = accounts[1]
+    assertNull(updatedAlice.relationships[bob.uid])
+    assertNull(updatedBob.relationships[alice.uid])
+  }
+
+  @Test
+  fun complexWorkflows_cancelRequestAndBlockUnblockBefriend() = runBlocking {
+    // Workflow 1: Friend request canceled before acceptance
+    accountRepository.sendFriendRequest(alice.uid, bob.uid)
+    accountRepository.resetRelationship(alice.uid, bob.uid)
+
+    var accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    assertNull(accounts[0].relationships[bob.uid])
+    assertNull(accounts[1].relationships[alice.uid])
+
+    // Workflow 2: Block, unblock, then befriend
+    accountRepository.blockUser(alice.uid, bob.uid, false)
+
+    var updatedAlice = accountRepository.getAccount(alice.uid)
+    assertEquals(RelationshipStatus.Blocked, updatedAlice.relationships[bob.uid])
+
+    accountRepository.resetRelationship(alice.uid, bob.uid)
+
+    updatedAlice = accountRepository.getAccount(alice.uid)
+    assertNull(updatedAlice.relationships[bob.uid])
+
+    accountRepository.sendFriendRequest(alice.uid, bob.uid)
+    accountRepository.acceptFriendRequest(bob.uid, alice.uid)
+
+    accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    assertEquals(RelationshipStatus.Friend, accounts[0].relationships[bob.uid])
+    assertEquals(RelationshipStatus.Friend, accounts[1].relationships[alice.uid])
+  }
+
+  @Test
+  fun multipleSimultaneousRelationships() = runBlocking {
+    // Alice sends to Bob
+    accountRepository.sendFriendRequest(alice.uid, bob.uid)
+
+    // Bob sends to Charlie
+    accountRepository.sendFriendRequest(bob.uid, charlie.uid)
+
+    // Charlie sends to Alice
+    accountRepository.sendFriendRequest(charlie.uid, alice.uid)
+
+    val accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid, charlie.uid))
+    val updatedAlice = accounts[0]
+    val updatedBob = accounts[1]
+    val updatedCharlie = accounts[2]
+
+    // Verify all relationships are independent
+    assertEquals(RelationshipStatus.Sent, updatedAlice.relationships[bob.uid])
+    assertEquals(RelationshipStatus.Pending, updatedAlice.relationships[charlie.uid])
+
+    assertEquals(RelationshipStatus.Pending, updatedBob.relationships[alice.uid])
+    assertEquals(RelationshipStatus.Sent, updatedBob.relationships[charlie.uid])
+
+    assertEquals(RelationshipStatus.Sent, updatedCharlie.relationships[alice.uid])
+    assertEquals(RelationshipStatus.Pending, updatedCharlie.relationships[bob.uid])
+  }
+
+  // ==================== Edge Cases ====================
+
+  @Test
+  fun relationshipsMapIsEmptyForNewAccount() = runBlocking {
+    val newAccount =
+        accountRepository.createAccount(
+            "new_user", "New User", email = "new_user@example.com", photoUrl = null)
+
+    assertTrue(newAccount.relationships.isEmpty())
+  }
+
+  @Test
+  fun multipleOperationsOnSameRelationship() = runBlocking {
+    // Send request
+    accountRepository.sendFriendRequest(alice.uid, bob.uid)
+
+    // Accept request
+    accountRepository.acceptFriendRequest(bob.uid, alice.uid)
+
+    // Block user
+    accountRepository.blockUser(alice.uid, bob.uid, false)
+
+    // Unblock
+    accountRepository.resetRelationship(alice.uid, bob.uid)
+
+    val accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    val updatedAlice = accounts[0]
+    val updatedBob = accounts[1]
+
+    // Final state should be no relationship
+    assertNull(updatedAlice.relationships[bob.uid])
+    assertNull(updatedBob.relationships[alice.uid])
+  }
+
+  @Test
+  fun relationshipsAreIndependentAndPersistent() = runBlocking {
+    // Test 1: Relationships persist across multiple retrievals
+    accountRepository.sendFriendRequest(alice.uid, bob.uid)
+
+    val fetch1 = accountRepository.getAccount(alice.uid)
+    val fetch2 = accountRepository.getAccount(alice.uid)
+    val fetch3 = accountRepository.getAccount(alice.uid)
+
+    assertEquals(RelationshipStatus.Sent, fetch1.relationships[bob.uid])
+    assertEquals(RelationshipStatus.Sent, fetch2.relationships[bob.uid])
+    assertEquals(RelationshipStatus.Sent, fetch3.relationships[bob.uid])
+
+    // Test 2: Friendship with one user doesn't affect other relationships
+    accountRepository.sendFriendRequest(alice.uid, charlie.uid)
+    accountRepository.acceptFriendRequest(bob.uid, alice.uid)
+
+    var updatedAlice = accountRepository.getAccount(alice.uid)
+    assertEquals(RelationshipStatus.Friend, updatedAlice.relationships[bob.uid])
+    assertEquals(RelationshipStatus.Sent, updatedAlice.relationships[charlie.uid])
+
+    // Test 3: Blocking one user doesn't affect other relationships
+    accountRepository.blockUser(alice.uid, bob.uid, false)
+
+    updatedAlice = accountRepository.getAccount(alice.uid)
+    assertEquals(RelationshipStatus.Blocked, updatedAlice.relationships[bob.uid])
+    assertEquals(RelationshipStatus.Sent, updatedAlice.relationships[charlie.uid])
+  }
+
+  // ==================== ViewModel Validation Tests ====================
+
+  @Test
+  fun viewModelSendFriendRequest_preventsInvalidOperations() = runBlocking {
+    // Test 1: Prevent sending to same user
+    viewModel.sendFriendRequest(alice, alice)
+    val aliceAfterSelf = accountRepository.getAccount(alice.uid)
+    assertNull(aliceAfterSelf.relationships[alice.uid])
+
+    // Test 2: Prevent duplicate request
+    accountRepository.sendFriendRequest(alice.uid, bob.uid)
+    var accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    var updatedAlice = accounts[0]
+    var updatedBob = accounts[1]
+
+    viewModel.sendFriendRequest(updatedAlice, updatedBob)
+    accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    assertEquals(RelationshipStatus.Sent, accounts[0].relationships[bob.uid])
+    assertEquals(RelationshipStatus.Pending, accounts[1].relationships[alice.uid])
+
+    // Test 3: Prevent when already friends
+    accountRepository.resetRelationship(alice.uid, bob.uid)
+    accountRepository.sendFriendRequest(alice.uid, bob.uid)
+    accountRepository.acceptFriendRequest(bob.uid, alice.uid)
+
+    accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    updatedAlice = accounts[0]
+    updatedBob = accounts[1]
+
+    viewModel.sendFriendRequest(updatedAlice, updatedBob)
+    accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    assertEquals(RelationshipStatus.Friend, accounts[0].relationships[bob.uid])
+    assertEquals(RelationshipStatus.Friend, accounts[1].relationships[alice.uid])
+
+    // Test 4: Prevent when one user blocked the other
+    accountRepository.resetRelationship(alice.uid, bob.uid)
+    accountRepository.blockUser(alice.uid, bob.uid, false)
+
+    accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    updatedAlice = accounts[0]
+    updatedBob = accounts[1]
+
+    viewModel.sendFriendRequest(updatedAlice, updatedBob)
+    viewModel.sendFriendRequest(updatedBob, updatedAlice)
+
+    accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    assertEquals(RelationshipStatus.Blocked, accounts[0].relationships[bob.uid])
+    assertNull(accounts[1].relationships[alice.uid])
+  }
+
+  @Test
+  fun viewModelSendFriendRequest_allowsValidRequest() = runBlocking {
+    accountRepository.resetRelationship(alice.uid, bob.uid)
+    var accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    viewModel.sendFriendRequest(accounts[0], accounts[1])
+
+    accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    assertEquals(RelationshipStatus.Sent, accounts[0].relationships[bob.uid])
+    assertEquals(RelationshipStatus.Pending, accounts[1].relationships[alice.uid])
+  }
+
+  @Test
+  fun viewModelAcceptFriendRequest_preventsInvalidOperations() = runBlocking {
+    accountRepository.resetRelationship(alice.uid, bob.uid)
+
+    // Test 1: Prevent accepting when there's no request
+    var accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    viewModel.acceptFriendRequest(accounts[0], accounts[1])
+
+    accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    assertNull(accounts[0].relationships[bob.uid])
+    assertNull(accounts[1].relationships[alice.uid])
+
+    // Test 2: Prevent accepting in wrong direction
+    accountRepository.sendFriendRequest(alice.uid, bob.uid)
+    accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+
+    viewModel.acceptFriendRequest(accounts[0], accounts[1])
+    accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    assertEquals(RelationshipStatus.Sent, accounts[0].relationships[bob.uid])
+    assertEquals(RelationshipStatus.Pending, accounts[1].relationships[alice.uid])
+
+    // Test 3: Prevent accepting when already friends
+    accountRepository.acceptFriendRequest(bob.uid, alice.uid)
+    accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+
+    viewModel.acceptFriendRequest(accounts[0], accounts[1])
+    accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    assertEquals(RelationshipStatus.Friend, accounts[0].relationships[bob.uid])
+    assertEquals(RelationshipStatus.Friend, accounts[1].relationships[alice.uid])
+
+    // Test 4: Prevent accepting same user
+    viewModel.acceptFriendRequest(alice, alice)
+    val aliceAfter = accountRepository.getAccount(alice.uid)
+    assertNull(aliceAfter.relationships[alice.uid])
+
+    // Test 5: Prevent accepting when blocked
+    accountRepository.resetRelationship(alice.uid, bob.uid)
+    accountRepository.blockUser(alice.uid, bob.uid, false)
+    accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+
+    viewModel.acceptFriendRequest(accounts[0], accounts[1])
+    viewModel.acceptFriendRequest(accounts[1], accounts[0])
+
+    accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    assertEquals(RelationshipStatus.Blocked, accounts[0].relationships[bob.uid])
+    assertNull(accounts[1].relationships[alice.uid])
+  }
+
+  @Test
+  fun viewModelAcceptFriendRequest_allowsValidAcceptance() = runBlocking {
+    accountRepository.sendFriendRequest(alice.uid, bob.uid)
+    var accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+
+    viewModel.acceptFriendRequest(accounts[1], accounts[0])
+
+    accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    assertEquals(RelationshipStatus.Friend, accounts[0].relationships[bob.uid])
+    assertEquals(RelationshipStatus.Friend, accounts[1].relationships[alice.uid])
+  }
+
+  @Test
+  fun viewModelBlockUser_preventsInvalidOperations() = runBlocking {
+    // Test 1: Prevent blocking same user
+    viewModel.blockUser(alice, alice)
+    val aliceAfterSelf = accountRepository.getAccount(alice.uid)
+    assertNull(aliceAfterSelf.relationships[alice.uid])
+
+    // Test 2: Prevent blocking when already blocked
+    accountRepository.blockUser(alice.uid, bob.uid, false)
+    var accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+
+    viewModel.blockUser(accounts[0], accounts[1])
+
+    accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    assertEquals(RelationshipStatus.Blocked, accounts[0].relationships[bob.uid])
+    assertNull(accounts[1].relationships[alice.uid])
+  }
+
+  @Test
+  fun viewModelBlockUser_allowsValidBlocking() = runBlocking {
+    // Test 1: Block user with no prior relationship
+    var accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    viewModel.blockUser(accounts[0], accounts[1])
+
+    accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    assertEquals(RelationshipStatus.Blocked, accounts[0].relationships[bob.uid])
+    assertNull(accounts[1].relationships[alice.uid])
+
+    // Test 2: Block after friendship
+    accountRepository.resetRelationship(alice.uid, bob.uid)
+    accountRepository.sendFriendRequest(alice.uid, charlie.uid)
+    accountRepository.acceptFriendRequest(charlie.uid, alice.uid)
+
+    accounts = accountRepository.getAccounts(listOf(alice.uid, charlie.uid))
+    viewModel.blockUser(accounts[0], accounts[1])
+
+    accounts = accountRepository.getAccounts(listOf(alice.uid, charlie.uid))
+    assertEquals(RelationshipStatus.Blocked, accounts[0].relationships[charlie.uid])
+    assertNull(accounts[1].relationships[alice.uid])
+
+    // Test 3: Mutual blocking
+    accountRepository.resetRelationship(alice.uid, charlie.uid)
+    accountRepository.blockUser(alice.uid, bob.uid, false)
+
+    accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    viewModel.blockUser(accounts[1], accounts[0])
+
+    accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    assertEquals(RelationshipStatus.Blocked, accounts[0].relationships[bob.uid])
+    assertEquals(RelationshipStatus.Blocked, accounts[1].relationships[alice.uid])
+  }
+
+  @Test
+  fun viewModelResetRelationship_preventsInvalidOperations() = runBlocking {
+    // Test 1: Prevent resetting same user
+    viewModel.resetRelationship(alice, alice)
+    val aliceAfterSelf = accountRepository.getAccount(alice.uid)
+    assertNull(aliceAfterSelf.relationships[alice.uid])
+
+    // Test 2: Prevent resetting when blocked
+    accountRepository.blockUser(alice.uid, bob.uid, false)
+    var accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+
+    viewModel.resetRelationship(accounts[0], accounts[1])
+    viewModel.resetRelationship(accounts[1], accounts[0])
+
+    accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    assertEquals(RelationshipStatus.Blocked, accounts[0].relationships[bob.uid])
+    assertNull(accounts[1].relationships[alice.uid])
+  }
+
+  @Test
+  fun viewModelResetRelationship_allowsValidReset() = runBlocking {
+    // Test 1: Cancel sent request
+    accountRepository.sendFriendRequest(alice.uid, bob.uid)
+    var accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+
+    viewModel.resetRelationship(accounts[0], accounts[1])
+
+    accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    assertNull(accounts[0].relationships[bob.uid])
+    assertNull(accounts[1].relationships[alice.uid])
+
+    // Test 2: Deny received request
+    accountRepository.sendFriendRequest(alice.uid, bob.uid)
+    accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+
+    viewModel.resetRelationship(accounts[1], accounts[0])
+
+    accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    assertNull(accounts[0].relationships[bob.uid])
+    assertNull(accounts[1].relationships[alice.uid])
+
+    // Test 3: Remove friendship
+    accountRepository.sendFriendRequest(alice.uid, bob.uid)
+    accountRepository.acceptFriendRequest(bob.uid, alice.uid)
+    accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+
+    viewModel.resetRelationship(accounts[0], accounts[1])
+
+    accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    assertNull(accounts[0].relationships[bob.uid])
+    assertNull(accounts[1].relationships[alice.uid])
+
+    // Test 4: Reset with no existing relationship (should not throw)
+    viewModel.resetRelationship(alice, charlie)
+
+    val charlieAfter = accountRepository.getAccount(charlie.uid)
+    assertNull(charlieAfter.relationships[alice.uid])
+  }
+
+  @Test
+  fun viewModelValidation_complexScenarios() = runBlocking {
+    // Test 1: Cannot send request in opposite direction when pending
+    accountRepository.sendFriendRequest(alice.uid, bob.uid)
+    var accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+
+    viewModel.sendFriendRequest(accounts[1], accounts[0])
+
+    accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    assertEquals(RelationshipStatus.Sent, accounts[0].relationships[bob.uid])
+    assertEquals(RelationshipStatus.Pending, accounts[1].relationships[alice.uid])
+
+    // Test 2: After accepting, cannot send another request
+    viewModel.acceptFriendRequest(accounts[1], accounts[0])
+    accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+
+    viewModel.sendFriendRequest(accounts[0], accounts[1])
+
+    accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    assertEquals(RelationshipStatus.Friend, accounts[0].relationships[bob.uid])
+    assertEquals(RelationshipStatus.Friend, accounts[1].relationships[alice.uid])
+
+    // Test 3: After blocking, cannot send friend request
+    viewModel.blockUser(accounts[0], accounts[1])
+    accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+
+    viewModel.sendFriendRequest(accounts[0], accounts[1])
+    viewModel.sendFriendRequest(accounts[1], accounts[0])
+
+    accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    assertEquals(RelationshipStatus.Blocked, accounts[0].relationships[bob.uid])
+    assertNull(accounts[1].relationships[alice.uid])
+  }
+}

--- a/app/src/androidTest/java/com/github/meeplemeet/integration/RelationshipsTests.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/RelationshipsTests.kt
@@ -62,9 +62,9 @@ class RelationshipsTests : FirestoreTests() {
     val updatedBob = accounts[1]
 
     assertNotNull(updatedAlice.relationships[bob.uid])
-    assertEquals(RelationshipStatus.Sent, updatedAlice.relationships[bob.uid])
+    assertEquals(RelationshipStatus.SENT, updatedAlice.relationships[bob.uid])
     assertNotNull(updatedBob.relationships[alice.uid])
-    assertEquals(RelationshipStatus.Pending, updatedBob.relationships[alice.uid])
+    assertEquals(RelationshipStatus.PENDING, updatedBob.relationships[alice.uid])
   }
 
   @Test
@@ -75,8 +75,8 @@ class RelationshipsTests : FirestoreTests() {
     val updatedCharlie = accountRepository.getAccount(charlie.uid)
 
     assertEquals(2, updatedCharlie.relationships.size)
-    assertEquals(RelationshipStatus.Pending, updatedCharlie.relationships[alice.uid])
-    assertEquals(RelationshipStatus.Pending, updatedCharlie.relationships[bob.uid])
+    assertEquals(RelationshipStatus.PENDING, updatedCharlie.relationships[alice.uid])
+    assertEquals(RelationshipStatus.PENDING, updatedCharlie.relationships[bob.uid])
   }
 
   @Test
@@ -87,8 +87,8 @@ class RelationshipsTests : FirestoreTests() {
     val updatedAlice = accountRepository.getAccount(alice.uid)
 
     assertEquals(2, updatedAlice.relationships.size)
-    assertEquals(RelationshipStatus.Sent, updatedAlice.relationships[bob.uid])
-    assertEquals(RelationshipStatus.Sent, updatedAlice.relationships[charlie.uid])
+    assertEquals(RelationshipStatus.SENT, updatedAlice.relationships[bob.uid])
+    assertEquals(RelationshipStatus.SENT, updatedAlice.relationships[charlie.uid])
   }
 
   // ==================== acceptFriendRequest Tests ====================
@@ -102,8 +102,8 @@ class RelationshipsTests : FirestoreTests() {
     val updatedAlice = accounts[0]
     val updatedBob = accounts[1]
 
-    assertEquals(RelationshipStatus.Friend, updatedAlice.relationships[bob.uid])
-    assertEquals(RelationshipStatus.Friend, updatedBob.relationships[alice.uid])
+    assertEquals(RelationshipStatus.FRIEND, updatedAlice.relationships[bob.uid])
+    assertEquals(RelationshipStatus.FRIEND, updatedBob.relationships[alice.uid])
   }
 
   @Test
@@ -112,13 +112,13 @@ class RelationshipsTests : FirestoreTests() {
 
     // Verify Sent and Pending states exist first
     val beforeAccept = accountRepository.getAccount(alice.uid)
-    assertEquals(RelationshipStatus.Sent, beforeAccept.relationships[bob.uid])
+    assertEquals(RelationshipStatus.SENT, beforeAccept.relationships[bob.uid])
 
     accountRepository.acceptFriendRequest(bob.uid, alice.uid)
 
     // Verify both are now Friend status
     val afterAccept = accountRepository.getAccount(alice.uid)
-    assertEquals(RelationshipStatus.Friend, afterAccept.relationships[bob.uid])
+    assertEquals(RelationshipStatus.FRIEND, afterAccept.relationships[bob.uid])
   }
 
   @Test
@@ -136,12 +136,12 @@ class RelationshipsTests : FirestoreTests() {
     val updatedCharlie = accounts[2]
 
     // Alice and Bob are friends
-    assertEquals(RelationshipStatus.Friend, updatedAlice.relationships[bob.uid])
-    assertEquals(RelationshipStatus.Friend, updatedBob.relationships[alice.uid])
+    assertEquals(RelationshipStatus.FRIEND, updatedAlice.relationships[bob.uid])
+    assertEquals(RelationshipStatus.FRIEND, updatedBob.relationships[alice.uid])
 
     // Alice and Charlie still have pending request
-    assertEquals(RelationshipStatus.Sent, updatedAlice.relationships[charlie.uid])
-    assertEquals(RelationshipStatus.Pending, updatedCharlie.relationships[alice.uid])
+    assertEquals(RelationshipStatus.SENT, updatedAlice.relationships[charlie.uid])
+    assertEquals(RelationshipStatus.PENDING, updatedCharlie.relationships[alice.uid])
   }
 
   // ==================== blockUser Tests ====================
@@ -154,7 +154,7 @@ class RelationshipsTests : FirestoreTests() {
     val updatedAlice = accounts[0]
     val updatedBob = accounts[1]
 
-    assertEquals(RelationshipStatus.Blocked, updatedAlice.relationships[bob.uid])
+    assertEquals(RelationshipStatus.BLOCKED, updatedAlice.relationships[bob.uid])
     assertNull(updatedBob.relationships[alice.uid])
     assertFalse(updatedBob.relationships.containsKey(alice.uid))
   }
@@ -172,8 +172,8 @@ class RelationshipsTests : FirestoreTests() {
     val updatedBob = accounts[1]
 
     // Both should have Blocked status
-    assertEquals(RelationshipStatus.Blocked, updatedAlice.relationships[bob.uid])
-    assertEquals(RelationshipStatus.Blocked, updatedBob.relationships[alice.uid])
+    assertEquals(RelationshipStatus.BLOCKED, updatedAlice.relationships[bob.uid])
+    assertEquals(RelationshipStatus.BLOCKED, updatedBob.relationships[alice.uid])
   }
 
   @Test
@@ -190,7 +190,7 @@ class RelationshipsTests : FirestoreTests() {
     val updatedBob = accounts[1]
 
     // Alice has Bob blocked
-    assertEquals(RelationshipStatus.Blocked, updatedAlice.relationships[bob.uid])
+    assertEquals(RelationshipStatus.BLOCKED, updatedAlice.relationships[bob.uid])
     // Bob has no relationship with Alice
     assertNull(updatedBob.relationships[alice.uid])
   }
@@ -208,7 +208,7 @@ class RelationshipsTests : FirestoreTests() {
     val updatedBob = accounts[1]
 
     // Bob has Alice blocked
-    assertEquals(RelationshipStatus.Blocked, updatedBob.relationships[alice.uid])
+    assertEquals(RelationshipStatus.BLOCKED, updatedBob.relationships[alice.uid])
     // Alice has no relationship (her Sent status was deleted)
     assertNull(updatedAlice.relationships[bob.uid])
   }
@@ -269,8 +269,8 @@ class RelationshipsTests : FirestoreTests() {
     var accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
     var updatedAlice = accounts[0]
     var updatedBob = accounts[1]
-    assertEquals(RelationshipStatus.Sent, updatedAlice.relationships[bob.uid])
-    assertEquals(RelationshipStatus.Pending, updatedBob.relationships[alice.uid])
+    assertEquals(RelationshipStatus.SENT, updatedAlice.relationships[bob.uid])
+    assertEquals(RelationshipStatus.PENDING, updatedBob.relationships[alice.uid])
 
     // Accept request
     accountRepository.acceptFriendRequest(bob.uid, alice.uid)
@@ -278,8 +278,8 @@ class RelationshipsTests : FirestoreTests() {
     accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
     updatedAlice = accounts[0]
     updatedBob = accounts[1]
-    assertEquals(RelationshipStatus.Friend, updatedAlice.relationships[bob.uid])
-    assertEquals(RelationshipStatus.Friend, updatedBob.relationships[alice.uid])
+    assertEquals(RelationshipStatus.FRIEND, updatedAlice.relationships[bob.uid])
+    assertEquals(RelationshipStatus.FRIEND, updatedBob.relationships[alice.uid])
 
     // Remove friendship
     accountRepository.resetRelationship(alice.uid, bob.uid)
@@ -305,7 +305,7 @@ class RelationshipsTests : FirestoreTests() {
     accountRepository.blockUser(alice.uid, bob.uid)
 
     var updatedAlice = accountRepository.getAccount(alice.uid)
-    assertEquals(RelationshipStatus.Blocked, updatedAlice.relationships[bob.uid])
+    assertEquals(RelationshipStatus.BLOCKED, updatedAlice.relationships[bob.uid])
 
     accountRepository.resetRelationship(alice.uid, bob.uid)
 
@@ -316,8 +316,8 @@ class RelationshipsTests : FirestoreTests() {
     accountRepository.acceptFriendRequest(bob.uid, alice.uid)
 
     accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
-    assertEquals(RelationshipStatus.Friend, accounts[0].relationships[bob.uid])
-    assertEquals(RelationshipStatus.Friend, accounts[1].relationships[alice.uid])
+    assertEquals(RelationshipStatus.FRIEND, accounts[0].relationships[bob.uid])
+    assertEquals(RelationshipStatus.FRIEND, accounts[1].relationships[alice.uid])
   }
 
   @Test
@@ -337,14 +337,14 @@ class RelationshipsTests : FirestoreTests() {
     val updatedCharlie = accounts[2]
 
     // Verify all relationships are independent
-    assertEquals(RelationshipStatus.Sent, updatedAlice.relationships[bob.uid])
-    assertEquals(RelationshipStatus.Pending, updatedAlice.relationships[charlie.uid])
+    assertEquals(RelationshipStatus.SENT, updatedAlice.relationships[bob.uid])
+    assertEquals(RelationshipStatus.PENDING, updatedAlice.relationships[charlie.uid])
 
-    assertEquals(RelationshipStatus.Pending, updatedBob.relationships[alice.uid])
-    assertEquals(RelationshipStatus.Sent, updatedBob.relationships[charlie.uid])
+    assertEquals(RelationshipStatus.PENDING, updatedBob.relationships[alice.uid])
+    assertEquals(RelationshipStatus.SENT, updatedBob.relationships[charlie.uid])
 
-    assertEquals(RelationshipStatus.Sent, updatedCharlie.relationships[alice.uid])
-    assertEquals(RelationshipStatus.Pending, updatedCharlie.relationships[bob.uid])
+    assertEquals(RelationshipStatus.SENT, updatedCharlie.relationships[alice.uid])
+    assertEquals(RelationshipStatus.PENDING, updatedCharlie.relationships[bob.uid])
   }
 
   // ==================== Edge Cases ====================
@@ -390,24 +390,24 @@ class RelationshipsTests : FirestoreTests() {
     val fetch2 = accountRepository.getAccount(alice.uid)
     val fetch3 = accountRepository.getAccount(alice.uid)
 
-    assertEquals(RelationshipStatus.Sent, fetch1.relationships[bob.uid])
-    assertEquals(RelationshipStatus.Sent, fetch2.relationships[bob.uid])
-    assertEquals(RelationshipStatus.Sent, fetch3.relationships[bob.uid])
+    assertEquals(RelationshipStatus.SENT, fetch1.relationships[bob.uid])
+    assertEquals(RelationshipStatus.SENT, fetch2.relationships[bob.uid])
+    assertEquals(RelationshipStatus.SENT, fetch3.relationships[bob.uid])
 
     // Test 2: Friendship with one user doesn't affect other relationships
     accountRepository.sendFriendRequest(alice.uid, charlie.uid)
     accountRepository.acceptFriendRequest(bob.uid, alice.uid)
 
     var updatedAlice = accountRepository.getAccount(alice.uid)
-    assertEquals(RelationshipStatus.Friend, updatedAlice.relationships[bob.uid])
-    assertEquals(RelationshipStatus.Sent, updatedAlice.relationships[charlie.uid])
+    assertEquals(RelationshipStatus.FRIEND, updatedAlice.relationships[bob.uid])
+    assertEquals(RelationshipStatus.SENT, updatedAlice.relationships[charlie.uid])
 
     // Test 3: Blocking one user doesn't affect other relationships
     accountRepository.blockUser(alice.uid, bob.uid)
 
     updatedAlice = accountRepository.getAccount(alice.uid)
-    assertEquals(RelationshipStatus.Blocked, updatedAlice.relationships[bob.uid])
-    assertEquals(RelationshipStatus.Sent, updatedAlice.relationships[charlie.uid])
+    assertEquals(RelationshipStatus.BLOCKED, updatedAlice.relationships[bob.uid])
+    assertEquals(RelationshipStatus.SENT, updatedAlice.relationships[charlie.uid])
   }
 
   // ==================== ViewModel Validation Tests ====================
@@ -427,8 +427,8 @@ class RelationshipsTests : FirestoreTests() {
 
     viewModel.sendFriendRequest(updatedAlice, updatedBob)
     accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
-    assertEquals(RelationshipStatus.Sent, accounts[0].relationships[bob.uid])
-    assertEquals(RelationshipStatus.Pending, accounts[1].relationships[alice.uid])
+    assertEquals(RelationshipStatus.SENT, accounts[0].relationships[bob.uid])
+    assertEquals(RelationshipStatus.PENDING, accounts[1].relationships[alice.uid])
 
     // Test 3: Prevent when already friends
     accountRepository.resetRelationship(alice.uid, bob.uid)
@@ -441,8 +441,8 @@ class RelationshipsTests : FirestoreTests() {
 
     viewModel.sendFriendRequest(updatedAlice, updatedBob)
     accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
-    assertEquals(RelationshipStatus.Friend, accounts[0].relationships[bob.uid])
-    assertEquals(RelationshipStatus.Friend, accounts[1].relationships[alice.uid])
+    assertEquals(RelationshipStatus.FRIEND, accounts[0].relationships[bob.uid])
+    assertEquals(RelationshipStatus.FRIEND, accounts[1].relationships[alice.uid])
 
     // Test 4: Prevent when one user blocked the other
     accountRepository.resetRelationship(alice.uid, bob.uid)
@@ -456,7 +456,7 @@ class RelationshipsTests : FirestoreTests() {
     viewModel.sendFriendRequest(updatedBob, updatedAlice)
 
     accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
-    assertEquals(RelationshipStatus.Blocked, accounts[0].relationships[bob.uid])
+    assertEquals(RelationshipStatus.BLOCKED, accounts[0].relationships[bob.uid])
     assertNull(accounts[1].relationships[alice.uid])
   }
 
@@ -467,8 +467,8 @@ class RelationshipsTests : FirestoreTests() {
     viewModel.sendFriendRequest(accounts[0], accounts[1])
 
     accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
-    assertEquals(RelationshipStatus.Sent, accounts[0].relationships[bob.uid])
-    assertEquals(RelationshipStatus.Pending, accounts[1].relationships[alice.uid])
+    assertEquals(RelationshipStatus.SENT, accounts[0].relationships[bob.uid])
+    assertEquals(RelationshipStatus.PENDING, accounts[1].relationships[alice.uid])
   }
 
   @Test
@@ -489,8 +489,8 @@ class RelationshipsTests : FirestoreTests() {
 
     viewModel.acceptFriendRequest(accounts[0], accounts[1])
     accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
-    assertEquals(RelationshipStatus.Sent, accounts[0].relationships[bob.uid])
-    assertEquals(RelationshipStatus.Pending, accounts[1].relationships[alice.uid])
+    assertEquals(RelationshipStatus.SENT, accounts[0].relationships[bob.uid])
+    assertEquals(RelationshipStatus.PENDING, accounts[1].relationships[alice.uid])
 
     // Test 3: Prevent accepting when already friends
     accountRepository.acceptFriendRequest(bob.uid, alice.uid)
@@ -498,8 +498,8 @@ class RelationshipsTests : FirestoreTests() {
 
     viewModel.acceptFriendRequest(accounts[0], accounts[1])
     accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
-    assertEquals(RelationshipStatus.Friend, accounts[0].relationships[bob.uid])
-    assertEquals(RelationshipStatus.Friend, accounts[1].relationships[alice.uid])
+    assertEquals(RelationshipStatus.FRIEND, accounts[0].relationships[bob.uid])
+    assertEquals(RelationshipStatus.FRIEND, accounts[1].relationships[alice.uid])
 
     // Test 4: Prevent accepting same user
     viewModel.acceptFriendRequest(alice, alice)
@@ -515,7 +515,7 @@ class RelationshipsTests : FirestoreTests() {
     viewModel.acceptFriendRequest(accounts[1], accounts[0])
 
     accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
-    assertEquals(RelationshipStatus.Blocked, accounts[0].relationships[bob.uid])
+    assertEquals(RelationshipStatus.BLOCKED, accounts[0].relationships[bob.uid])
     assertNull(accounts[1].relationships[alice.uid])
   }
 
@@ -527,8 +527,8 @@ class RelationshipsTests : FirestoreTests() {
     viewModel.acceptFriendRequest(accounts[1], accounts[0])
 
     accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
-    assertEquals(RelationshipStatus.Friend, accounts[0].relationships[bob.uid])
-    assertEquals(RelationshipStatus.Friend, accounts[1].relationships[alice.uid])
+    assertEquals(RelationshipStatus.FRIEND, accounts[0].relationships[bob.uid])
+    assertEquals(RelationshipStatus.FRIEND, accounts[1].relationships[alice.uid])
   }
 
   @Test
@@ -548,7 +548,7 @@ class RelationshipsTests : FirestoreTests() {
     viewModel.blockUser(accounts[0], accounts[1])
 
     accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
-    assertEquals(RelationshipStatus.Blocked, accounts[0].relationships[bob.uid])
+    assertEquals(RelationshipStatus.BLOCKED, accounts[0].relationships[bob.uid])
     assertNull(accounts[1].relationships[alice.uid])
   }
 
@@ -566,7 +566,7 @@ class RelationshipsTests : FirestoreTests() {
     kotlinx.coroutines.delay(100)
 
     accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
-    assertEquals(RelationshipStatus.Blocked, accounts[0].relationships[bob.uid])
+    assertEquals(RelationshipStatus.BLOCKED, accounts[0].relationships[bob.uid])
     assertNull(accounts[1].relationships[alice.uid])
 
     // Test 2: Block after friendship
@@ -581,7 +581,7 @@ class RelationshipsTests : FirestoreTests() {
     kotlinx.coroutines.delay(100)
 
     accounts = accountRepository.getAccounts(listOf(alice.uid, charlie.uid))
-    assertEquals(RelationshipStatus.Blocked, accounts[0].relationships[charlie.uid])
+    assertEquals(RelationshipStatus.BLOCKED, accounts[0].relationships[charlie.uid])
     assertNull(accounts[1].relationships[alice.uid])
 
     // Test 3: Mutual blocking
@@ -593,8 +593,8 @@ class RelationshipsTests : FirestoreTests() {
     accountRepository.blockUser(bob.uid, alice.uid)
 
     accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
-    assertEquals(RelationshipStatus.Blocked, accounts[0].relationships[bob.uid])
-    assertEquals(RelationshipStatus.Blocked, accounts[1].relationships[alice.uid])
+    assertEquals(RelationshipStatus.BLOCKED, accounts[0].relationships[bob.uid])
+    assertEquals(RelationshipStatus.BLOCKED, accounts[1].relationships[alice.uid])
   }
 
   @Test
@@ -611,7 +611,7 @@ class RelationshipsTests : FirestoreTests() {
     viewModel.cancelFriendRequest(accounts[0], accounts[1])
 
     accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
-    assertEquals(RelationshipStatus.Blocked, accounts[0].relationships[bob.uid])
+    assertEquals(RelationshipStatus.BLOCKED, accounts[0].relationships[bob.uid])
     assertNull(accounts[1].relationships[alice.uid])
   }
 
@@ -629,7 +629,7 @@ class RelationshipsTests : FirestoreTests() {
     viewModel.denyFriendRequest(accounts[1], accounts[0])
 
     accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
-    assertEquals(RelationshipStatus.Blocked, accounts[0].relationships[bob.uid])
+    assertEquals(RelationshipStatus.BLOCKED, accounts[0].relationships[bob.uid])
     assertNull(accounts[1].relationships[alice.uid])
   }
 
@@ -650,7 +650,7 @@ class RelationshipsTests : FirestoreTests() {
     viewModel.removeFriend(accounts[0], accounts[1])
 
     accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
-    assertEquals(RelationshipStatus.Blocked, accounts[0].relationships[bob.uid])
+    assertEquals(RelationshipStatus.BLOCKED, accounts[0].relationships[bob.uid])
     assertNull(accounts[1].relationships[alice.uid])
   }
 
@@ -681,8 +681,8 @@ class RelationshipsTests : FirestoreTests() {
     viewModel.unblockUser(accounts[0], accounts[1])
 
     accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
-    assertEquals(RelationshipStatus.Friend, accounts[0].relationships[bob.uid])
-    assertEquals(RelationshipStatus.Friend, accounts[1].relationships[alice.uid])
+    assertEquals(RelationshipStatus.FRIEND, accounts[0].relationships[bob.uid])
+    assertEquals(RelationshipStatus.FRIEND, accounts[1].relationships[alice.uid])
   }
 
   @Test
@@ -742,8 +742,8 @@ class RelationshipsTests : FirestoreTests() {
     viewModel.sendFriendRequest(accounts[1], accounts[0])
 
     accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
-    assertEquals(RelationshipStatus.Sent, accounts[0].relationships[bob.uid])
-    assertEquals(RelationshipStatus.Pending, accounts[1].relationships[alice.uid])
+    assertEquals(RelationshipStatus.SENT, accounts[0].relationships[bob.uid])
+    assertEquals(RelationshipStatus.PENDING, accounts[1].relationships[alice.uid])
 
     // Test 2: After accepting, cannot send another request
     viewModel.acceptFriendRequest(accounts[1], accounts[0])
@@ -752,8 +752,8 @@ class RelationshipsTests : FirestoreTests() {
     viewModel.sendFriendRequest(accounts[0], accounts[1])
 
     accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
-    assertEquals(RelationshipStatus.Friend, accounts[0].relationships[bob.uid])
-    assertEquals(RelationshipStatus.Friend, accounts[1].relationships[alice.uid])
+    assertEquals(RelationshipStatus.FRIEND, accounts[0].relationships[bob.uid])
+    assertEquals(RelationshipStatus.FRIEND, accounts[1].relationships[alice.uid])
 
     // Test 3: After blocking, cannot send friend request
     viewModel.blockUser(accounts[0], accounts[1])
@@ -763,7 +763,7 @@ class RelationshipsTests : FirestoreTests() {
     viewModel.sendFriendRequest(accounts[1], accounts[0])
 
     accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
-    assertEquals(RelationshipStatus.Blocked, accounts[0].relationships[bob.uid])
+    assertEquals(RelationshipStatus.BLOCKED, accounts[0].relationships[bob.uid])
     assertNull(accounts[1].relationships[alice.uid])
   }
 }

--- a/app/src/androidTest/java/com/github/meeplemeet/integration/RelationshipsTests.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/RelationshipsTests.kt
@@ -600,7 +600,7 @@ class RelationshipsTests : FirestoreTests() {
   @Test
   fun viewModelCancelFriendRequest_preventsInvalidOperations() = runBlocking {
     // Test 1: Prevent canceling same user
-    viewModel.cancelFriendRequest(alice, alice)
+    viewModel.rejectFriendRequest(alice, alice)
     val aliceAfterSelf = accountRepository.getAccount(alice.uid)
     assertNull(aliceAfterSelf.relationships[alice.uid])
 
@@ -608,7 +608,7 @@ class RelationshipsTests : FirestoreTests() {
     accountRepository.blockUser(alice.uid, bob.uid)
     var accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
 
-    viewModel.cancelFriendRequest(accounts[0], accounts[1])
+    viewModel.rejectFriendRequest(accounts[0], accounts[1])
 
     accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
     assertEquals(RelationshipStatus.BLOCKED, accounts[0].relationships[bob.uid])
@@ -618,7 +618,7 @@ class RelationshipsTests : FirestoreTests() {
   @Test
   fun viewModelDenyFriendRequest_preventsInvalidOperations() = runBlocking {
     // Test 1: Prevent denying same user
-    viewModel.denyFriendRequest(alice, alice)
+    viewModel.rejectFriendRequest(alice, alice)
     val aliceAfterSelf = accountRepository.getAccount(alice.uid)
     assertNull(aliceAfterSelf.relationships[alice.uid])
 
@@ -626,7 +626,7 @@ class RelationshipsTests : FirestoreTests() {
     accountRepository.blockUser(alice.uid, bob.uid)
     var accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
 
-    viewModel.denyFriendRequest(accounts[1], accounts[0])
+    viewModel.rejectFriendRequest(accounts[1], accounts[0])
 
     accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
     assertEquals(RelationshipStatus.BLOCKED, accounts[0].relationships[bob.uid])
@@ -690,7 +690,7 @@ class RelationshipsTests : FirestoreTests() {
     accountRepository.sendFriendRequest(alice.uid, bob.uid)
     var accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
 
-    viewModel.cancelFriendRequest(accounts[0], accounts[1])
+    viewModel.rejectFriendRequest(accounts[0], accounts[1])
 
     accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
     assertNull(accounts[0].relationships[bob.uid])
@@ -702,7 +702,7 @@ class RelationshipsTests : FirestoreTests() {
     accountRepository.sendFriendRequest(alice.uid, bob.uid)
     var accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
 
-    viewModel.denyFriendRequest(accounts[1], accounts[0])
+    viewModel.rejectFriendRequest(accounts[1], accounts[0])
 
     accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
     assertNull(accounts[0].relationships[bob.uid])

--- a/app/src/androidTest/java/com/github/meeplemeet/integration/RelationshipsTests.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/RelationshipsTests.kt
@@ -148,7 +148,7 @@ class RelationshipsTests : FirestoreTests() {
 
   @Test
   fun blockUser_setsBlockedStatusAndRemovesFromBlockedUser() = runBlocking {
-    accountRepository.blockUser(alice.uid, bob.uid, false)
+    accountRepository.blockUser(alice.uid, bob.uid)
 
     val accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
     val updatedAlice = accounts[0]
@@ -162,10 +162,10 @@ class RelationshipsTests : FirestoreTests() {
   @Test
   fun blockUser_whenMutualBlock_preservesBothBlockStatuses() = runBlocking {
     // Bob blocks Alice first
-    accountRepository.blockUser(bob.uid, alice.uid, false)
+    accountRepository.blockUser(bob.uid, alice.uid)
 
     // Alice blocks Bob (Bob has already blocked Alice)
-    accountRepository.blockUser(alice.uid, bob.uid, true)
+    accountRepository.blockUser(alice.uid, bob.uid)
 
     val accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
     val updatedAlice = accounts[0]
@@ -183,7 +183,7 @@ class RelationshipsTests : FirestoreTests() {
     accountRepository.acceptFriendRequest(bob.uid, alice.uid)
 
     // Alice blocks Bob
-    accountRepository.blockUser(alice.uid, bob.uid, false)
+    accountRepository.blockUser(alice.uid, bob.uid)
 
     val accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
     val updatedAlice = accounts[0]
@@ -201,7 +201,7 @@ class RelationshipsTests : FirestoreTests() {
     accountRepository.sendFriendRequest(alice.uid, bob.uid)
 
     // Bob blocks Alice instead of accepting
-    accountRepository.blockUser(bob.uid, alice.uid, false)
+    accountRepository.blockUser(bob.uid, alice.uid)
 
     val accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
     val updatedAlice = accounts[0]
@@ -243,7 +243,7 @@ class RelationshipsTests : FirestoreTests() {
     assertNull(accounts[1].relationships[alice.uid])
 
     // Test 4: Unblock user
-    accountRepository.blockUser(alice.uid, bob.uid, false)
+    accountRepository.blockUser(alice.uid, bob.uid)
     accountRepository.resetRelationship(alice.uid, bob.uid)
 
     accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
@@ -302,7 +302,7 @@ class RelationshipsTests : FirestoreTests() {
     assertNull(accounts[1].relationships[alice.uid])
 
     // Workflow 2: Block, unblock, then befriend
-    accountRepository.blockUser(alice.uid, bob.uid, false)
+    accountRepository.blockUser(alice.uid, bob.uid)
 
     var updatedAlice = accountRepository.getAccount(alice.uid)
     assertEquals(RelationshipStatus.Blocked, updatedAlice.relationships[bob.uid])
@@ -367,7 +367,7 @@ class RelationshipsTests : FirestoreTests() {
     accountRepository.acceptFriendRequest(bob.uid, alice.uid)
 
     // Block user
-    accountRepository.blockUser(alice.uid, bob.uid, false)
+    accountRepository.blockUser(alice.uid, bob.uid)
 
     // Unblock
     accountRepository.resetRelationship(alice.uid, bob.uid)
@@ -403,7 +403,7 @@ class RelationshipsTests : FirestoreTests() {
     assertEquals(RelationshipStatus.Sent, updatedAlice.relationships[charlie.uid])
 
     // Test 3: Blocking one user doesn't affect other relationships
-    accountRepository.blockUser(alice.uid, bob.uid, false)
+    accountRepository.blockUser(alice.uid, bob.uid)
 
     updatedAlice = accountRepository.getAccount(alice.uid)
     assertEquals(RelationshipStatus.Blocked, updatedAlice.relationships[bob.uid])
@@ -446,7 +446,7 @@ class RelationshipsTests : FirestoreTests() {
 
     // Test 4: Prevent when one user blocked the other
     accountRepository.resetRelationship(alice.uid, bob.uid)
-    accountRepository.blockUser(alice.uid, bob.uid, false)
+    accountRepository.blockUser(alice.uid, bob.uid)
 
     accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
     updatedAlice = accounts[0]
@@ -508,7 +508,7 @@ class RelationshipsTests : FirestoreTests() {
 
     // Test 5: Prevent accepting when blocked
     accountRepository.resetRelationship(alice.uid, bob.uid)
-    accountRepository.blockUser(alice.uid, bob.uid, false)
+    accountRepository.blockUser(alice.uid, bob.uid)
     accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
 
     viewModel.acceptFriendRequest(accounts[0], accounts[1])
@@ -539,7 +539,7 @@ class RelationshipsTests : FirestoreTests() {
     assertNull(aliceAfterSelf.relationships[alice.uid])
 
     // Test 2: Prevent blocking when already blocked
-    accountRepository.blockUser(alice.uid, bob.uid, false)
+    accountRepository.blockUser(alice.uid, bob.uid)
     var accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
 
     viewModel.blockUser(accounts[0], accounts[1])
@@ -573,7 +573,7 @@ class RelationshipsTests : FirestoreTests() {
 
     // Test 3: Mutual blocking
     accountRepository.resetRelationship(alice.uid, charlie.uid)
-    accountRepository.blockUser(alice.uid, bob.uid, false)
+    accountRepository.blockUser(alice.uid, bob.uid)
 
     accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
     viewModel.blockUser(accounts[1], accounts[0])
@@ -591,7 +591,7 @@ class RelationshipsTests : FirestoreTests() {
     assertNull(aliceAfterSelf.relationships[alice.uid])
 
     // Test 2: Prevent canceling when blocked
-    accountRepository.blockUser(alice.uid, bob.uid, false)
+    accountRepository.blockUser(alice.uid, bob.uid)
     var accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
 
     viewModel.cancelFriendRequest(accounts[0], accounts[1])
@@ -609,7 +609,7 @@ class RelationshipsTests : FirestoreTests() {
     assertNull(aliceAfterSelf.relationships[alice.uid])
 
     // Test 2: Prevent denying when blocked
-    accountRepository.blockUser(alice.uid, bob.uid, false)
+    accountRepository.blockUser(alice.uid, bob.uid)
     var accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
 
     viewModel.denyFriendRequest(accounts[1], accounts[0])
@@ -627,7 +627,7 @@ class RelationshipsTests : FirestoreTests() {
     assertNull(aliceAfterSelf.relationships[alice.uid])
 
     // Test 2: Prevent removing when blocked
-    accountRepository.blockUser(alice.uid, bob.uid, false)
+    accountRepository.blockUser(alice.uid, bob.uid)
     var accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
 
     viewModel.removeFriend(accounts[0], accounts[1])
@@ -645,7 +645,7 @@ class RelationshipsTests : FirestoreTests() {
     assertNull(aliceAfterSelf.relationships[alice.uid])
 
     // Test 2: Prevent unblocking when blocked
-    accountRepository.blockUser(alice.uid, bob.uid, false)
+    accountRepository.blockUser(alice.uid, bob.uid)
     var accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
 
     viewModel.unblockUser(accounts[0], accounts[1])
@@ -694,9 +694,9 @@ class RelationshipsTests : FirestoreTests() {
 
   @Test
   fun viewModelUnblockUser_allowsValidUnblock() = runBlocking {
-    accountRepository.blockUser(alice.uid, bob.uid, false)
+    accountRepository.blockUser(alice.uid, bob.uid)
     accountRepository.resetRelationship(alice.uid, bob.uid)
-    var accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
+    val accounts = accountRepository.getAccounts(listOf(alice.uid, bob.uid))
 
     // Relationship should be null after unblock
     assertNull(accounts[0].relationships[bob.uid])

--- a/app/src/main/java/com/github/meeplemeet/model/account/Account.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/Account.kt
@@ -1,5 +1,7 @@
 package com.github.meeplemeet.model.account
 
+// Claude Code generated the documentation
+
 import com.github.meeplemeet.model.discussions.DiscussionPreview
 import com.github.meeplemeet.model.discussions.DiscussionPreviewNoUid
 import com.github.meeplemeet.model.discussions.fromNoUid
@@ -96,8 +98,6 @@ data class Account(
  * @property description User's self-description or bio. Null if not provided.
  * @property shopOwner Indicates whether this account owns a board game shop. Defaults to false.
  * @property spaceRenter Indicates whether this account rents out gaming spaces. Defaults to false.
- * @property relationships List of all relationships this account has with other users. Defaults to
- *   empty list.
  */
 @Serializable
 data class AccountNoUid(
@@ -107,8 +107,7 @@ data class AccountNoUid(
     val photoUrl: String? = null,
     val description: String? = null,
     val shopOwner: Boolean = false,
-    val spaceRenter: Boolean = false,
-    val relationships: List<Relationship> = emptyList()
+    val spaceRenter: Boolean = false
 )
 
 /**

--- a/app/src/main/java/com/github/meeplemeet/model/account/Account.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/Account.kt
@@ -62,7 +62,10 @@ enum class RelationshipStatus {
   Pending,
 
   /** Blocked - the current user has blocked the other user. */
-  Blocked
+  Blocked,
+
+  /** Deleted - removes the relationship with the other user altogether */
+  Delete,
 }
 
 /**
@@ -145,6 +148,7 @@ fun fromNoUid(
       RelationshipStatus.Sent -> sent += other
       RelationshipStatus.Pending -> pending += other
       RelationshipStatus.Blocked -> blocked += other
+      RelationshipStatus.Delete -> {} // Does not exist in the db
     }
   }
 

--- a/app/src/main/java/com/github/meeplemeet/model/account/Account.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/Account.kt
@@ -8,17 +8,25 @@ import kotlinx.serialization.Serializable
 /**
  * Represents a user account stored in Firestore.
  *
+ * This data class models the complete account structure including user profile information, social
+ * relationships, and discussion metadata. It serves as the runtime representation of account data
+ * throughout the application.
+ *
  * @property uid Globally unique identifier of the account (Firestore document ID).
- * @property handle unique human-readable identifier for the user
- * @property name Human-readable name of the account.
- * @property email User's email used to create the account
+ * @property handle Unique human-readable identifier for the user (e.g., @username).
+ * @property name Human-readable display name of the account.
+ * @property email User's email address used to create the account.
  * @property previews Map of discussion previews keyed by discussion ID. Each preview stores
  *   lightweight metadata (e.g. last message, unread count) for discussions this account
  *   participates in.
- * @property photoUrl User's profile picture
- * @property description A user's description about himself
- * @property shopOwner Tells if this account is a shop owner
- * @property spaceRenter Tells if this account is a space renter
+ * @property photoUrl URL to the user's profile picture. Null if no profile picture is set.
+ * @property description User's self-description or bio. Null if not provided.
+ * @property shopOwner Indicates whether this account owns a board game shop.
+ * @property spaceRenter Indicates whether this account rents out gaming spaces.
+ * @property friends List of UIDs of users who are mutual friends with this account.
+ * @property sent List of UIDs of users to whom this account has sent friend requests.
+ * @property pending List of UIDs of users who have sent friend requests to this account.
+ * @property blocked List of UIDs of users who have been blocked by this account.
  */
 data class Account(
     val uid: String,
@@ -29,13 +37,67 @@ data class Account(
     var photoUrl: String? = null,
     var description: String? = null,
     var shopOwner: Boolean = false,
-    var spaceRenter: Boolean = false
+    var spaceRenter: Boolean = false,
+    val friends: List<String> = emptyList(),
+    val sent: List<String> = emptyList(),
+    val pending: List<String> = emptyList(),
+    val blocked: List<String> = emptyList(),
+)
+
+/**
+ * Represents the status of a relationship between two users.
+ *
+ * This enum is used to categorize the type of social connection or interaction between the current
+ * user and another user in the system.
+ */
+@Serializable
+enum class RelationshipStatus {
+  /** Mutual friendship - both users have accepted the friend request. */
+  Friend,
+
+  /** Friend request sent - the current user has sent a request to the other user. */
+  Sent,
+
+  /** Friend request pending - the other user has sent a request to the current user. */
+  Pending,
+
+  /** Blocked - the current user has blocked the other user. */
+  Blocked
+}
+
+/**
+ * Represents a relationship between the current user and another user.
+ *
+ * This data class pairs a user's UID with the status of their relationship to the current account.
+ * It is used for serialization to/from Firestore.
+ *
+ * @property uid The unique identifier of the other user in the relationship.
+ * @property status The type of relationship (Friend, Sent, Pending, or Blocked). Defaults to Friend
+ *   if not specified.
+ */
+@Serializable
+data class Relationship(
+    val uid: String,
+    val status: RelationshipStatus = RelationshipStatus.Friend
 )
 
 /**
  * Minimal serializable form of [Account] without the UID, used for Firestore storage.
  *
- * Firestore stores the UID as the document ID, so it is omitted from the stored object.
+ * Firestore stores the UID as the document ID, so it is omitted from the stored object. This class
+ * is optimized for serialization and contains only the fields that need to be persisted in the
+ * database. The relationships are stored as a flat list rather than separate fields for friends,
+ * sent, pending, and blocked.
+ *
+ * @property handle Unique human-readable identifier for the user. Defaults to empty string.
+ * @property name Human-readable display name. Defaults to empty string.
+ * @property email User's email address. Defaults to empty string.
+ * @property photoUrl URL to the user's profile picture. Null if not set.
+ * @property description User's self-description or bio. Null if not provided.
+ * @property shopOwner Indicates whether this account owns a board game shop. Defaults to false.
+ * @property spaceRenter Indicates whether this account rents out gaming spaces. Defaults to false.
+ * @property relationships List of all relationships this account has with other users. Defaults to
+ *   empty list.
  */
 @Serializable
 data class AccountNoUid(
@@ -45,30 +107,59 @@ data class AccountNoUid(
     val photoUrl: String? = null,
     val description: String? = null,
     val shopOwner: Boolean = false,
-    val spaceRenter: Boolean = false
+    val spaceRenter: Boolean = false,
+    val relationships: List<Relationship> = emptyList()
 )
 
 /**
  * Reconstructs a full [Account] object from its Firestore representation.
  *
+ * This function deserializes account data from Firestore by combining the document ID with the
+ * stored [AccountNoUid] data. It also transforms the flat list of relationships into separate
+ * categorized lists (friends, sent, pending, blocked) for easier access in the application.
+ *
  * @param id The Firestore document ID (used as account UID).
  * @param accountNoUid The deserialized [AccountNoUid] data from Firestore.
- * @param previews Optional map of discussion preview data keyed by discussion ID.
- * @return A fully constructed [Account] instance.
+ * @param previews Optional map of discussion preview data keyed by discussion ID. Each preview will
+ *   be converted from [DiscussionPreviewNoUid] to [DiscussionPreview]. Defaults to empty map.
+ * @param relationships List of all relationships this account has. This will be split into separate
+ *   lists based on relationship status. Defaults to empty list.
+ * @return A fully constructed [Account] instance with all relationship lists populated.
  */
 fun fromNoUid(
     id: String,
     accountNoUid: AccountNoUid,
-    previews: Map<String, DiscussionPreviewNoUid> = emptyMap()
-): Account =
-    Account(
-        id,
-        accountNoUid.handle,
-        accountNoUid.name,
-        email = accountNoUid.email,
-        previews.mapValues { (uid, preview) -> fromNoUid(uid, preview) },
-        photoUrl = accountNoUid.photoUrl,
-        description = accountNoUid.description,
-        shopOwner = accountNoUid.shopOwner,
-        spaceRenter = accountNoUid.spaceRenter,
-    )
+    previews: Map<String, DiscussionPreviewNoUid> = emptyMap(),
+    relationships: List<Relationship> = emptyList()
+): Account {
+  val friends = mutableListOf<String>()
+  val sent = mutableListOf<String>()
+  val pending = mutableListOf<String>()
+  val blocked = mutableListOf<String>()
+
+  // Categorize relationships by status
+  for (rel in relationships) {
+    val other = rel.uid
+    when (rel.status) {
+      RelationshipStatus.Friend -> friends += other
+      RelationshipStatus.Sent -> sent += other
+      RelationshipStatus.Pending -> pending += other
+      RelationshipStatus.Blocked -> blocked += other
+    }
+  }
+
+  return Account(
+      id,
+      accountNoUid.handle,
+      accountNoUid.name,
+      email = accountNoUid.email,
+      previews.mapValues { (uid, preview) -> fromNoUid(uid, preview) },
+      photoUrl = accountNoUid.photoUrl,
+      description = accountNoUid.description,
+      shopOwner = accountNoUid.shopOwner,
+      spaceRenter = accountNoUid.spaceRenter,
+      friends = friends,
+      sent = sent,
+      pending = pending,
+      blocked = blocked)
+}

--- a/app/src/main/java/com/github/meeplemeet/model/account/Account.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/Account.kt
@@ -6,45 +6,6 @@ import com.github.meeplemeet.model.discussions.fromNoUid
 import kotlinx.serialization.Serializable
 
 /**
- * Represents a user account stored in Firestore.
- *
- * This data class models the complete account structure including user profile information, social
- * relationships, and discussion metadata. It serves as the runtime representation of account data
- * throughout the application.
- *
- * @property uid Globally unique identifier of the account (Firestore document ID).
- * @property handle Unique human-readable identifier for the user (e.g., @username).
- * @property name Human-readable display name of the account.
- * @property email User's email address used to create the account.
- * @property previews Map of discussion previews keyed by discussion ID. Each preview stores
- *   lightweight metadata (e.g. last message, unread count) for discussions this account
- *   participates in.
- * @property photoUrl URL to the user's profile picture. Null if no profile picture is set.
- * @property description User's self-description or bio. Null if not provided.
- * @property shopOwner Indicates whether this account owns a board game shop.
- * @property spaceRenter Indicates whether this account rents out gaming spaces.
- * @property friends List of UIDs of users who are mutual friends with this account.
- * @property sent List of UIDs of users to whom this account has sent friend requests.
- * @property pending List of UIDs of users who have sent friend requests to this account.
- * @property blocked List of UIDs of users who have been blocked by this account.
- */
-data class Account(
-    val uid: String,
-    val handle: String,
-    val name: String,
-    val email: String,
-    val previews: Map<String, DiscussionPreview> = emptyMap(),
-    var photoUrl: String? = null,
-    var description: String? = null,
-    var shopOwner: Boolean = false,
-    var spaceRenter: Boolean = false,
-    val friends: List<String> = emptyList(),
-    val sent: List<String> = emptyList(),
-    val pending: List<String> = emptyList(),
-    val blocked: List<String> = emptyList(),
-)
-
-/**
  * Represents the status of a relationship between two users.
  *
  * This enum is used to categorize the type of social connection or interaction between the current
@@ -85,6 +46,42 @@ data class Relationship(
 )
 
 /**
+ * Represents a user account stored in Firestore.
+ *
+ * This data class models the complete account structure including user profile information, social
+ * relationships, and discussion metadata. It serves as the runtime representation of account data
+ * throughout the application.
+ *
+ * @property uid Globally unique identifier of the account (Firestore document ID).
+ * @property handle Unique human-readable identifier for the user (e.g., @username).
+ * @property name Human-readable display name of the account.
+ * @property email User's email address used to create the account.
+ * @property previews Map of discussion previews keyed by discussion ID. Each preview stores
+ *   lightweight metadata (e.g. last message, unread count) for discussions this account
+ *   participates in.
+ * @property photoUrl URL to the user's profile picture. Null if no profile picture is set.
+ * @property description User's self-description or bio. Null if not provided.
+ * @property shopOwner Indicates whether this account owns a board game shop.
+ * @property spaceRenter Indicates whether this account rents out gaming spaces.
+ * @property relationships Map of user relationships keyed by the other user's UID, with values
+ *   indicating the relationship status from this account's perspective. Possible statuses include
+ *   Friend (mutual friendship), Sent (friend request sent), Pending (friend request received), and
+ *   Blocked (user has been blocked). An absent key indicates no relationship exists.
+ */
+data class Account(
+    val uid: String,
+    val handle: String,
+    val name: String,
+    val email: String,
+    val previews: Map<String, DiscussionPreview> = emptyMap(),
+    var photoUrl: String? = null,
+    var description: String? = null,
+    var shopOwner: Boolean = false,
+    var spaceRenter: Boolean = false,
+    val relationships: Map<String, RelationshipStatus> = emptyMap()
+)
+
+/**
  * Minimal serializable form of [Account] without the UID, used for Firestore storage.
  *
  * Firestore stores the UID as the document ID, so it is omitted from the stored object. This class
@@ -118,16 +115,17 @@ data class AccountNoUid(
  * Reconstructs a full [Account] object from its Firestore representation.
  *
  * This function deserializes account data from Firestore by combining the document ID with the
- * stored [AccountNoUid] data. It also transforms the flat list of relationships into separate
- * categorized lists (friends, sent, pending, blocked) for easier access in the application.
+ * stored [AccountNoUid] data. It transforms the list of [Relationship] objects from Firestore into
+ * a map structure for efficient lookup by user ID.
  *
  * @param id The Firestore document ID (used as account UID).
  * @param accountNoUid The deserialized [AccountNoUid] data from Firestore.
  * @param previews Optional map of discussion preview data keyed by discussion ID. Each preview will
  *   be converted from [DiscussionPreviewNoUid] to [DiscussionPreview]. Defaults to empty map.
- * @param relationships List of all relationships this account has. This will be split into separate
- *   lists based on relationship status. Defaults to empty list.
- * @return A fully constructed [Account] instance with all relationship lists populated.
+ * @param relationships List of all relationships this account has. This will be converted into a
+ *   map keyed by the other user's UID with the relationship status as the value. Defaults to empty
+ *   list.
+ * @return A fully constructed [Account] instance with relationships map populated.
  */
 fun fromNoUid(
     id: String,
@@ -135,21 +133,10 @@ fun fromNoUid(
     previews: Map<String, DiscussionPreviewNoUid> = emptyMap(),
     relationships: List<Relationship> = emptyList()
 ): Account {
-  val friends = mutableListOf<String>()
-  val sent = mutableListOf<String>()
-  val pending = mutableListOf<String>()
-  val blocked = mutableListOf<String>()
-
-  // Categorize relationships by status
+  // Convert relationship list to map for efficient lookup
+  val mappedRelationships = mutableMapOf<String, RelationshipStatus>()
   for (rel in relationships) {
-    val other = rel.uid
-    when (rel.status) {
-      RelationshipStatus.Friend -> friends += other
-      RelationshipStatus.Sent -> sent += other
-      RelationshipStatus.Pending -> pending += other
-      RelationshipStatus.Blocked -> blocked += other
-      RelationshipStatus.Delete -> {} // Does not exist in the db
-    }
+    mappedRelationships += rel.uid to rel.status
   }
 
   return Account(
@@ -162,8 +149,5 @@ fun fromNoUid(
       description = accountNoUid.description,
       shopOwner = accountNoUid.shopOwner,
       spaceRenter = accountNoUid.spaceRenter,
-      friends = friends,
-      sent = sent,
-      pending = pending,
-      blocked = blocked)
+      relationships = mappedRelationships)
 }

--- a/app/src/main/java/com/github/meeplemeet/model/account/Account.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/Account.kt
@@ -88,8 +88,7 @@ data class Account(
  *
  * Firestore stores the UID as the document ID, so it is omitted from the stored object. This class
  * is optimized for serialization and contains only the fields that need to be persisted in the
- * database. The relationships are stored as a flat list rather than separate fields for friends,
- * sent, pending, and blocked.
+ * database. The relationships are stored as a flat list rather than a map.
  *
  * @property handle Unique human-readable identifier for the user. Defaults to empty string.
  * @property name Human-readable display name. Defaults to empty string.
@@ -133,10 +132,7 @@ fun fromNoUid(
     relationships: List<Relationship> = emptyList()
 ): Account {
   // Convert relationship list to map for efficient lookup
-  val mappedRelationships = mutableMapOf<String, RelationshipStatus>()
-  for (rel in relationships) {
-    mappedRelationships += rel.uid to rel.status
-  }
+  val mappedRelationships = relationships.associate { it.uid to it.status }
 
   return Account(
       id,

--- a/app/src/main/java/com/github/meeplemeet/model/account/Account.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/Account.kt
@@ -16,19 +16,16 @@ import kotlinx.serialization.Serializable
 @Serializable
 enum class RelationshipStatus {
   /** Mutual friendship - both users have accepted the friend request. */
-  Friend,
+  FRIEND,
 
   /** Friend request sent - the current user has sent a request to the other user. */
-  Sent,
+  SENT,
 
   /** Friend request pending - the other user has sent a request to the current user. */
-  Pending,
+  PENDING,
 
   /** Blocked - the current user has blocked the other user. */
-  Blocked,
-
-  /** Deleted - removes the relationship with the other user altogether */
-  Delete,
+  BLOCKED,
 }
 
 /**
@@ -44,7 +41,7 @@ enum class RelationshipStatus {
 @Serializable
 data class Relationship(
     val uid: String,
-    val status: RelationshipStatus = RelationshipStatus.Friend
+    val status: RelationshipStatus = RelationshipStatus.FRIEND
 )
 
 /**

--- a/app/src/main/java/com/github/meeplemeet/model/account/AccountRepository.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/AccountRepository.kt
@@ -225,16 +225,16 @@ class AccountRepository : FirestoreRepository("accounts") {
    */
   suspend fun blockUser(accountId: String, otherId: String) {
     db.runTransaction { tx ->
-          val aRef = relationships(accountId).document(otherId)
-          val bRef = relationships(otherId).document(accountId)
+          val accountRef = relationships(accountId).document(otherId)
+          val otherRef = relationships(otherId).document(accountId)
 
-          val bSnap = tx[bRef]
+          val bSnap = tx[otherRef]
           val bStatus = bSnap.getString("status")
 
-          tx[aRef] = mapOf(FIELD_STATUS to RelationshipStatus.BLOCKED)
+          tx[accountRef] = mapOf(FIELD_STATUS to RelationshipStatus.BLOCKED)
 
           if (bStatus != RelationshipStatus.BLOCKED.name) {
-            tx.delete(bRef)
+            tx.delete(otherRef)
           }
         }
         .await()
@@ -298,16 +298,16 @@ class AccountRepository : FirestoreRepository("accounts") {
   ) {
     val batch = db.batch()
 
-    val aRef = relationships(accountId).document(friendId)
-    val bRef = relationships(friendId).document(accountId)
+    val accountRef = relationships(accountId).document(friendId)
+    val otherRef = relationships(friendId).document(accountId)
 
     // Update or delete the first user's relationship document
-    if (accountStatus == null) batch.delete(aRef)
-    else batch[aRef] = mapOf(FIELD_STATUS to accountStatus)
+    if (accountStatus == null) batch.delete(accountRef)
+    else batch[accountRef] = mapOf(FIELD_STATUS to accountStatus)
 
     // Update or delete the second user's relationship document
-    if (friendStatus == null) batch.delete(bRef)
-    else batch[bRef] = mapOf(FIELD_STATUS to friendStatus)
+    if (friendStatus == null) batch.delete(otherRef)
+    else batch[otherRef] = mapOf(FIELD_STATUS to friendStatus)
 
     batch.commit().await()
   }

--- a/app/src/main/java/com/github/meeplemeet/model/account/AccountRepository.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/AccountRepository.kt
@@ -250,10 +250,7 @@ class AccountRepository : FirestoreRepository("accounts") {
    * @param otherId The ID of the account being unblocked
    */
   suspend fun unblockUser(accountId: String, otherId: String) {
-    relationships(accountId)
-        .document(otherId)
-        .set(mapOf(FIELD_STATUS to RelationshipStatus.Blocked))
-        .await()
+    relationships(accountId).document(otherId).delete().await()
   }
 
   /**

--- a/app/src/main/java/com/github/meeplemeet/model/account/AccountRepository.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/AccountRepository.kt
@@ -228,10 +228,10 @@ class AccountRepository : FirestoreRepository("accounts") {
           val aRef = relationships(accountId).document(otherId)
           val bRef = relationships(otherId).document(accountId)
 
-          val bSnap = tx.get(bRef)
+          val bSnap = tx[bRef]
           val bStatus = bSnap.getString("status")
 
-          tx.set(aRef, mapOf(FIELD_STATUS to RelationshipStatus.BLOCKED))
+          tx[aRef] = mapOf(FIELD_STATUS to RelationshipStatus.BLOCKED)
 
           if (bStatus != RelationshipStatus.BLOCKED.name) {
             tx.delete(bRef)

--- a/app/src/main/java/com/github/meeplemeet/model/account/ProfileScreenViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/ProfileScreenViewModel.kt
@@ -1,0 +1,148 @@
+package com.github.meeplemeet.model.account
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.github.meeplemeet.RepositoryProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+/**
+ * ViewModel for managing user profile interactions and friend system operations.
+ *
+ * This ViewModel provides methods for handling friend requests, accepting requests, blocking users,
+ * and resetting relationships. It includes validation logic to prevent invalid operations (e.g.,
+ * sending duplicate friend requests, accepting non-existent requests).
+ *
+ * @property repository The AccountRepository used for data operations. Defaults to the shared
+ *   instance from RepositoryProvider.
+ */
+class ProfileScreenViewModel(
+    private val repository: AccountRepository = RepositoryProvider.accounts
+) : ViewModel(), AccountViewModel {
+  override val scope: CoroutineScope
+    get() = this.viewModelScope
+
+  /**
+   * Checks if two accounts are the same user or if either has blocked the other.
+   *
+   * This helper method is used to prevent relationship operations between users who should not be
+   * able to interact (same user or blocked relationship).
+   *
+   * @param account The first account to check
+   * @param friend The second account to check
+   * @return True if the accounts are the same user, or if either has blocked the other
+   */
+  private fun sameOrBlocked(account: Account, friend: Account) =
+      account.uid == friend.uid ||
+          account.blocked.contains(friend.uid) ||
+          friend.blocked.contains(account.uid)
+
+  /**
+   * Sends a friend request from the current account to another user.
+   *
+   * This method validates that a friend request can be sent before initiating the operation. It
+   * prevents sending requests in the following cases:
+   * - The accounts are the same user
+   * - Either user has blocked the other
+   * - A friend request has already been sent (in either direction)
+   * - A friend request is already pending (from either side)
+   * - The users are already friends
+   *
+   * If validation passes, the request is sent asynchronously via the repository.
+   *
+   * @param account The account sending the friend request
+   * @param other The account receiving the friend request
+   */
+  fun sendFriendRequest(account: Account, other: Account) {
+    // Prevent duplicate or invalid friend request
+    if (sameOrBlocked(account, other) ||
+        account.sent.contains(other.uid) ||
+        account.pending.contains(other.uid) ||
+        account.friends.contains(other.uid) ||
+        other.sent.contains(account.uid) ||
+        other.pending.contains(account.uid) ||
+        other.friends.contains(other.uid))
+        return
+
+    viewModelScope.launch { repository.sendFriendRequest(account.uid, other.uid) }
+  }
+
+  /**
+   * Accepts a pending friend request, establishing a mutual friendship.
+   *
+   * This method validates that a friend request can be accepted before proceeding. It requires:
+   * - The current account has a pending request from the other user
+   * - The other user has a sent request to the current account
+   * - Neither user has blocked the other
+   * - The accounts are not the same user
+   * - The users are not already friends
+   * - There are no conflicting request states
+   *
+   * If validation passes, the friendship is established asynchronously via the repository.
+   *
+   * @param account The account accepting the friend request
+   * @param other The account whose friend request is being accepted
+   */
+  fun acceptFriendRequest(account: Account, other: Account) {
+    if (sameOrBlocked(account, other) ||
+        !account.pending.contains(other.uid) ||
+        !other.sent.contains(account.uid) ||
+        account.sent.contains(other.uid) ||
+        other.pending.contains(account.uid) ||
+        account.friends.contains(other.uid) ||
+        other.friends.contains(account.uid))
+        return
+
+    viewModelScope.launch { repository.acceptFriendRequest(account.uid, other.uid) }
+  }
+
+  /**
+   * Blocks another user, preventing all future interactions.
+   *
+   * This method validates that the block operation is valid before proceeding. It prevents blocking
+   * in the following cases:
+   * - The accounts are the same user
+   * - The other user is already blocked
+   *
+   * The method handles the case where both users have blocked each other by checking if the other
+   * user has already blocked the current account and passing this information to the repository to
+   * preserve the other user's block status.
+   *
+   * If validation passes, the block is executed asynchronously via the repository.
+   *
+   * @param account The account performing the block action
+   * @param other The account being blocked
+   */
+  fun blockUser(account: Account, other: Account) {
+    if (account.uid == other.uid || account.blocked.contains(other.uid)) return
+
+    viewModelScope.launch {
+      repository.blockUser(account.uid, other.uid, other.blocked.contains(account.uid))
+    }
+  }
+
+  /**
+   * Resets the relationship between two users, removing all connection data.
+   *
+   * This method can be used for multiple purposes:
+   * - Unblocking a user
+   * - Canceling a sent friend request
+   * - Denying a received friend request
+   * - Removing an existing friend
+   *
+   * It validates that the operation is valid before proceeding. It prevents resetting relationships
+   * in the following cases:
+   * - The accounts are the same user
+   * - Either user has blocked the other (use blockUser to unblock instead)
+   *
+   * If validation passes, the relationship is reset asynchronously via the repository.
+   *
+   * @param account The first account in the relationship
+   * @param friend The second account in the relationship
+   */
+  fun resetRelationship(account: Account, friend: Account) {
+    if (sameOrBlocked(account, friend)) return
+
+    viewModelScope.launch { repository.resetRelationship(account.uid, friend.uid) }
+  }
+}

--- a/app/src/main/java/com/github/meeplemeet/model/account/ProfileScreenViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/ProfileScreenViewModel.kt
@@ -36,8 +36,8 @@ class ProfileScreenViewModel(
    */
   private fun sameOrBlocked(account: Account, other: Account) =
       account.uid == other.uid ||
-          account.relationships[other.uid] == RelationshipStatus.Blocked ||
-          other.relationships[account.uid] == RelationshipStatus.Blocked
+          account.relationships[other.uid] == RelationshipStatus.BLOCKED ||
+          other.relationships[account.uid] == RelationshipStatus.BLOCKED
 
   /**
    * Sends a friend request from the current account to another user.
@@ -88,8 +88,8 @@ class ProfileScreenViewModel(
     val b = other.relationships[account.uid]
 
     if (sameOrBlocked(account, other) ||
-        a != RelationshipStatus.Pending ||
-        b != RelationshipStatus.Sent)
+        a != RelationshipStatus.PENDING ||
+        b != RelationshipStatus.SENT)
         return
 
     viewModelScope.launch { repository.acceptFriendRequest(account.uid, other.uid) }
@@ -113,7 +113,7 @@ class ProfileScreenViewModel(
    * @param other The account being blocked
    */
   fun blockUser(account: Account, other: Account) {
-    if (account.uid == other.uid || account.relationships[other.uid] == RelationshipStatus.Blocked)
+    if (account.uid == other.uid || account.relationships[other.uid] == RelationshipStatus.BLOCKED)
         return
 
     viewModelScope.launch { repository.blockUser(account.uid, other.uid) }
@@ -190,7 +190,7 @@ class ProfileScreenViewModel(
    * @param other The account being unblocked
    */
   fun unblockUser(account: Account, other: Account) {
-    if (account.uid == other.uid || account.relationships[other.uid] != RelationshipStatus.Blocked)
+    if (account.uid == other.uid || account.relationships[other.uid] != RelationshipStatus.BLOCKED)
         return
 
     viewModelScope.launch { repository.unblockUser(account.uid, other.uid) }

--- a/app/src/main/java/com/github/meeplemeet/model/account/ProfileScreenViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/ProfileScreenViewModel.kt
@@ -120,7 +120,7 @@ class ProfileScreenViewModel(
   }
 
   /**
-   * Cancels a sent friend request from the current account to another user.
+   * Cancels or deny's a sent friend request from the current account to another user.
    *
    * This method validates that the operation is valid before proceeding. It prevents canceling in
    * the following cases:
@@ -132,26 +132,7 @@ class ProfileScreenViewModel(
    * @param account The account canceling the sent friend request
    * @param other The account to whom the friend request was sent
    */
-  fun cancelFriendRequest(account: Account, other: Account) {
-    if (sameOrBlocked(account, other)) return
-
-    viewModelScope.launch { repository.resetRelationship(account.uid, other.uid) }
-  }
-
-  /**
-   * Denies a received friend request from another user.
-   *
-   * This method validates that the operation is valid before proceeding. It prevents denying in the
-   * following cases:
-   * - The accounts are the same user
-   * - Either user has blocked the other
-   *
-   * If validation passes, the relationship is reset asynchronously via the repository.
-   *
-   * @param account The account denying the received friend request
-   * @param other The account who sent the friend request
-   */
-  fun denyFriendRequest(account: Account, other: Account) {
+  fun rejectFriendRequest(account: Account, other: Account) {
     if (sameOrBlocked(account, other)) return
 
     viewModelScope.launch { repository.resetRelationship(account.uid, other.uid) }

--- a/app/src/main/java/com/github/meeplemeet/model/account/ProfileScreenViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/ProfileScreenViewModel.kt
@@ -1,5 +1,7 @@
 package com.github.meeplemeet.model.account
 
+// Claude Code generated the documentation
+
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.github.meeplemeet.RepositoryProvider

--- a/app/src/main/java/com/github/meeplemeet/model/account/ProfileScreenViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/ProfileScreenViewModel.kt
@@ -84,12 +84,12 @@ class ProfileScreenViewModel(
    * @param other The account whose friend request is being accepted
    */
   fun acceptFriendRequest(account: Account, other: Account) {
-    val a = account.relationships[other.uid]
-    val b = other.relationships[account.uid]
+    val accountRels = account.relationships[other.uid]
+    val otherRels = other.relationships[account.uid]
 
     if (sameOrBlocked(account, other) ||
-        a != RelationshipStatus.PENDING ||
-        b != RelationshipStatus.SENT)
+        accountRels != RelationshipStatus.PENDING ||
+        otherRels != RelationshipStatus.SENT)
         return
 
     viewModelScope.launch { repository.acceptFriendRequest(account.uid, other.uid) }

--- a/app/src/main/java/com/github/meeplemeet/model/account/ProfileScreenViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/ProfileScreenViewModel.kt
@@ -113,8 +113,8 @@ class ProfileScreenViewModel(
    * @param other The account being blocked
    */
   fun blockUser(account: Account, other: Account) {
-    val a = account.relationships[other.uid]
-    if (account.uid == other.uid || (a != null && a == RelationshipStatus.Blocked)) return
+    if (account.uid == other.uid || account.relationships[other.uid] == RelationshipStatus.Blocked)
+        return
 
     viewModelScope.launch { repository.blockUser(account.uid, other.uid) }
   }


### PR DESCRIPTION
 ## Summary
  - Add relationship management system supporting friend requests, friendships, and blocking
  - Implement bidirectional relationship tracking with `RelationshipStatus` enum (Friend, Sent, Pending, Blocked)
  - Create `ProfileScreenViewModel` with validation logic to prevent invalid operations
  - Add comprehensive integration tests (678 lines) covering all relationship workflows

  ## Changes
  - **Account.kt**: Add `relationships` map and helper methods (`isFriendsWith()`, `hasBlocked()`, etc.)
  - **AccountRepository.kt**: Add `sendFriendRequest()`, `acceptFriendRequest()`, `blockUser()`, `resetRelationship()` with atomic Firestore updates
  - **ProfileScreenViewModel.kt**: Implement validation layer preventing invalid operations (duplicate requests, self-operations, wrong-direction accepts)
  - **RelationshipsTests.kt**: Integration tests verifying bidirectional consistency, state transitions, complex workflows, and edge cases

  🤖 Generated with [Claude Code](https://claude.com/claude-code)