### PR TITLE
Map Clustering & Cluster Preview

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/integration/MapViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/MapViewModelTest.kt
@@ -75,7 +75,7 @@ class MapViewModelTest : FirestoreTests() {
 
     assertEquals(MapUIState(), state)
     assertTrue(state.allGeoPins.isEmpty())
-    assertTrue(state.geoPins.isEmpty())
+    assertTrue(viewModel.getFilteredPins().isEmpty())
     assertEquals(PinType.entries.toSet(), state.activeFilters)
     assertNull(state.errorMsg)
     assertNull(state.selectedMarkerPreview)
@@ -96,9 +96,9 @@ class MapViewModelTest : FirestoreTests() {
 
     val state = viewModel.uiState.value
     assertTrue(state.allGeoPins.isNotEmpty())
-    assertTrue(state.geoPins.isNotEmpty())
+    assertTrue(viewModel.getFilteredPins().isNotEmpty())
 
-    val shopPin = state.geoPins.find { it.geoPin.uid == shop.id }
+    val shopPin = viewModel.getFilteredPins().find { it.geoPin.uid == shop.id }
     assertNotNull(shopPin)
     assertEquals(PinType.SHOP, shopPin!!.geoPin.type)
 
@@ -121,7 +121,7 @@ class MapViewModelTest : FirestoreTests() {
     val state = viewModel.uiState.value
     assertTrue(state.allGeoPins.isNotEmpty())
 
-    val spacePin = state.geoPins.find { it.geoPin.uid == spaceRenter.id }
+    val spacePin = viewModel.getFilteredPins().find { it.geoPin.uid == spaceRenter.id }
     assertNotNull(spacePin)
     assertEquals(PinType.SPACE, spacePin!!.geoPin.type)
 
@@ -165,8 +165,8 @@ class MapViewModelTest : FirestoreTests() {
     viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
     delay(100)
 
-    var state = viewModel.uiState.value
-    val sessionPin = state.geoPins.find { it.geoPin.uid == discussion.uid } // note: discussion.uid
+    val sessionPin =
+        viewModel.getFilteredPins().find { it.geoPin.uid == discussion.uid } // note: discussion.uid
     assertNotNull(sessionPin)
     assertEquals(PinType.SESSION, sessionPin!!.geoPin.type)
 
@@ -177,8 +177,7 @@ class MapViewModelTest : FirestoreTests() {
     viewModel2.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount2.uid)
     delay(100)
 
-    state = viewModel2.uiState.value
-    val sessionPin2 = state.geoPins.find { it.geoPin.uid == discussion.uid }
+    val sessionPin2 = viewModel.getFilteredPins().find { it.geoPin.uid == discussion.uid }
     assertNull(sessionPin2)
 
     // cleanup
@@ -233,9 +232,9 @@ class MapViewModelTest : FirestoreTests() {
     val state = viewModel.uiState.value
     assertTrue(state.allGeoPins.size >= 3)
 
-    val shopPin = state.geoPins.find { it.geoPin.type == PinType.SHOP }
-    val spacePin = state.geoPins.find { it.geoPin.type == PinType.SPACE }
-    val sessionPin = state.geoPins.find { it.geoPin.type == PinType.SESSION }
+    val shopPin = viewModel.getFilteredPins().find { it.geoPin.type == PinType.SHOP }
+    val spacePin = viewModel.getFilteredPins().find { it.geoPin.type == PinType.SPACE }
+    val sessionPin = viewModel.getFilteredPins().find { it.geoPin.type == PinType.SESSION }
 
     assertNotNull(shopPin)
     assertNotNull(spacePin)
@@ -260,8 +259,7 @@ class MapViewModelTest : FirestoreTests() {
     viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
     delay(100)
 
-    val state = viewModel.uiState.value
-    val farPin = state.geoPins.find { it.geoPin.uid == farShop.id }
+    val farPin = viewModel.getFilteredPins().find { it.geoPin.uid == farShop.id }
     assertNull(farPin)
 
     shopRepository.deleteShop(farShop.id)
@@ -286,7 +284,7 @@ class MapViewModelTest : FirestoreTests() {
 
     state = viewModel.uiState.value
     assertTrue(state.allGeoPins.isEmpty())
-    assertTrue(state.geoPins.isEmpty())
+    assertTrue(viewModel.getFilteredPins().isEmpty())
 
     shopRepository.deleteShop(shop.id)
   }
@@ -313,29 +311,28 @@ class MapViewModelTest : FirestoreTests() {
 
     var state = viewModel.uiState.value
     assertTrue(state.allGeoPins.size >= 2)
-    assertTrue(state.geoPins.size >= 2)
+    assertTrue(viewModel.getFilteredPins().size >= 2)
 
     viewModel.updateFilters(setOf(PinType.SHOP))
     delay(100)
 
     state = viewModel.uiState.value
     assertTrue(state.allGeoPins.size >= 2)
-    assertTrue(state.geoPins.all { it.geoPin.type == PinType.SHOP })
-    assertTrue(state.geoPins.none { it.geoPin.type == PinType.SPACE })
+    assertTrue(viewModel.getFilteredPins().all { it.geoPin.type == PinType.SHOP })
+    assertTrue(viewModel.getFilteredPins().none { it.geoPin.type == PinType.SPACE })
 
     viewModel.updateFilters(setOf(PinType.SPACE))
     delay(100)
 
     state = viewModel.uiState.value
     assertTrue(state.allGeoPins.size >= 2)
-    assertTrue(state.geoPins.all { it.geoPin.type == PinType.SPACE })
-    assertTrue(state.geoPins.none { it.geoPin.type == PinType.SHOP })
+    assertTrue(viewModel.getFilteredPins().all { it.geoPin.type == PinType.SPACE })
+    assertTrue(viewModel.getFilteredPins().none { it.geoPin.type == PinType.SHOP })
 
     viewModel.updateFilters(setOf(PinType.SHOP, PinType.SPACE))
     delay(100)
 
-    state = viewModel.uiState.value
-    assertTrue(state.geoPins.size >= 2)
+    assertTrue(viewModel.getFilteredPins().size >= 2)
 
     shopRepository.deleteShop(shop.id)
     spaceRenterRepository.deleteSpaceRenter(spaceRenter.id)
@@ -355,14 +352,14 @@ class MapViewModelTest : FirestoreTests() {
 
     var state = viewModel.uiState.value
     assertTrue(state.allGeoPins.isNotEmpty())
-    assertTrue(state.geoPins.isNotEmpty())
+    assertTrue(viewModel.getFilteredPins().isNotEmpty())
 
     viewModel.updateFilters(emptySet())
     delay(100)
 
     state = viewModel.uiState.value
     assertTrue(state.allGeoPins.isNotEmpty())
-    assertTrue(state.geoPins.isEmpty())
+    assertTrue(viewModel.getFilteredPins().isEmpty())
 
     shopRepository.deleteShop(shop.id)
   }
@@ -379,8 +376,7 @@ class MapViewModelTest : FirestoreTests() {
     viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
     delay(100)
 
-    val state = viewModel.uiState.value
-    val shopPin = state.geoPins.find { it.geoPin.uid == shop.id }
+    val shopPin = viewModel.getFilteredPins().find { it.geoPin.uid == shop.id }
     assertNotNull(shopPin)
 
     viewModel.selectPin(shopPin!!)
@@ -407,8 +403,7 @@ class MapViewModelTest : FirestoreTests() {
     viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
     delay(100)
 
-    val state = viewModel.uiState.value
-    val spacePin = state.geoPins.find { it.geoPin.uid == spaceRenter.id }
+    val spacePin = viewModel.getFilteredPins().find { it.geoPin.uid == spaceRenter.id }
     assertNotNull(spacePin)
 
     viewModel.selectPin(spacePin!!)
@@ -456,8 +451,7 @@ class MapViewModelTest : FirestoreTests() {
     viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
     delay(100)
 
-    val state = viewModel.uiState.value
-    val sessionPin = state.geoPins.find { it.geoPin.uid == discussion.uid }
+    val sessionPin = viewModel.getFilteredPins().find { it.geoPin.uid == discussion.uid }
 
     assertNotNull(sessionPin)
 
@@ -485,8 +479,7 @@ class MapViewModelTest : FirestoreTests() {
     viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
     delay(100)
 
-    val state = viewModel.uiState.value
-    val shopPin = state.geoPins.find { it.geoPin.uid == shop.id }
+    val shopPin = viewModel.getFilteredPins().find { it.geoPin.uid == shop.id }
     assertNotNull(shopPin)
 
     viewModel.selectPin(shopPin!!)
@@ -792,7 +785,7 @@ class MapViewModelTest : FirestoreTests() {
 
     val filteredState = viewModel.uiState.value
     assertEquals(initialAllCount, filteredState.allGeoPins.size)
-    assertTrue(filteredState.geoPins.size < initialAllCount)
+    assertTrue(viewModel.getFilteredPins().size < initialAllCount)
 
     shopRepository.deleteShop(shop.id)
     spaceRenterRepository.deleteSpaceRenter(spaceRenter.id)

--- a/app/src/androidTest/java/com/github/meeplemeet/integration/MapViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/MapViewModelTest.kt
@@ -5,6 +5,10 @@ import com.github.meeplemeet.model.account.Account
 import com.github.meeplemeet.model.map.MapUIState
 import com.github.meeplemeet.model.map.MapViewModel
 import com.github.meeplemeet.model.map.PinType
+import com.github.meeplemeet.model.map.cluster.Cluster
+import com.github.meeplemeet.model.map.cluster.ClusterItem
+import com.github.meeplemeet.model.map.cluster.ClusterManager
+import com.github.meeplemeet.model.map.cluster.ClusterStrategy
 import com.github.meeplemeet.model.shared.game.GAMES_COLLECTION_PATH
 import com.github.meeplemeet.model.shared.game.GameNoUid
 import com.github.meeplemeet.model.shared.location.Location
@@ -14,6 +18,7 @@ import com.github.meeplemeet.model.space_renter.Space
 import com.github.meeplemeet.utils.FirestoreTests
 import com.google.firebase.Timestamp
 import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertNotNull
 import junit.framework.TestCase.assertNull
 import junit.framework.TestCase.assertTrue
@@ -24,18 +29,17 @@ import org.junit.Before
 import org.junit.Test
 
 /**
- * Comprehensive integration test suite for MapViewModel using real Firestore repositories.
+ * Comprehensive integration test suite for MapViewModel with clustering support.
  *
  * Tests cover:
- * - Geo query lifecycle with real pins
- * - UI-side type filtering
- * - Session participant filtering
- * - Pin selection and preview loading
- * - Query parameter updates
+ * - Geo query lifecycle with debounced updates
+ * - Clustering with cache invalidation
+ * - Cluster selection and preview loading
+ * - Filter updates and cache behavior
+ * - Zoom level changes
  * - Error handling
  */
 class MapViewModelTest : FirestoreTests() {
-  private lateinit var viewModel: MapViewModel
   private lateinit var testAccount1: Account
   private lateinit var testAccount2: Account
   private lateinit var testLocation: Location
@@ -43,10 +47,32 @@ class MapViewModelTest : FirestoreTests() {
   private lateinit var testLocationFar: Location
   private lateinit var testOpeningHours: List<OpeningHours>
 
+  // Test cluster strategies
+  private val singleClusterStrategy =
+      object : ClusterStrategy {
+        override fun clusterize(
+            items: List<ClusterItem>,
+            zoomLevel: Float
+        ): List<Cluster<ClusterItem>> {
+          if (items.isEmpty()) return emptyList()
+          val centerLat = items.map { it.lat }.average()
+          val centerLng = items.map { it.lng }.average()
+          return listOf(Cluster(centerLat, centerLng, items))
+        }
+      }
+
+  private val noClusterStrategy =
+      object : ClusterStrategy {
+        override fun clusterize(
+            items: List<ClusterItem>,
+            zoomLevel: Float
+        ): List<Cluster<ClusterItem>> {
+          return items.map { Cluster(it.lat, it.lng, listOf(it)) }
+        }
+      }
+
   @Before
   fun setup() {
-    viewModel = MapViewModel()
-
     runBlocking {
       testAccount1 =
           accountRepository.createAccount("user1", "User One", "user1@test.com", photoUrl = null)
@@ -69,21 +95,41 @@ class MapViewModelTest : FirestoreTests() {
             OpeningHours(day = 7, hours = listOf(TimeSlot("10:00", "17:00"))))
   }
 
+  // ============================================================================
+  // BASIC STATE & INITIALIZATION TESTS
+  // ============================================================================
+
   @Test
   fun initialState_isEmpty() {
+    val viewModel = MapViewModel(clusterManager = ClusterManager(singleClusterStrategy))
     val state = viewModel.uiState.value
 
     assertEquals(MapUIState(), state)
     assertTrue(state.allGeoPins.isEmpty())
-    assertTrue(viewModel.getFilteredPins().isEmpty())
     assertEquals(PinType.entries.toSet(), state.activeFilters)
     assertNull(state.errorMsg)
     assertNull(state.selectedMarkerPreview)
     assertNull(state.selectedGeoPin)
+    assertNull(state.selectedClusterPreviews)
+    assertNull(state.clusterCache)
+    assertEquals(0, state.cacheVersion)
   }
 
   @Test
+  fun initialClusters_isEmpty() {
+    val viewModel = MapViewModel(clusterManager = ClusterManager(singleClusterStrategy))
+    val clusters = viewModel.getClusters()
+
+    assertTrue(clusters.isEmpty())
+  }
+
+  // ============================================================================
+  // GEO QUERY LIFECYCLE TESTS
+  // ============================================================================
+
+  @Test
   fun startGeoQuery_loadsShopPins() = runBlocking {
+    val viewModel = MapViewModel(clusterManager = ClusterManager(singleClusterStrategy))
     val shop =
         shopRepository.createShop(
             owner = testAccount1,
@@ -92,13 +138,12 @@ class MapViewModelTest : FirestoreTests() {
             openingHours = testOpeningHours)
 
     viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
-    delay(100)
+    delay(700)
 
     val state = viewModel.uiState.value
     assertTrue(state.allGeoPins.isNotEmpty())
-    assertTrue(viewModel.getFilteredPins().isNotEmpty())
 
-    val shopPin = viewModel.getFilteredPins().find { it.geoPin.uid == shop.id }
+    val shopPin = state.allGeoPins.find { it.geoPin.uid == shop.id }
     assertNotNull(shopPin)
     assertEquals(PinType.SHOP, shopPin!!.geoPin.type)
 
@@ -106,31 +151,9 @@ class MapViewModelTest : FirestoreTests() {
   }
 
   @Test
-  fun startGeoQuery_loadsSpacePins() = runBlocking {
-    val spaceRenter =
-        spaceRenterRepository.createSpaceRenter(
-            owner = testAccount1,
-            name = "Test Game Space",
-            address = testLocation,
-            openingHours = testOpeningHours,
-            spaces = listOf(Space(seats = 10, costPerHour = 25.0)))
-
-    viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
-    delay(100)
-
-    val state = viewModel.uiState.value
-    assertTrue(state.allGeoPins.isNotEmpty())
-
-    val spacePin = viewModel.getFilteredPins().find { it.geoPin.uid == spaceRenter.id }
-    assertNotNull(spacePin)
-    assertEquals(PinType.SPACE, spacePin!!.geoPin.type)
-
-    spaceRenterRepository.deleteSpaceRenter(spaceRenter.id)
-  }
-
-  @Test
   fun startGeoQuery_loadsSessionPinsOnlyForParticipant() = runBlocking {
-    // create a game entry
+    val viewModel = MapViewModel(clusterManager = ClusterManager(singleClusterStrategy))
+
     db.collection(GAMES_COLLECTION_PATH)
         .document("test_game_chess_mv")
         .set(
@@ -146,13 +169,10 @@ class MapViewModelTest : FirestoreTests() {
         .await()
 
     val testGame = gameRepository.getGameById("test_game_chess_mv")
-
-    // create discussion then create session linked to it
     val discussion =
         discussionRepository.createDiscussion(
             "Chess Night Discussion", "Test discussion for chess session", testAccount1.uid)
 
-    // create session via discussion (sessionRepository.createSession(discussionId,...))
     sessionRepository.createSession(
         discussion.uid,
         "Chess Night",
@@ -161,112 +181,29 @@ class MapViewModelTest : FirestoreTests() {
         testLocation,
         testAccount1.uid)
 
-    // User1 is creator / participant -> should see the session pin (search by discussion.uid)
     viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
-    delay(100)
+    delay(700)
 
-    val sessionPin =
-        viewModel.getFilteredPins().find { it.geoPin.uid == discussion.uid } // note: discussion.uid
+    val sessionPin = viewModel.uiState.value.allGeoPins.find { it.geoPin.uid == discussion.uid }
     assertNotNull(sessionPin)
     assertEquals(PinType.SESSION, sessionPin!!.geoPin.type)
 
     viewModel.stopGeoQuery()
 
-    // User2 (not participant) should not see the session pin
-    val viewModel2 = MapViewModel()
+    val viewModel2 = MapViewModel(clusterManager = ClusterManager(singleClusterStrategy))
     viewModel2.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount2.uid)
-    delay(100)
+    delay(700)
 
-    val sessionPin2 = viewModel.getFilteredPins().find { it.geoPin.uid == discussion.uid }
+    val sessionPin2 = viewModel2.uiState.value.allGeoPins.find { it.geoPin.uid == discussion.uid }
     assertNull(sessionPin2)
 
-    // cleanup
     val context = InstrumentationRegistry.getInstrumentation().targetContext
     discussionRepository.deleteDiscussion(context, discussion)
-  }
-
-  @Test
-  fun startGeoQuery_loadsMultiplePinTypes() = runBlocking {
-    // create game + discussion+session
-    db.collection(GAMES_COLLECTION_PATH)
-        .document("test_game_catan_mv")
-        .set(
-            GameNoUid(
-                name = "Catan",
-                description = "Trading and building board game",
-                imageURL = "https://example.com/catan.jpg",
-                minPlayers = 3,
-                maxPlayers = 4,
-                recommendedPlayers = null,
-                averagePlayTime = null,
-                genres = emptyList()))
-        .await()
-
-    val testGame = gameRepository.getGameById("test_game_catan_mv")
-
-    val discussion =
-        discussionRepository.createDiscussion(
-            "Catan Night Discussion", "Discussion for Catan session test", testAccount1.uid)
-
-    sessionRepository.createSession(
-        discussion.uid, "Game Night", testGame.uid, Timestamp.now(), testLocation, testAccount1.uid)
-
-    val shop =
-        shopRepository.createShop(
-            owner = testAccount1,
-            name = "Shop",
-            address = testLocation,
-            openingHours = testOpeningHours)
-
-    val spaceRenter =
-        spaceRenterRepository.createSpaceRenter(
-            owner = testAccount1,
-            name = "Space",
-            address = testLocation,
-            openingHours = testOpeningHours,
-            spaces = listOf(Space(seats = 10, costPerHour = 25.0)))
-
-    viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
-    delay(100)
-
-    val state = viewModel.uiState.value
-    assertTrue(state.allGeoPins.size >= 3)
-
-    val shopPin = viewModel.getFilteredPins().find { it.geoPin.type == PinType.SHOP }
-    val spacePin = viewModel.getFilteredPins().find { it.geoPin.type == PinType.SPACE }
-    val sessionPin = viewModel.getFilteredPins().find { it.geoPin.type == PinType.SESSION }
-
-    assertNotNull(shopPin)
-    assertNotNull(spacePin)
-    assertNotNull(sessionPin)
-
-    shopRepository.deleteShop(shop.id)
-    spaceRenterRepository.deleteSpaceRenter(spaceRenter.id)
-    // cleanup discussion which contains the session link
-    val context = InstrumentationRegistry.getInstrumentation().targetContext
-    discussionRepository.deleteDiscussion(context, discussion)
-  }
-
-  @Test
-  fun startGeoQuery_doesNotLoadPinsOutsideRadius() = runBlocking {
-    val farShop =
-        shopRepository.createShop(
-            owner = testAccount1,
-            name = "Far Shop",
-            address = testLocationFar,
-            openingHours = testOpeningHours)
-
-    viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
-    delay(100)
-
-    val farPin = viewModel.getFilteredPins().find { it.geoPin.uid == farShop.id }
-    assertNull(farPin)
-
-    shopRepository.deleteShop(farShop.id)
   }
 
   @Test
   fun stopGeoQuery_clearsAllPins() = runBlocking {
+    val viewModel = MapViewModel(clusterManager = ClusterManager(singleClusterStrategy))
     val shop =
         shopRepository.createShop(
             owner = testAccount1,
@@ -275,22 +212,115 @@ class MapViewModelTest : FirestoreTests() {
             openingHours = testOpeningHours)
 
     viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
-    delay(100)
+    delay(700)
 
-    var state = viewModel.uiState.value
-    assertTrue(state.allGeoPins.isNotEmpty())
+    assertTrue(viewModel.uiState.value.allGeoPins.isNotEmpty())
 
     viewModel.stopGeoQuery()
 
-    state = viewModel.uiState.value
+    val state = viewModel.uiState.value
     assertTrue(state.allGeoPins.isEmpty())
-    assertTrue(viewModel.getFilteredPins().isEmpty())
+    assertNull(state.clusterCache)
 
     shopRepository.deleteShop(shop.id)
   }
 
+  // ============================================================================
+  // DEBOUNCING TESTS
+  // ============================================================================
+
   @Test
-  fun updateFilters_filtersGeoPinsProperty() = runBlocking {
+  fun geoQuery_debouncesBatchUpdates() = runBlocking {
+    val viewModel = MapViewModel(clusterManager = ClusterManager(singleClusterStrategy))
+
+    viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
+
+    val shops = mutableListOf<String>()
+    repeat(5) { i ->
+      val shop =
+          shopRepository.createShop(
+              owner = testAccount1,
+              name = "Shop $i",
+              address = testLocation,
+              openingHours = testOpeningHours)
+      shops.add(shop.id)
+    }
+
+    delay(700)
+    val stateAfterDebounce = viewModel.uiState.value
+    assertTrue(stateAfterDebounce.allGeoPins.size >= 5)
+
+    shops.forEach { shopRepository.deleteShop(it) }
+  }
+
+  // ============================================================================
+  // CLUSTERING TESTS
+  // ============================================================================
+
+  @Test
+  fun getClusters_withSingleClusterStrategy_returnsOneCluster() = runBlocking {
+    val viewModel = MapViewModel(clusterManager = ClusterManager(singleClusterStrategy))
+
+    val shop1 =
+        shopRepository.createShop(
+            owner = testAccount1,
+            name = "Shop 1",
+            address = testLocation,
+            openingHours = testOpeningHours)
+
+    val shop2 =
+        shopRepository.createShop(
+            owner = testAccount1,
+            name = "Shop 2",
+            address = testLocationNearby,
+            openingHours = testOpeningHours)
+
+    viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
+    delay(700)
+
+    val clusters = viewModel.getClusters()
+
+    assertEquals(1, clusters.size)
+    assertTrue(clusters[0].items.size >= 2)
+
+    shopRepository.deleteShop(shop1.id)
+    shopRepository.deleteShop(shop2.id)
+  }
+
+  @Test
+  fun getClusters_withNoClusterStrategy_returnsIndividualClusters() = runBlocking {
+    val viewModel = MapViewModel(clusterManager = ClusterManager(noClusterStrategy))
+
+    val shop1 =
+        shopRepository.createShop(
+            owner = testAccount1,
+            name = "Shop 1",
+            address = testLocation,
+            openingHours = testOpeningHours)
+
+    val shop2 =
+        shopRepository.createShop(
+            owner = testAccount1,
+            name = "Shop 2",
+            address = testLocationNearby,
+            openingHours = testOpeningHours)
+
+    viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
+    delay(700)
+
+    val clusters = viewModel.getClusters()
+
+    assertTrue(clusters.size >= 2)
+    assertTrue(clusters.all { it.items.size == 1 })
+
+    shopRepository.deleteShop(shop1.id)
+    shopRepository.deleteShop(shop2.id)
+  }
+
+  @Test
+  fun getClusters_cacheIsValid_returnsCachedResult() = runBlocking {
+    val viewModel = MapViewModel(clusterManager = ClusterManager(singleClusterStrategy))
+
     val shop =
         shopRepository.createShop(
             owner = testAccount1,
@@ -298,48 +328,151 @@ class MapViewModelTest : FirestoreTests() {
             address = testLocation,
             openingHours = testOpeningHours)
 
-    val spaceRenter =
+    viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
+    delay(700)
+
+    val clusters1 = viewModel.getClusters()
+    val state1 = viewModel.uiState.value
+    assertNotNull(state1.clusterCache)
+
+    val cacheVersion = state1.cacheVersion
+
+    val clusters2 = viewModel.getClusters()
+    val state2 = viewModel.uiState.value
+
+    assertEquals(cacheVersion, state2.clusterCache!!.version)
+    assertEquals(clusters1, clusters2)
+
+    shopRepository.deleteShop(shop.id)
+  }
+
+  @Test
+  fun getClusters_afterFilterChange_invalidatesCache() = runBlocking {
+    val viewModel = MapViewModel(clusterManager = ClusterManager(singleClusterStrategy))
+
+    val shop =
+        shopRepository.createShop(
+            owner = testAccount1,
+            name = "Shop",
+            address = testLocation,
+            openingHours = testOpeningHours)
+
+    viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
+    delay(700)
+
+    viewModel.getClusters()
+    val version1 = viewModel.uiState.value.cacheVersion
+
+    viewModel.updateFilters(setOf(PinType.SHOP))
+
+    val version2 = viewModel.uiState.value.cacheVersion
+    assertTrue(version2 > version1)
+
+    viewModel.getClusters()
+    val cache2 = viewModel.uiState.value.clusterCache
+    assertNotNull(cache2)
+    assertEquals(version2, cache2!!.version)
+
+    shopRepository.deleteShop(shop.id)
+  }
+
+  @Test
+  fun getClusters_afterZoomChange_invalidatesCache() = runBlocking {
+    val viewModel = MapViewModel(clusterManager = ClusterManager(singleClusterStrategy))
+
+    val shop =
+        shopRepository.createShop(
+            owner = testAccount1,
+            name = "Shop",
+            address = testLocation,
+            openingHours = testOpeningHours)
+
+    viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
+    delay(700)
+
+    viewModel.getClusters()
+    val version1 = viewModel.uiState.value.cacheVersion
+
+    viewModel.updateZoomLevel(16f)
+
+    val version2 = viewModel.uiState.value.cacheVersion
+    assertTrue(version2 > version1)
+
+    shopRepository.deleteShop(shop.id)
+  }
+
+  @Test
+  fun getClusters_afterPinAdded_invalidatesCache() = runBlocking {
+    val viewModel = MapViewModel(clusterManager = ClusterManager(singleClusterStrategy))
+
+    val shop1 =
+        shopRepository.createShop(
+            owner = testAccount1,
+            name = "Shop 1",
+            address = testLocation,
+            openingHours = testOpeningHours)
+
+    viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
+    delay(700)
+
+    viewModel.getClusters()
+    val version1 = viewModel.uiState.value.cacheVersion
+
+    val shop2 =
+        shopRepository.createShop(
+            owner = testAccount1,
+            name = "Shop 2",
+            address = testLocationNearby,
+            openingHours = testOpeningHours)
+
+    delay(700)
+
+    val version2 = viewModel.uiState.value.cacheVersion
+    assertTrue(version2 > version1)
+
+    shopRepository.deleteShop(shop1.id)
+    shopRepository.deleteShop(shop2.id)
+  }
+
+  // ============================================================================
+  // FILTER TESTS
+  // ============================================================================
+
+  @Test
+  fun updateFilters_filtersCorrectly() = runBlocking {
+    val viewModel = MapViewModel(clusterManager = ClusterManager(noClusterStrategy))
+
+    val shop =
+        shopRepository.createShop(
+            owner = testAccount1,
+            name = "Shop",
+            address = testLocation,
+            openingHours = testOpeningHours)
+
+    val space =
         spaceRenterRepository.createSpaceRenter(
             owner = testAccount1,
             name = "Space",
-            address = testLocation,
+            address = testLocationNearby,
             openingHours = testOpeningHours,
             spaces = listOf(Space(seats = 10, costPerHour = 25.0)))
 
     viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
-    delay(100)
-
-    var state = viewModel.uiState.value
-    assertTrue(state.allGeoPins.size >= 2)
-    assertTrue(viewModel.getFilteredPins().size >= 2)
+    delay(700)
 
     viewModel.updateFilters(setOf(PinType.SHOP))
-    delay(100)
+    val clusters = viewModel.getClusters()
 
-    state = viewModel.uiState.value
-    assertTrue(state.allGeoPins.size >= 2)
-    assertTrue(viewModel.getFilteredPins().all { it.geoPin.type == PinType.SHOP })
-    assertTrue(viewModel.getFilteredPins().none { it.geoPin.type == PinType.SPACE })
-
-    viewModel.updateFilters(setOf(PinType.SPACE))
-    delay(100)
-
-    state = viewModel.uiState.value
-    assertTrue(state.allGeoPins.size >= 2)
-    assertTrue(viewModel.getFilteredPins().all { it.geoPin.type == PinType.SPACE })
-    assertTrue(viewModel.getFilteredPins().none { it.geoPin.type == PinType.SHOP })
-
-    viewModel.updateFilters(setOf(PinType.SHOP, PinType.SPACE))
-    delay(100)
-
-    assertTrue(viewModel.getFilteredPins().size >= 2)
+    assertTrue(clusters.all { cluster -> cluster.items.all { it.geoPin.type == PinType.SHOP } })
 
     shopRepository.deleteShop(shop.id)
-    spaceRenterRepository.deleteSpaceRenter(spaceRenter.id)
+    spaceRenterRepository.deleteSpaceRenter(space.id)
   }
 
   @Test
-  fun updateFilters_withEmptySet_hidesAllPins() = runBlocking {
+  fun updateFilters_withEmptySet_yieldsEmptyClusters() = runBlocking {
+    val viewModel = MapViewModel(clusterManager = ClusterManager(singleClusterStrategy))
+
     val shop =
         shopRepository.createShop(
             owner = testAccount1,
@@ -348,24 +481,26 @@ class MapViewModelTest : FirestoreTests() {
             openingHours = testOpeningHours)
 
     viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
-    delay(100)
+    delay(700)
 
-    var state = viewModel.uiState.value
-    assertTrue(state.allGeoPins.isNotEmpty())
-    assertTrue(viewModel.getFilteredPins().isNotEmpty())
+    assertTrue(viewModel.getClusters().isNotEmpty())
 
     viewModel.updateFilters(emptySet())
-    delay(100)
 
-    state = viewModel.uiState.value
-    assertTrue(state.allGeoPins.isNotEmpty())
-    assertTrue(viewModel.getFilteredPins().isEmpty())
+    val clusters = viewModel.getClusters()
+    assertTrue(clusters.isEmpty())
 
     shopRepository.deleteShop(shop.id)
   }
 
+  // ============================================================================
+  // SINGLE PIN SELECTION TESTS
+  // ============================================================================
+
   @Test
   fun selectPin_loadsShopPreview() = runBlocking {
+    val viewModel = MapViewModel(clusterManager = ClusterManager(singleClusterStrategy))
+
     val shop =
         shopRepository.createShop(
             owner = testAccount1,
@@ -374,101 +509,27 @@ class MapViewModelTest : FirestoreTests() {
             openingHours = testOpeningHours)
 
     viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
-    delay(100)
+    delay(700)
 
-    val shopPin = viewModel.getFilteredPins().find { it.geoPin.uid == shop.id }
+    val shopPin = viewModel.uiState.value.allGeoPins.find { it.geoPin.uid == shop.id }
     assertNotNull(shopPin)
 
     viewModel.selectPin(shopPin!!)
     delay(1000)
 
-    val updatedState = viewModel.uiState.value
-    assertNotNull(updatedState.selectedMarkerPreview)
-    assertNotNull(updatedState.selectedGeoPin)
-    assertEquals(shop.id, updatedState.selectedGeoPin!!.uid)
+    val state = viewModel.uiState.value
+    assertNotNull(state.selectedMarkerPreview)
+    assertNotNull(state.selectedGeoPin)
+    assertEquals(shop.id, state.selectedGeoPin!!.uid)
+    assertFalse(state.isLoadingPreview)
 
     shopRepository.deleteShop(shop.id)
-  }
-
-  @Test
-  fun selectPin_loadsSpacePreview() = runBlocking {
-    val spaceRenter =
-        spaceRenterRepository.createSpaceRenter(
-            owner = testAccount1,
-            name = "Game Hall",
-            address = testLocation,
-            openingHours = testOpeningHours,
-            spaces = listOf(Space(seats = 10, costPerHour = 25.0)))
-
-    viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
-    delay(100)
-
-    val spacePin = viewModel.getFilteredPins().find { it.geoPin.uid == spaceRenter.id }
-    assertNotNull(spacePin)
-
-    viewModel.selectPin(spacePin!!)
-    delay(1000)
-
-    val updatedState = viewModel.uiState.value
-    assertNotNull(updatedState.selectedMarkerPreview)
-    assertEquals(spaceRenter.id, updatedState.selectedGeoPin!!.uid)
-
-    spaceRenterRepository.deleteSpaceRenter(spaceRenter.id)
-  }
-
-  @Test
-  fun selectPin_loadsSessionPreview() = runBlocking {
-    // create game entry
-    db.collection(GAMES_COLLECTION_PATH)
-        .document("test_game_chess_select")
-        .set(
-            GameNoUid(
-                name = "Chess",
-                description = "Strategy board game",
-                imageURL = "https://example.com/chess.jpg",
-                minPlayers = 2,
-                maxPlayers = 2,
-                recommendedPlayers = null,
-                averagePlayTime = null,
-                genres = emptyList()))
-        .await()
-
-    val testGame = gameRepository.getGameById("test_game_chess_select")
-
-    // create discussion then session via discussion
-    val discussion =
-        discussionRepository.createDiscussion(
-            "Chess Tournament Discussion", "Test discussion for tournament", testAccount1.uid)
-
-    sessionRepository.createSession(
-        discussion.uid,
-        "Chess Tournament",
-        testGame.uid,
-        Timestamp.now(),
-        testLocation,
-        testAccount1.uid)
-
-    viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
-    delay(100)
-
-    val sessionPin = viewModel.getFilteredPins().find { it.geoPin.uid == discussion.uid }
-
-    assertNotNull(sessionPin)
-
-    viewModel.selectPin(sessionPin!!)
-    delay(1000)
-
-    val updatedState = viewModel.uiState.value
-    assertNotNull(updatedState.selectedMarkerPreview)
-    assertEquals(discussion.uid, updatedState.selectedGeoPin!!.uid)
-
-    // cleanup
-    val context = InstrumentationRegistry.getInstrumentation().targetContext
-    discussionRepository.deleteDiscussion(context, discussion)
   }
 
   @Test
   fun clearSelectedPin_removesSelection() = runBlocking {
+    val viewModel = MapViewModel(clusterManager = ClusterManager(singleClusterStrategy))
+
     val shop =
         shopRepository.createShop(
             owner = testAccount1,
@@ -477,101 +538,308 @@ class MapViewModelTest : FirestoreTests() {
             openingHours = testOpeningHours)
 
     viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
-    delay(100)
+    delay(700)
 
-    val shopPin = viewModel.getFilteredPins().find { it.geoPin.uid == shop.id }
-    assertNotNull(shopPin)
-
+    val shopPin = viewModel.uiState.value.allGeoPins.find { it.geoPin.uid == shop.id }
     viewModel.selectPin(shopPin!!)
     delay(1000)
 
-    var updatedState = viewModel.uiState.value
-    assertNotNull(updatedState.selectedMarkerPreview)
+    assertNotNull(viewModel.uiState.value.selectedMarkerPreview)
 
     viewModel.clearSelectedPin()
 
-    updatedState = viewModel.uiState.value
-    assertNull(updatedState.selectedMarkerPreview)
-    assertNull(updatedState.selectedGeoPin)
+    val state = viewModel.uiState.value
+    assertNull(state.selectedMarkerPreview)
+    assertNull(state.selectedGeoPin)
+
+    shopRepository.deleteShop(shop.id)
+  }
+
+  // ============================================================================
+  // CLUSTER SELECTION TESTS
+  // ============================================================================
+
+  @Test
+  fun selectCluster_loadsAllPreviews() = runBlocking {
+    val viewModel = MapViewModel(clusterManager = ClusterManager(singleClusterStrategy))
+
+    val shop1 =
+        shopRepository.createShop(
+            owner = testAccount1,
+            name = "Shop 1",
+            address = testLocation,
+            openingHours = testOpeningHours)
+
+    val shop2 =
+        shopRepository.createShop(
+            owner = testAccount1,
+            name = "Shop 2",
+            address = testLocationNearby,
+            openingHours = testOpeningHours)
+
+    viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
+    delay(700)
+
+    val clusters = viewModel.getClusters()
+    assertTrue(clusters.isNotEmpty())
+
+    val cluster = clusters[0]
+    assertTrue(cluster.items.size >= 2)
+
+    viewModel.selectCluster(cluster)
+    delay(1500)
+
+    val state = viewModel.uiState.value
+    assertNotNull(state.selectedClusterPreviews)
+    assertTrue(state.selectedClusterPreviews!!.size >= 2)
+    assertFalse(state.isLoadingPreview)
+
+    shopRepository.deleteShop(shop1.id)
+    shopRepository.deleteShop(shop2.id)
+  }
+
+  @Test
+  fun selectPinFromCluster_transitionsToSingleSelection() = runBlocking {
+    val viewModel = MapViewModel(clusterManager = ClusterManager(singleClusterStrategy))
+
+    val shop1 =
+        shopRepository.createShop(
+            owner = testAccount1,
+            name = "Shop 1",
+            address = testLocation,
+            openingHours = testOpeningHours)
+
+    val shop2 =
+        shopRepository.createShop(
+            owner = testAccount1,
+            name = "Shop 2",
+            address = testLocationNearby,
+            openingHours = testOpeningHours)
+
+    viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
+    delay(700)
+
+    val cluster = viewModel.getClusters()[0]
+    viewModel.selectCluster(cluster)
+    delay(1500)
+
+    val clusterState = viewModel.uiState.value
+    assertNotNull(clusterState.selectedClusterPreviews)
+    assertTrue(clusterState.selectedClusterPreviews!!.isNotEmpty())
+
+    val (pin, preview) = clusterState.selectedClusterPreviews!![0]
+    viewModel.selectPinFromCluster(pin, preview)
+
+    val finalState = viewModel.uiState.value
+    assertNull(finalState.selectedClusterPreviews)
+    assertNotNull(finalState.selectedGeoPin)
+    assertNotNull(finalState.selectedMarkerPreview)
+    assertEquals(pin.geoPin.uid, finalState.selectedGeoPin!!.uid)
+
+    shopRepository.deleteShop(shop1.id)
+    shopRepository.deleteShop(shop2.id)
+  }
+
+  @Test
+  fun clearSelectedCluster_removesClusterSelection() = runBlocking {
+    val viewModel = MapViewModel(clusterManager = ClusterManager(singleClusterStrategy))
+
+    val shop1 =
+        shopRepository.createShop(
+            owner = testAccount1,
+            name = "Shop 1",
+            address = testLocation,
+            openingHours = testOpeningHours)
+
+    val shop2 =
+        shopRepository.createShop(
+            owner = testAccount1,
+            name = "Shop 2",
+            address = testLocationNearby,
+            openingHours = testOpeningHours)
+
+    viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
+    delay(700)
+
+    val cluster = viewModel.getClusters()[0]
+    viewModel.selectCluster(cluster)
+    delay(1500)
+
+    assertNotNull(viewModel.uiState.value.selectedClusterPreviews)
+
+    viewModel.clearSelectedCluster()
+
+    val state = viewModel.uiState.value
+    assertNull(state.selectedClusterPreviews)
+
+    shopRepository.deleteShop(shop1.id)
+    shopRepository.deleteShop(shop2.id)
+  }
+
+  // ============================================================================
+  // QUERY UPDATE TESTS
+  // ============================================================================
+
+  @Test
+  fun updateQueryCenter_triggersNewPinLoad() = runBlocking {
+    val viewModel = MapViewModel(clusterManager = ClusterManager(singleClusterStrategy))
+
+    val shop1 =
+        shopRepository.createShop(
+            owner = testAccount1,
+            name = "Shop Near EPFL",
+            address = testLocation,
+            openingHours = testOpeningHours)
+
+    val shop2 =
+        shopRepository.createShop(
+            owner = testAccount1,
+            name = "Shop in Geneva",
+            address = testLocationFar,
+            openingHours = testOpeningHours)
+
+    viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
+    delay(700)
+
+    val pin1 = viewModel.uiState.value.allGeoPins.find { it.geoPin.uid == shop1.id }
+    val pin2 = viewModel.uiState.value.allGeoPins.find { it.geoPin.uid == shop2.id }
+
+    assertNotNull(pin1)
+    assertNull(pin2)
+
+    viewModel.updateQueryCenter(testLocationFar)
+    delay(1000)
+
+    val pin1After = viewModel.uiState.value.allGeoPins.find { it.geoPin.uid == shop1.id }
+    val pin2After = viewModel.uiState.value.allGeoPins.find { it.geoPin.uid == shop2.id }
+
+    assertNull(pin1After)
+    assertNotNull(pin2After)
+
+    shopRepository.deleteShop(shop1.id)
+    shopRepository.deleteShop(shop2.id)
+  }
+
+  @Test
+  fun updateRadius_loadsAdditionalPins() = runBlocking {
+    val viewModel = MapViewModel(clusterManager = ClusterManager(singleClusterStrategy))
+
+    val shop =
+        shopRepository.createShop(
+            owner = testAccount1,
+            name = "Shop",
+            address = Location(46.00, 6.00, "Far away"),
+            openingHours = testOpeningHours)
+
+    // Start query with radius smaller than distance to shop
+    viewModel.startGeoQuery(
+        Location(45.00, 5.00, "Center"), radiusKm = 50.0, currentUserId = testAccount1.uid)
+    delay(700)
+
+    val pinBefore = viewModel.uiState.value.allGeoPins.find { it.geoPin.uid == shop.id }
+    assertNull(pinBefore)
+
+    // Increase radius to include shop
+    viewModel.updateRadius(200.0)
+    delay(1000)
+
+    val pinAfter = viewModel.uiState.value.allGeoPins.find { it.geoPin.uid == shop.id }
+    assertNotNull(pinAfter)
 
     shopRepository.deleteShop(shop.id)
   }
 
   @Test
-  fun updateQueryCenter_keepsQueryAlive() = runBlocking {
-    val shop =
+  fun updateRadius_reducingRadiusRemovesPins() = runBlocking {
+    val viewModel = MapViewModel(clusterManager = ClusterManager(singleClusterStrategy))
+
+    val shopNear =
         shopRepository.createShop(
             owner = testAccount1,
-            name = "Shop",
-            address = testLocation,
+            name = "Shop Near",
+            address = Location(45.01, 5.01, "Near center"),
             openingHours = testOpeningHours)
 
-    viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
-    delay(100)
+    val shopFar =
+        shopRepository.createShop(
+            owner = testAccount1,
+            name = "Shop Far",
+            address = Location(46.00, 6.00, "Far away"),
+            openingHours = testOpeningHours)
 
-    var state = viewModel.uiState.value
-    val initialCount = state.allGeoPins.size
-    assertTrue(initialCount > 0)
+    // Start query large enough to include both
+    viewModel.startGeoQuery(
+        Location(45.00, 5.00, "Center"), radiusKm = 200.0, currentUserId = testAccount1.uid)
+    delay(700)
 
-    viewModel.updateQueryCenter(testLocationNearby)
+    val nearBefore = viewModel.uiState.value.allGeoPins.find { it.geoPin.uid == shopNear.id }
+    val farBefore = viewModel.uiState.value.allGeoPins.find { it.geoPin.uid == shopFar.id }
+
+    assertNotNull(nearBefore)
+    assertNotNull(farBefore)
+
+    // Reduce radius to only include near shop
+    viewModel.updateRadius(50.0)
     delay(1000)
 
-    state = viewModel.uiState.value
-    assertTrue(state.allGeoPins.isNotEmpty())
+    val nearAfter = viewModel.uiState.value.allGeoPins.find { it.geoPin.uid == shopNear.id }
+    val farAfter = viewModel.uiState.value.allGeoPins.find { it.geoPin.uid == shopFar.id }
 
-    shopRepository.deleteShop(shop.id)
+    assertNotNull(nearAfter)
+    assertNull(farAfter)
+
+    shopRepository.deleteShop(shopNear.id)
+    shopRepository.deleteShop(shopFar.id)
   }
 
   @Test
-  fun updateRadius_keepsQueryAlive() = runBlocking {
-    val shop =
+  fun updateCenterAndRadius_updatesQueryCorrectly() = runBlocking {
+    val viewModel = MapViewModel(clusterManager = ClusterManager(singleClusterStrategy))
+
+    val shopEPFL =
         shopRepository.createShop(
             owner = testAccount1,
-            name = "Shop",
+            name = "Shop EPFL",
             address = testLocation,
             openingHours = testOpeningHours)
 
-    viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
-    delay(100)
-
-    var state = viewModel.uiState.value
-    assertTrue(state.allGeoPins.isNotEmpty())
-
-    viewModel.updateRadius(15.0)
-    delay(1000)
-
-    state = viewModel.uiState.value
-    assertTrue(state.allGeoPins.isNotEmpty())
-
-    shopRepository.deleteShop(shop.id)
-  }
-
-  @Test
-  fun updateCenterAndRadius_keepsQueryAlive() = runBlocking {
-    val shop =
+    val shopGeneva =
         shopRepository.createShop(
             owner = testAccount1,
-            name = "Shop",
-            address = testLocation,
+            name = "Shop Geneva",
+            address = testLocationFar,
             openingHours = testOpeningHours)
 
-    viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
-    delay(100)
+    viewModel.startGeoQuery(testLocation, radiusKm = 5.0, currentUserId = testAccount1.uid)
+    delay(700)
 
-    var state = viewModel.uiState.value
-    assertTrue(state.allGeoPins.isNotEmpty())
+    val epflBefore = viewModel.uiState.value.allGeoPins.find { it.geoPin.uid == shopEPFL.id }
+    val genevaBefore = viewModel.uiState.value.allGeoPins.find { it.geoPin.uid == shopGeneva.id }
 
-    viewModel.updateCenterAndRadius(testLocationNearby, 15.0)
+    assertNotNull(epflBefore)
+    assertNull(genevaBefore)
+
+    viewModel.updateCenterAndRadius(testLocationFar, 10.0)
     delay(1000)
 
-    state = viewModel.uiState.value
-    assertTrue(state.allGeoPins.isNotEmpty())
+    val epflAfter = viewModel.uiState.value.allGeoPins.find { it.geoPin.uid == shopEPFL.id }
+    val genevaAfter = viewModel.uiState.value.allGeoPins.find { it.geoPin.uid == shopGeneva.id }
 
-    shopRepository.deleteShop(shop.id)
+    assertNull(epflAfter)
+    assertNotNull(genevaAfter)
+
+    shopRepository.deleteShop(shopEPFL.id)
+    shopRepository.deleteShop(shopGeneva.id)
   }
+
+  // ============================================================================
+  // PIN MOVEMENT & DELETION TESTS
+  // ============================================================================
 
   @Test
   fun geoQuery_onKeyMoved_updatesLocation() = runBlocking {
+    val viewModel = MapViewModel(clusterManager = ClusterManager(singleClusterStrategy))
+
     val shop =
         shopRepository.createShop(
             owner = testAccount1,
@@ -580,54 +848,26 @@ class MapViewModelTest : FirestoreTests() {
             openingHours = testOpeningHours)
 
     viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
-    delay(100)
+    delay(700)
 
-    var state = viewModel.uiState.value
-    val initialPin = state.allGeoPins.find { it.geoPin.uid == shop.id }
+    val initialPin = viewModel.uiState.value.allGeoPins.find { it.geoPin.uid == shop.id }
     assertNotNull(initialPin)
     assertEquals(testLocation.latitude, initialPin!!.location.latitude, 0.0001)
-    assertEquals(testLocation.longitude, initialPin.location.longitude, 0.0001)
 
     shopRepository.updateShop(shop.id, address = testLocationNearby)
-    delay(100)
+    delay(700)
 
-    state = viewModel.uiState.value
-    val updatedPin = state.allGeoPins.find { it.geoPin.uid == shop.id }
+    val updatedPin = viewModel.uiState.value.allGeoPins.find { it.geoPin.uid == shop.id }
     assertNotNull(updatedPin)
     assertEquals(testLocationNearby.latitude, updatedPin!!.location.latitude, 0.0001)
-    assertEquals(testLocationNearby.longitude, updatedPin.location.longitude, 0.0001)
-
-    shopRepository.deleteShop(shop.id)
-  }
-
-  @Test
-  fun geoQuery_onKeyExited_removesPinWhenMovedOutOfRadius() = runBlocking {
-    val shop =
-        shopRepository.createShop(
-            owner = testAccount1,
-            name = "Exiting Shop",
-            address = testLocation,
-            openingHours = testOpeningHours)
-
-    viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
-    delay(100)
-
-    var state = viewModel.uiState.value
-    val initialPin = state.allGeoPins.find { it.geoPin.uid == shop.id }
-    assertNotNull(initialPin)
-
-    shopRepository.updateShop(shop.id, address = testLocationFar)
-    delay(100)
-
-    state = viewModel.uiState.value
-    val exitedPin = state.allGeoPins.find { it.geoPin.uid == shop.id }
-    assertNull(exitedPin)
 
     shopRepository.deleteShop(shop.id)
   }
 
   @Test
   fun geoQuery_onKeyExited_removesPinWhenDeleted() = runBlocking {
+    val viewModel = MapViewModel(clusterManager = ClusterManager(singleClusterStrategy))
+
     val shop =
         shopRepository.createShop(
             owner = testAccount1,
@@ -636,22 +876,24 @@ class MapViewModelTest : FirestoreTests() {
             openingHours = testOpeningHours)
 
     viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
-    delay(100)
+    delay(700)
 
-    var state = viewModel.uiState.value
-    val initialPin = state.allGeoPins.find { it.geoPin.uid == shop.id }
-    assertNotNull(initialPin)
+    assertNotNull(viewModel.uiState.value.allGeoPins.find { it.geoPin.uid == shop.id })
 
     shopRepository.deleteShop(shop.id)
-    delay(100)
+    delay(700)
 
-    state = viewModel.uiState.value
-    val deletedPin = state.allGeoPins.find { it.geoPin.uid == shop.id }
-    assertNull(deletedPin)
+    assertNull(viewModel.uiState.value.allGeoPins.find { it.geoPin.uid == shop.id })
   }
+
+  // ============================================================================
+  // ERROR HANDLING & LIFECYCLE TESTS
+  // ============================================================================
 
   @Test
   fun clearErrorMsg_removesError() {
+    val viewModel = MapViewModel(clusterManager = ClusterManager(singleClusterStrategy))
+
     viewModel.clearErrorMsg()
 
     val state = viewModel.uiState.value
@@ -659,35 +901,9 @@ class MapViewModelTest : FirestoreTests() {
   }
 
   @Test
-  fun multipleQueryCycles_workCorrectly() = runBlocking {
-    val shop =
-        shopRepository.createShop(
-            owner = testAccount1,
-            name = "Shop",
-            address = testLocation,
-            openingHours = testOpeningHours)
-
-    viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
-    delay(100)
-
-    var state = viewModel.uiState.value
-    assertTrue(state.allGeoPins.isNotEmpty())
-
-    viewModel.stopGeoQuery()
-    state = viewModel.uiState.value
-    assertTrue(state.allGeoPins.isEmpty())
-
-    viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
-    delay(100)
-
-    state = viewModel.uiState.value
-    assertTrue(state.allGeoPins.isNotEmpty())
-
-    shopRepository.deleteShop(shop.id)
-  }
-
-  @Test
   fun stopGeoQuery_canBeCalledMultipleTimes() {
+    val viewModel = MapViewModel(clusterManager = ClusterManager(singleClusterStrategy))
+
     viewModel.stopGeoQuery()
     viewModel.stopGeoQuery()
     viewModel.stopGeoQuery()
@@ -698,96 +914,13 @@ class MapViewModelTest : FirestoreTests() {
   }
 
   @Test
-  fun startGeoQuery_restartingQueryClearsPreviousState() = runBlocking {
-    val shop1 =
-        shopRepository.createShop(
-            owner = testAccount1,
-            name = "Shop 1",
-            address = testLocation,
-            openingHours = testOpeningHours)
+  fun updateZoomLevel_updatesStateCorrectly() {
+    val viewModel = MapViewModel(clusterManager = ClusterManager(singleClusterStrategy))
 
-    viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
-    delay(100)
+    assertEquals(14f, viewModel.uiState.value.currentZoomLevel)
 
-    var state = viewModel.uiState.value
-    assertTrue(state.allGeoPins.isNotEmpty())
+    viewModel.updateZoomLevel(16f)
 
-    val shop2 =
-        shopRepository.createShop(
-            owner = testAccount1,
-            name = "Shop 2",
-            address = testLocationFar,
-            openingHours = testOpeningHours)
-
-    viewModel.startGeoQuery(testLocationFar, radiusKm = 10.0, currentUserId = testAccount1.uid)
-    delay(100)
-
-    state = viewModel.uiState.value
-    val pin1 = state.allGeoPins.find { it.geoPin.uid == shop1.id }
-    val pin2 = state.allGeoPins.find { it.geoPin.uid == shop2.id }
-    assertNull(pin1)
-    assertNotNull(pin2)
-
-    shopRepository.deleteShop(shop1.id)
-    shopRepository.deleteShop(shop2.id)
-  }
-
-  @Test
-  fun geoQuery_dynamicallyLoadsNewPins() = runBlocking {
-    viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
-    delay(100)
-
-    var state = viewModel.uiState.value
-    val initialCount = state.allGeoPins.size
-
-    val newShop =
-        shopRepository.createShop(
-            owner = testAccount1,
-            name = "New Shop",
-            address = testLocation,
-            openingHours = testOpeningHours)
-
-    delay(100)
-
-    state = viewModel.uiState.value
-    assertTrue(state.allGeoPins.size > initialCount)
-    val newPin = state.allGeoPins.find { it.geoPin.uid == newShop.id }
-    assertNotNull(newPin)
-
-    shopRepository.deleteShop(newShop.id)
-  }
-
-  @Test
-  fun updateFilters_doesNotAffectAllGeoPins() = runBlocking {
-    val shop =
-        shopRepository.createShop(
-            owner = testAccount1,
-            name = "Shop",
-            address = testLocation,
-            openingHours = testOpeningHours)
-
-    val spaceRenter =
-        spaceRenterRepository.createSpaceRenter(
-            owner = testAccount1,
-            name = "Space",
-            address = testLocation,
-            openingHours = testOpeningHours,
-            spaces = listOf(Space(seats = 10, costPerHour = 25.0)))
-
-    viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
-    delay(100)
-
-    val initialState = viewModel.uiState.value
-    val initialAllCount = initialState.allGeoPins.size
-
-    viewModel.updateFilters(setOf(PinType.SHOP))
-    delay(100)
-
-    val filteredState = viewModel.uiState.value
-    assertEquals(initialAllCount, filteredState.allGeoPins.size)
-    assertTrue(viewModel.getFilteredPins().size < initialAllCount)
-
-    shopRepository.deleteShop(shop.id)
-    spaceRenterRepository.deleteSpaceRenter(spaceRenter.id)
+    assertEquals(16f, viewModel.uiState.value.currentZoomLevel)
   }
 }

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/MapScreenTest.kt
@@ -12,7 +12,6 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -21,6 +20,11 @@ import androidx.test.rule.GrantPermissionRule
 import com.github.meeplemeet.model.account.Account
 import com.github.meeplemeet.model.map.MapViewModel
 import com.github.meeplemeet.model.map.PinType
+import com.github.meeplemeet.model.map.cluster.Cluster
+import com.github.meeplemeet.model.map.cluster.ClusterItem
+import com.github.meeplemeet.model.map.cluster.ClusterManager
+import com.github.meeplemeet.model.map.cluster.ClusterStrategy
+import com.github.meeplemeet.model.map.cluster.DistanceBasedClusterStrategy
 import com.github.meeplemeet.model.shared.game.GAMES_COLLECTION_PATH
 import com.github.meeplemeet.model.shared.game.GameNoUid
 import com.github.meeplemeet.model.shared.location.Location
@@ -35,8 +39,10 @@ import com.google.android.gms.maps.MapsInitializer
 import com.google.android.gms.maps.OnMapsSdkInitializedCallback
 import com.google.firebase.Timestamp
 import io.mockk.mockk
+import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNotNull
 import junit.framework.TestCase.assertNull
+import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.tasks.await
@@ -48,15 +54,15 @@ import org.junit.runner.RunWith
 private const val DEFAULT_TEST_KM = 10.0
 
 /**
- * Comprehensive UI test suite for MapScreen with real Firestore data.
+ * Comprehensive UI test suite for MapScreen with clustering support.
  *
  * Tests cover:
- * - Map display and UI structure
- * - FAB visibility and interactions based on user roles
- * - Create dialog for users with multiple roles
- * - Filter functionality
- * - Bottom sheet previews with real data
- * - Integration with geo queries
+ * - Basic UI structure and FAB behavior
+ * - Clustering display and interactions
+ * - Single pin and cluster bottom sheets
+ * - Filter functionality with clustering
+ * - Zoom level effects on clustering
+ * - Session filtering by participant
  */
 @RunWith(AndroidJUnit4::class)
 class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
@@ -71,7 +77,6 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
 
   private fun checkpoint(name: String, block: () -> Unit) = ck.ck(name, block)
 
-  private lateinit var mapViewModel: MapViewModel
   private lateinit var mockNavigation: NavigationActions
 
   private lateinit var regularAccount: Account
@@ -88,6 +93,30 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
   private lateinit var currentAccountState: MutableState<Account>
   private var renderTrigger by mutableStateOf(0)
 
+  // Cluster strategies for testing
+  private val singleClusterStrategy =
+      object : ClusterStrategy {
+        override fun clusterize(
+            items: List<ClusterItem>,
+            zoomLevel: Float
+        ): List<Cluster<ClusterItem>> {
+          if (items.isEmpty()) return emptyList()
+          val centerLat = items.map { it.lat }.average()
+          val centerLng = items.map { it.lng }.average()
+          return listOf(Cluster(centerLat, centerLng, items))
+        }
+      }
+
+  private val noClusterStrategy =
+      object : ClusterStrategy {
+        override fun clusterize(
+            items: List<ClusterItem>,
+            zoomLevel: Float
+        ): List<Cluster<ClusterItem>> {
+          return items.map { Cluster(it.lat, it.lng, listOf(it)) }
+        }
+      }
+
   @Before
   fun setup() {
     try {
@@ -97,7 +126,6 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
           this)
     } catch (_: Exception) {}
 
-    mapViewModel = MapViewModel()
     mockNavigation = mockk(relaxed = true)
 
     testLocation = Location(latitude = 46.5197, longitude = 6.5665, name = "EPFL")
@@ -151,14 +179,20 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
 
   override fun onMapsSdkInitialized(renderer: MapsInitializer.Renderer) {}
 
+  /**
+   * Tests basic UI structure, FAB behavior, filters, and creation dialog. Uses no clustering
+   * strategy to test individual pins.
+   */
   @Test
-  fun all_tests() {
+  fun test_basicUI_FAB_and_filters() {
+    val viewModel = MapViewModel(clusterManager = ClusterManager(noClusterStrategy))
+
     composeRule.setContent {
       val trigger = renderTrigger
       AppTheme {
         key(trigger) {
           MapScreen(
-              viewModel = mapViewModel,
+              viewModel = viewModel,
               navigation = mockNavigation,
               account = currentAccountState.value,
               onFABCLick = { type ->
@@ -194,96 +228,43 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
       composeRule.onNodeWithTag(MapScreenTestTags.ADD_FAB).assertHasClickAction()
     }
 
-    checkpoint("fab_visibleForSpaceRenter") {
-      currentAccountState.value = spaceRenterAccount
-      composeRule.waitForIdle()
-
-      composeRule.onNodeWithTag(MapScreenTestTags.ADD_FAB).assertIsDisplayed()
-      composeRule.onNodeWithTag(MapScreenTestTags.ADD_FAB).assertHasClickAction()
-    }
-
-    checkpoint("fab_visibleForBothRoles") {
-      currentAccountState.value = bothRolesAccount
-      composeRule.waitForIdle()
-
-      composeRule.onNodeWithTag(MapScreenTestTags.ADD_FAB).assertIsDisplayed()
-    }
-
     checkpoint("fab_shopOwnerOnly_directlyCallsCallbackWithShopType") {
       currentAccountState.value = shopOwnerAccount
-      fabClickCount = 0 // Reset counter
+      fabClickCount = 0
       lastFabClickType = null
       composeRule.waitForIdle()
 
       composeRule.onNodeWithTag(MapScreenTestTags.ADD_FAB).performClick()
       composeRule.waitForIdle()
 
-      assert(fabClickCount == 1)
-      assert(lastFabClickType == PinType.SHOP)
+      assertEquals(1, fabClickCount)
+      assertEquals(PinType.SHOP, lastFabClickType)
       composeRule.onNodeWithTag(MapScreenTestTags.ADD_CHOOSE_DIALOG).assertDoesNotExist()
     }
 
     checkpoint("fab_spaceRenterOnly_directlyCallsCallbackWithSpaceType") {
       currentAccountState.value = spaceRenterAccount
-      fabClickCount = 0 // Reset counter
+      fabClickCount = 0
       lastFabClickType = null
       composeRule.waitForIdle()
 
       composeRule.onNodeWithTag(MapScreenTestTags.ADD_FAB).performClick()
       composeRule.waitForIdle()
 
-      assert(fabClickCount == 1)
-      assert(lastFabClickType == PinType.SPACE)
-      composeRule.onNodeWithTag(MapScreenTestTags.ADD_CHOOSE_DIALOG).assertDoesNotExist()
+      assertEquals(1, fabClickCount)
+      assertEquals(PinType.SPACE, lastFabClickType)
     }
 
     checkpoint("fab_bothRoles_showsDialogForSelection") {
       currentAccountState.value = bothRolesAccount
-      fabClickCount = 0 // Reset counter
+      fabClickCount = 0
       composeRule.waitForIdle()
 
       composeRule.onNodeWithTag(MapScreenTestTags.ADD_FAB).performClick()
       composeRule.waitForIdle()
 
       composeRule.onNodeWithTag(MapScreenTestTags.ADD_CHOOSE_DIALOG).assertIsDisplayed()
-      assert(fabClickCount == 0)
-    }
-
-    checkpoint("createDialog_canSelectShop") {
-      currentAccountState.value = bothRolesAccount
-      fabClickCount = 0 // Reset counter
-      composeRule.waitForIdle()
-
-      composeRule.onNodeWithTag(MapScreenTestTags.ADD_FAB).performClick()
-      composeRule.waitForIdle()
-
-      composeRule.onNodeWithTag(MapScreenTestTags.ADD_CHOOSE_DIALOG).assertIsDisplayed()
-
-      composeRule.waitForIdle()
-
-      assert(fabClickCount == 0)
-    }
-
-    checkpoint("createDialog_canSelectSpace") {
-      currentAccountState.value = bothRolesAccount
-      fabClickCount = 0 // Reset counter
-      composeRule.waitForIdle()
-
-      // Close any open dialog first
-      if (composeRule
-          .onAllNodesWithTag(MapScreenTestTags.ADD_CHOOSE_DIALOG)
-          .fetchSemanticsNodes()
-          .isNotEmpty()) {
-        composeRule.onNodeWithTag(MapScreenTestTags.GOOGLE_MAP_SCREEN).performClick()
-        composeRule.waitForIdle()
-      }
-
-      composeRule.onNodeWithTag(MapScreenTestTags.ADD_FAB).performClick()
-      composeRule.waitForIdle()
-
-      composeRule.onNodeWithTag(MapScreenTestTags.ADD_CHOOSE_DIALOG).assertIsDisplayed()
-
-      assert(fabClickCount == 0)
+      assertEquals(0, fabClickCount)
     }
 
     checkpoint("filterButton_opensAndClosesFilterPanel") {
@@ -312,173 +293,139 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
       composeRule.onNodeWithTag(MapScreenTestTags.FILTER_BUTTON).performClick()
       composeRule.waitForIdle()
 
-      composeRule.onNodeWithTag(MapScreenTestTags.FILTER_SHOP_CHIP).assertIsDisplayed()
       composeRule.onNodeWithTag(MapScreenTestTags.FILTER_SHOP_CHIP).performClick()
       composeRule.waitForIdle()
 
       composeRule.onNodeWithTag(MapScreenTestTags.FILTER_SPACE_CHIP).performClick()
       composeRule.waitForIdle()
-
-      composeRule.onNodeWithTag(MapScreenTestTags.FILTER_SESSIONS_CHIP).performClick()
-      composeRule.waitForIdle()
-
-      composeRule.onNodeWithTag(MapScreenTestTags.FILTER_SHOP_CHIP).performClick()
-      composeRule.waitForIdle()
     }
 
-    checkpoint("bottomSheet_displaysShopPreview") {
+    checkpoint("filterIntegration_hidesAndShowsPins") {
       runBlocking {
         val shop =
             shopRepository.createShop(
                 owner = shopOwnerAccount,
-                name = "Chess & Checkers Shop",
+                name = "Filter Test Shop",
+                address = testLocation,
+                openingHours = testOpeningHours)
+
+        val space =
+            spaceRenterRepository.createSpaceRenter(
+                owner = spaceRenterAccount,
+                name = "Filter Test Space",
+                address = testLocation,
+                openingHours = testOpeningHours,
+                spaces = listOf(Space(seats = 10, costPerHour = 25.0)))
+
+        refreshContent()
+
+        viewModel.startGeoQuery(
+            testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
+        delay(1500)
+
+        val initialClusters = viewModel.getClusters()
+        assertTrue(initialClusters.size >= 2)
+
+        composeRule.onNodeWithTag(MapScreenTestTags.FILTER_BUTTON).performClick()
+        composeRule.onNodeWithTag(MapScreenTestTags.FILTER_SHOP_CHIP).performClick()
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+          !viewModel.uiState.value.activeFilters.contains(PinType.SHOP)
+        }
+
+        val filteredClusters = viewModel.getClusters()
+        assertTrue(
+            filteredClusters.all { cluster ->
+              cluster.items.all { it.geoPin.type != PinType.SHOP }
+            })
+
+        shopRepository.deleteShop(shop.id)
+        spaceRenterRepository.deleteSpaceRenter(space.id)
+      }
+    }
+  }
+
+  /**
+   * Tests clustering display, single pin selection, and cluster interactions. Tests with both
+   * single cluster strategy and no cluster strategy.
+   */
+  @Test
+  fun test_clustering_and_singlePin_interactions() {
+    // First part: test with no clustering (individual pins)
+    val noClusterViewModel = MapViewModel(clusterManager = ClusterManager(noClusterStrategy))
+
+    composeRule.setContent {
+      val trigger = renderTrigger
+      AppTheme {
+        key(trigger) {
+          MapScreen(
+              viewModel = noClusterViewModel,
+              navigation = mockNavigation,
+              account = currentAccountState.value,
+              onFABCLick = { type ->
+                fabClickCount++
+                lastFabClickType = type
+              },
+              onRedirect = { pin -> lastRedirect = pin.uid })
+        }
+      }
+    }
+
+    checkpoint("singlePin_displaysMarkerPreviewSheet") {
+      runBlocking {
+        val shop =
+            shopRepository.createShop(
+                owner = shopOwnerAccount,
+                name = "Single Pin Shop",
                 address = testLocation,
                 openingHours = testOpeningHours)
 
         refreshContent()
 
-        mapViewModel.startGeoQuery(
+        noClusterViewModel.startGeoQuery(
             testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
-        delay(2000)
+        delay(1500)
 
-        val pin = mapViewModel.getFilteredPins().find { it.geoPin.uid == shop.id }
-        assertNotNull(pin)
+        val clusters = noClusterViewModel.getClusters()
+        val cluster = clusters.find { it.items.size == 1 && it.items[0].geoPin.uid == shop.id }
+        assertNotNull(cluster)
+        assertEquals(1, cluster!!.items.size)
 
-        mapViewModel.selectPin(pin!!)
+        // Click on the single pin
+        noClusterViewModel.selectPin(cluster.items[0])
         delay(1000)
 
         composeRule.onNodeWithTag(MapScreenTestTags.MARKER_PREVIEW_SHEET).assertIsDisplayed()
         composeRule.onNodeWithTag(MapScreenTestTags.PREVIEW_TITLE).assertTextContains(shop.name)
         composeRule
             .onNodeWithTag(MapScreenTestTags.PREVIEW_ADDRESS)
-            .assertTextContains(shop.address.name)
+            .assertTextContains(testLocation.name)
         composeRule.onNodeWithTag(MapScreenTestTags.PREVIEW_OPENING_HOURS).assertIsDisplayed()
         composeRule.onNodeWithTag(MapScreenTestTags.PREVIEW_CLOSE_BUTTON).assertHasClickAction()
-        composeRule.onNodeWithTag(MapScreenTestTags.PREVIEW_VIEW_DETAILS_BUTTON).assertIsDisplayed()
 
         shopRepository.deleteShop(shop.id)
       }
     }
 
-    checkpoint("bottomSheet_displaysSpacePreview") {
-      runBlocking {
-        val spaceRenter =
-            spaceRenterRepository.createSpaceRenter(
-                owner = spaceRenterAccount,
-                name = "Game Arena",
-                address = testLocation,
-                openingHours = testOpeningHours,
-                spaces = listOf(Space(seats = 20, costPerHour = 30.0)))
-
-        refreshContent()
-
-        mapViewModel.startGeoQuery(
-            testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
-        delay(2000)
-
-        val pin = mapViewModel.getFilteredPins().find { it.geoPin.uid == spaceRenter.id }
-        assertNotNull(pin)
-
-        mapViewModel.selectPin(pin!!)
-        delay(1000)
-
-        composeRule.onNodeWithTag(MapScreenTestTags.MARKER_PREVIEW_SHEET).assertIsDisplayed()
-        composeRule
-            .onNodeWithTag(MapScreenTestTags.PREVIEW_TITLE)
-            .assertTextContains(spaceRenter.name)
-        composeRule
-            .onNodeWithTag(MapScreenTestTags.PREVIEW_ADDRESS)
-            .assertTextContains(spaceRenter.address.name)
-        composeRule.onNodeWithTag(MapScreenTestTags.PREVIEW_OPENING_HOURS).assertIsDisplayed()
-
-        spaceRenterRepository.deleteSpaceRenter(spaceRenter.id)
-      }
-    }
-
-    checkpoint("bottomSheet_displaysSessionPreview") {
-      runBlocking {
-        // create game document
-        db.collection(GAMES_COLLECTION_PATH)
-            .document("test_game_map")
-            .set(
-                GameNoUid(
-                    name = "Catan",
-                    description = "Strategy board game",
-                    imageURL = "https://example.com/catan.jpg",
-                    minPlayers = 3,
-                    maxPlayers = 4,
-                    recommendedPlayers = null,
-                    averagePlayTime = null,
-                    genres = emptyList()))
-            .await()
-
-        val testGame = gameRepository.getGameById("test_game_map")
-
-        // create discussion then session linked to it
-        val discussion =
-            discussionRepository.createDiscussion(
-                "Friday Night Catan",
-                "Test discussion for bottom sheet preview",
-                regularAccount.uid)
-
-        sessionRepository.createSession(
-            discussion.uid,
-            "Friday Night Catan",
-            testGame.uid,
-            Timestamp.now(),
-            testLocation,
-            regularAccount.uid)
-
-        refreshContent()
-
-        mapViewModel.startGeoQuery(
-            testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
-        delay(2000)
-
-        val pin = mapViewModel.getFilteredPins().find { it.geoPin.uid == discussion.uid }
-        assertNotNull(pin)
-
-        mapViewModel.selectPin(pin!!)
-        delay(2000)
-
-        val newState = mapViewModel.uiState.value
-        assertNotNull(newState.selectedMarkerPreview)
-
-        composeRule.onNodeWithTag(MapScreenTestTags.MARKER_PREVIEW_SHEET).assertIsDisplayed()
-        composeRule
-            .onNodeWithTag(MapScreenTestTags.PREVIEW_TITLE)
-            .assertTextContains("Friday Night Catan")
-        composeRule
-            .onNodeWithTag(MapScreenTestTags.PREVIEW_GAME)
-            .assertTextContains("Catan", substring = true)
-        composeRule.onNodeWithTag(MapScreenTestTags.PREVIEW_ADDRESS).assertTextContains("EPFL")
-        composeRule.onNodeWithTag(MapScreenTestTags.PREVIEW_DATE).assertExists()
-
-        // cleanup via discussion delete (removes session index)
-        val context = InstrumentationRegistry.getInstrumentation().targetContext
-        discussionRepository.deleteDiscussion(context, discussion)
-      }
-    }
-
-    checkpoint("bottomSheet_closeButton_closesSheet") {
+    checkpoint("singlePin_closeButton_closesSheet") {
       runBlocking {
         val shop =
             shopRepository.createShop(
                 owner = shopOwnerAccount,
-                name = "Test Shop",
+                name = "Close Test Shop",
                 address = testLocation,
                 openingHours = testOpeningHours)
 
         refreshContent()
 
-        mapViewModel.startGeoQuery(
+        noClusterViewModel.startGeoQuery(
             testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
-        delay(2000)
+        delay(1500)
 
-        val pin = mapViewModel.getFilteredPins().find { it.geoPin.uid == shop.id }
-        assertNotNull(pin)
+        val clusters = noClusterViewModel.getClusters()
+        val cluster = clusters.find { it.items[0].geoPin.uid == shop.id }
+        assertNotNull(cluster)
 
-        mapViewModel.selectPin(pin!!)
+        noClusterViewModel.selectPin(cluster!!.items[0])
         delay(1000)
 
         composeRule.onNodeWithTag(MapScreenTestTags.MARKER_PREVIEW_SHEET).assertIsDisplayed()
@@ -491,225 +438,99 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
       }
     }
 
-    checkpoint("bottomSheet_viewDetailsButton_callsRedirect") {
+    checkpoint("singlePin_viewDetailsButton_callsRedirect") {
       runBlocking {
         val shop =
             shopRepository.createShop(
                 owner = shopOwnerAccount,
-                name = "Details Test Shop",
+                name = "Redirect Test Shop",
                 address = testLocation,
                 openingHours = testOpeningHours)
 
         refreshContent()
 
-        mapViewModel.startGeoQuery(
+        noClusterViewModel.startGeoQuery(
             testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
-        delay(2000)
+        delay(1500)
 
-        val pin = mapViewModel.getFilteredPins().find { it.geoPin.uid == shop.id }
-        assertNotNull(pin)
+        val clusters = noClusterViewModel.getClusters()
+        val cluster = clusters.find { it.items[0].geoPin.uid == shop.id }
+        assertNotNull(cluster)
 
-        mapViewModel.selectPin(pin!!)
+        noClusterViewModel.selectPin(cluster!!.items[0])
         delay(1000)
 
-        composeRule.onNodeWithTag(MapScreenTestTags.MARKER_PREVIEW_SHEET).assertIsDisplayed()
+        lastRedirect = null
         composeRule.onNodeWithTag(MapScreenTestTags.PREVIEW_VIEW_DETAILS_BUTTON).performClick()
         composeRule.waitForIdle()
 
-        assert(lastRedirect == shop.id)
+        assertEquals(shop.id, lastRedirect)
 
         shopRepository.deleteShop(shop.id)
       }
     }
 
-    checkpoint("completeUserFlow_shopOwner_createAndView") {
+    checkpoint("sessionPin_displaysCorrectPreview") {
       runBlocking {
-        val shop =
-            shopRepository.createShop(
-                owner = shopOwnerAccount,
-                name = "Complete Flow Shop",
-                address = testLocation,
-                openingHours = testOpeningHours)
+        db.collection(GAMES_COLLECTION_PATH)
+            .document("test_game_session_pin")
+            .set(
+                GameNoUid(
+                    name = "Catan",
+                    description = "Strategy board game",
+                    imageURL = "https://example.com/catan.jpg",
+                    minPlayers = 3,
+                    maxPlayers = 4,
+                    recommendedPlayers = null,
+                    averagePlayTime = null,
+                    genres = emptyList()))
+            .await()
 
-        refreshContent(shopOwnerAccount)
+        val testGame = gameRepository.getGameById("test_game_session_pin")
 
-        composeRule.onNodeWithTag(MapScreenTestTags.GOOGLE_MAP_SCREEN).assertIsDisplayed()
-        composeRule.onNodeWithTag(MapScreenTestTags.ADD_FAB).assertIsDisplayed()
+        val discussion =
+            discussionRepository.createDiscussion(
+                "Session Preview Test", "Test discussion", regularAccount.uid)
 
-        val initialCount = fabClickCount
-        composeRule.onNodeWithTag(MapScreenTestTags.ADD_FAB).performClick()
-        composeRule.waitForIdle()
-        assert(fabClickCount == initialCount + 1)
-        assert(lastFabClickType == PinType.SHOP)
+        sessionRepository.createSession(
+            discussion.uid,
+            "Session Preview Test",
+            testGame.uid,
+            Timestamp.now(),
+            testLocation,
+            regularAccount.uid)
 
-        mapViewModel.startGeoQuery(
-            testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = shopOwnerAccount.uid)
-        delay(2000)
+        refreshContent()
 
-        val pin = mapViewModel.getFilteredPins().find { it.geoPin.uid == shop.id }
-        assertNotNull(pin)
+        noClusterViewModel.startGeoQuery(
+            testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
+        delay(1500)
 
-        mapViewModel.selectPin(pin!!)
-        delay(1000)
+        val clusters = noClusterViewModel.getClusters()
+        val cluster = clusters.find { it.items[0].geoPin.uid == discussion.uid }
+        assertNotNull(cluster)
+
+        noClusterViewModel.selectPin(cluster!!.items[0])
+        delay(1500)
 
         composeRule.onNodeWithTag(MapScreenTestTags.MARKER_PREVIEW_SHEET).assertIsDisplayed()
         composeRule
-            .onNodeWithTag(MapScreenTestTags.PREVIEW_VIEW_DETAILS_BUTTON)
-            .assertHasClickAction()
+            .onNodeWithTag(MapScreenTestTags.PREVIEW_TITLE)
+            .assertTextContains("Session Preview Test")
+        composeRule
+            .onNodeWithTag(MapScreenTestTags.PREVIEW_GAME)
+            .assertTextContains("Catan", substring = true)
+        composeRule.onNodeWithTag(MapScreenTestTags.PREVIEW_DATE).assertExists()
 
-        mapViewModel.clearSelectedPin()
-        delay(500)
-
-        val clearedState = mapViewModel.uiState.value
-        assert(clearedState.selectedMarkerPreview == null)
-
-        shopRepository.deleteShop(shop.id)
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        discussionRepository.deleteDiscussion(context, discussion)
       }
     }
 
-    checkpoint("filterIntegration_hidesAndShowsPins") {
-      runBlocking {
-        val shop =
-            shopRepository.createShop(
-                owner = shopOwnerAccount,
-                name = "Shop",
-                address = testLocation,
-                openingHours = testOpeningHours)
-
-        val spaceRenter =
-            spaceRenterRepository.createSpaceRenter(
-                owner = spaceRenterAccount,
-                name = "Space",
-                address = testLocation,
-                openingHours = testOpeningHours,
-                spaces = listOf(Space(seats = 10, costPerHour = 25.0)))
-
-        refreshContent()
-
-        mapViewModel.startGeoQuery(
-            testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
-        delay(2000)
-
-        val initialCount = mapViewModel.getFilteredPins().size
-        assert(initialCount >= 2)
-
-        composeRule.onNodeWithTag(MapScreenTestTags.FILTER_BUTTON).performClick()
-        composeRule.onNodeWithTag(MapScreenTestTags.FILTER_SHOP_CHIP).performClick()
-        composeRule.waitUntil(timeoutMillis = 5_000) {
-          !mapViewModel.uiState.value.activeFilters.contains(PinType.SHOP)
-        }
-
-        assert(mapViewModel.getFilteredPins().size < initialCount)
-        assert(mapViewModel.getFilteredPins().none { it.geoPin.type == PinType.SHOP })
-
-        composeRule.onNodeWithTag(MapScreenTestTags.FILTER_SHOP_CHIP).performClick()
-        composeRule.waitUntil(timeoutMillis = 5_000) {
-          mapViewModel.uiState.value.activeFilters.contains(PinType.SHOP)
-        }
-
-        assert(mapViewModel.getFilteredPins().size == initialCount)
-
-        shopRepository.deleteShop(shop.id)
-        spaceRenterRepository.deleteSpaceRenter(spaceRenter.id)
-      }
-    }
-
-    checkpoint("filterIntegration_canHideAllPinTypes") {
-      runBlocking {
-        val shop =
-            shopRepository.createShop(
-                owner = shopOwnerAccount,
-                name = "Shop",
-                address = testLocation,
-                openingHours = testOpeningHours)
-
-        refreshContent()
-
-        mapViewModel.startGeoQuery(
-            testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
-        delay(2000)
-
-        val state = mapViewModel.uiState.value
-        assert(mapViewModel.getFilteredPins().isNotEmpty())
-        assert(state.allGeoPins.isNotEmpty())
-
-        composeRule.onNodeWithTag(MapScreenTestTags.FILTER_BUTTON).performClick()
-        composeRule.waitForIdle()
-
-        composeRule.onNodeWithTag(MapScreenTestTags.FILTER_SHOP_CHIP).performClick()
-        composeRule.onNodeWithTag(MapScreenTestTags.FILTER_SPACE_CHIP).performClick()
-        composeRule.onNodeWithTag(MapScreenTestTags.FILTER_SESSIONS_CHIP).performClick()
-        composeRule.waitUntil(timeoutMillis = 5_000) {
-          mapViewModel.uiState.value.activeFilters.isEmpty()
-        }
-
-        val filteredState = mapViewModel.uiState.value
-
-        assert(mapViewModel.getFilteredPins().isEmpty())
-        assert(filteredState.allGeoPins.isNotEmpty())
-
-        shopRepository.deleteShop(shop.id)
-      }
-    }
-
-    checkpoint("markers_areDisplayedOnMap") {
-      runBlocking {
-        val shop =
-            shopRepository.createShop(
-                owner = shopOwnerAccount,
-                name = "Marker Shop",
-                address = testLocation,
-                openingHours = testOpeningHours)
-
-        refreshContent()
-
-        mapViewModel.startGeoQuery(
-            testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
-        delay(2000)
-
-        val pin = mapViewModel.getFilteredPins().find { it.geoPin.uid == shop.id }
-        assertNotNull(pin)
-
-        // Marker do not expose tag to compose => fix later if possible, but assertNotNull is enough
-        // composeRule.onNodeWithTag(MapScreenTestTags.getTestTagForPin(shop.id)).assertExists()
-
-        shopRepository.deleteShop(shop.id)
-      }
-    }
-
-    checkpoint("multipleMarkers_allDisplayed") {
-      runBlocking {
-        val shop1 =
-            shopRepository.createShop(
-                owner = shopOwnerAccount,
-                name = "Shop 1",
-                address = testLocation,
-                openingHours = testOpeningHours)
-
-        val shop2 =
-            shopRepository.createShop(
-                owner = shopOwnerAccount,
-                name = "Shop 2",
-                address = testLocation,
-                openingHours = testOpeningHours)
-
-        refreshContent()
-
-        mapViewModel.startGeoQuery(
-            testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
-        delay(2000)
-
-        assert(mapViewModel.getFilteredPins().size >= 2)
-
-        shopRepository.deleteShop(shop1.id)
-        shopRepository.deleteShop(shop2.id)
-      }
-    }
-
-    checkpoint("sessionMarkers_onlyVisibleToParticipants") {
+    checkpoint("sessionPin_onlyVisibleToParticipants") {
       runBlocking {
         db.collection(GAMES_COLLECTION_PATH)
-            .document("test_game_private_session")
+            .document("test_game_private")
             .set(
                 GameNoUid(
                     name = "Chess",
@@ -722,11 +543,11 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
                     genres = emptyList()))
             .await()
 
-        val testGame = gameRepository.getGameById("test_game_private_session")
+        val testGame = gameRepository.getGameById("test_game_private")
 
         val discussion =
             discussionRepository.createDiscussion(
-                "Private Session Discussion", "Private session test", shopOwnerAccount.uid)
+                "Private Session", "Private test", shopOwnerAccount.uid)
 
         sessionRepository.createSession(
             discussion.uid,
@@ -738,71 +559,356 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
 
         refreshContent(regularAccount)
 
-        mapViewModel.startGeoQuery(
+        noClusterViewModel.startGeoQuery(
             testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
-        delay(2000)
+        delay(1500)
 
-        var sessionPin = mapViewModel.getFilteredPins().find { it.geoPin.uid == discussion.uid }
-        assertNull(sessionPin)
+        val clusters = noClusterViewModel.getClusters()
+        val sessionCluster = clusters.find { it.items[0].geoPin.uid == discussion.uid }
+        assertNull(sessionCluster)
 
-        mapViewModel.stopGeoQuery()
+        noClusterViewModel.stopGeoQuery()
 
-        val ownerViewModel = MapViewModel()
+        val ownerViewModel = MapViewModel(clusterManager = ClusterManager(noClusterStrategy))
         ownerViewModel.startGeoQuery(
             testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = shopOwnerAccount.uid)
-        delay(2000)
+        delay(1500)
 
-        sessionPin = mapViewModel.getFilteredPins().find { it.geoPin.uid == discussion.uid }
-        assertNotNull(sessionPin)
+        val ownerClusters = ownerViewModel.getClusters()
+        val ownerSessionCluster = ownerClusters.find { it.items[0].geoPin.uid == discussion.uid }
+        assertNotNull(ownerSessionCluster)
 
-        // cleanup
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         discussionRepository.deleteDiscussion(context, discussion)
       }
     }
+  }
 
-    checkpoint("loadingState_displaysWhileLoadingPreview") {
+  /**
+   * Tests cluster sheet display, cluster item selection, and zoom level effects. Uses single
+   * cluster strategy to force clustering.
+   */
+  @Test
+  fun test_clusterSheet_items_and_zoomEffects() {
+    val singleClusterViewModel =
+        MapViewModel(clusterManager = ClusterManager(singleClusterStrategy))
+
+    composeRule.setContent {
+      val trigger = renderTrigger
+      AppTheme {
+        key(trigger) {
+          MapScreen(
+              viewModel = singleClusterViewModel,
+              navigation = mockNavigation,
+              account = currentAccountState.value,
+              onFABCLick = { type ->
+                fabClickCount++
+                lastFabClickType = type
+              },
+              onRedirect = { pin -> lastRedirect = pin.uid })
+        }
+      }
+    }
+
+    checkpoint("cluster_displaysClusterSheet") {
       runBlocking {
-        val shop =
+        val shop1 =
             shopRepository.createShop(
                 owner = shopOwnerAccount,
-                name = "Loading Test Shop",
+                name = "Cluster Shop 1",
+                address = testLocation,
+                openingHours = testOpeningHours)
+
+        val shop2 =
+            shopRepository.createShop(
+                owner = shopOwnerAccount,
+                name = "Cluster Shop 2",
                 address = testLocation,
                 openingHours = testOpeningHours)
 
         refreshContent()
 
-        mapViewModel.startGeoQuery(
+        singleClusterViewModel.startGeoQuery(
             testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
-        delay(2000)
+        delay(1500)
 
-        val pin = mapViewModel.getFilteredPins().find { it.geoPin.uid == shop.id }
-        assertNotNull(pin)
+        val clusters = singleClusterViewModel.getClusters()
+        assertEquals(1, clusters.size)
+        assertTrue(clusters[0].items.size >= 2)
 
-        mapViewModel.selectPin(pin!!)
+        // Select the cluster
+        singleClusterViewModel.selectCluster(clusters[0])
+        delay(1500)
+
+        composeRule.onNodeWithTag(MapScreenTestTags.CLUSTER_SHEET).assertIsDisplayed()
+
+        // Verify cluster items are displayed
+        composeRule
+            .onNodeWithTag(MapScreenTestTags.getTestTagForClusterItem(shop1.id))
+            .assertIsDisplayed()
+        composeRule
+            .onNodeWithTag(MapScreenTestTags.getTestTagForClusterItem(shop2.id))
+            .assertIsDisplayed()
+
+        shopRepository.deleteShop(shop1.id)
+        shopRepository.deleteShop(shop2.id)
+      }
+    }
+
+    checkpoint("clusterSheet_loadingState_displayed") {
+      runBlocking {
+        val shop1 =
+            shopRepository.createShop(
+                owner = shopOwnerAccount,
+                name = "Loading Cluster Shop 1",
+                address = testLocation,
+                openingHours = testOpeningHours)
+
+        val shop2 =
+            shopRepository.createShop(
+                owner = shopOwnerAccount,
+                name = "Loading Cluster Shop 2",
+                address = testLocation,
+                openingHours = testOpeningHours)
+
+        refreshContent()
+
+        singleClusterViewModel.startGeoQuery(
+            testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
+        delay(1500)
+
+        val clusters = singleClusterViewModel.getClusters()
+        singleClusterViewModel.selectCluster(clusters[0])
 
         composeRule.waitForIdle()
         delay(100)
 
-        val loadingState = mapViewModel.uiState.value
-        assert(loadingState.isLoadingPreview || loadingState.selectedMarkerPreview != null)
+        val loadingState = singleClusterViewModel.uiState.value
+        assertTrue(loadingState.isLoadingPreview || loadingState.selectedClusterPreviews != null)
 
-        shopRepository.deleteShop(shop.id)
+        shopRepository.deleteShop(shop1.id)
+        shopRepository.deleteShop(shop2.id)
       }
     }
 
-    checkpoint("darkMode_appliesMapStyle") {
-      refreshContent()
-      composeRule.waitForIdle()
+    checkpoint("clusterItem_click_transitionsToSinglePinSheet") {
+      runBlocking {
+        val shop1 =
+            shopRepository.createShop(
+                owner = shopOwnerAccount,
+                name = "Item Click Shop 1",
+                address = testLocation,
+                openingHours = testOpeningHours)
 
-      composeRule.onNodeWithTag(MapScreenTestTags.GOOGLE_MAP_SCREEN).assertIsDisplayed()
+        val shop2 =
+            shopRepository.createShop(
+                owner = shopOwnerAccount,
+                name = "Item Click Shop 2",
+                address = testLocation,
+                openingHours = testOpeningHours)
+
+        refreshContent()
+
+        singleClusterViewModel.startGeoQuery(
+            testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
+        delay(1500)
+
+        val clusters = singleClusterViewModel.getClusters()
+        singleClusterViewModel.selectCluster(clusters[0])
+        delay(1500)
+
+        composeRule.onNodeWithTag(MapScreenTestTags.CLUSTER_SHEET).assertIsDisplayed()
+
+        // Click on first cluster item
+        composeRule
+            .onNodeWithTag(MapScreenTestTags.getTestTagForClusterItem(shop1.id))
+            .performClick()
+        delay(500)
+
+        // Should now show single pin preview sheet
+        composeRule.onNodeWithTag(MapScreenTestTags.CLUSTER_SHEET).assertDoesNotExist()
+        composeRule.onNodeWithTag(MapScreenTestTags.MARKER_PREVIEW_SHEET).assertIsDisplayed()
+        composeRule
+            .onNodeWithTag(MapScreenTestTags.PREVIEW_TITLE)
+            .assertTextContains("Item Click Shop 1")
+
+        shopRepository.deleteShop(shop1.id)
+        shopRepository.deleteShop(shop2.id)
+      }
     }
 
-    checkpoint("mapScreen_displaysBottomNavigation") {
-      refreshContent()
-      composeRule.waitForIdle()
+    checkpoint("clusterSheet_displaysMultipleTypes") {
+      runBlocking {
+        val shop =
+            shopRepository.createShop(
+                owner = shopOwnerAccount,
+                name = "Mixed Cluster Shop",
+                address = testLocation,
+                openingHours = testOpeningHours)
 
-      composeRule.onNodeWithTag(MapScreenTestTags.GOOGLE_MAP_SCREEN).assertIsDisplayed()
+        val space =
+            spaceRenterRepository.createSpaceRenter(
+                owner = spaceRenterAccount,
+                name = "Mixed Cluster Space",
+                address = testLocation,
+                openingHours = testOpeningHours,
+                spaces = listOf(Space(seats = 10, costPerHour = 25.0)))
+
+        refreshContent()
+
+        singleClusterViewModel.startGeoQuery(
+            testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
+        delay(1500)
+
+        val clusters = singleClusterViewModel.getClusters()
+        assertTrue(clusters[0].items.size >= 2)
+
+        singleClusterViewModel.selectCluster(clusters[0])
+        delay(1500)
+
+        composeRule.onNodeWithTag(MapScreenTestTags.CLUSTER_SHEET).assertIsDisplayed()
+        composeRule
+            .onNodeWithTag(MapScreenTestTags.getTestTagForClusterItem(shop.id))
+            .assertIsDisplayed()
+        composeRule
+            .onNodeWithTag(MapScreenTestTags.getTestTagForClusterItem(space.id))
+            .assertIsDisplayed()
+
+        shopRepository.deleteShop(shop.id)
+        spaceRenterRepository.deleteSpaceRenter(space.id)
+      }
+    }
+
+    checkpoint("multipleMarkers_displayedAsClusters") {
+      runBlocking {
+        val shops = mutableListOf<String>()
+        repeat(5) { i ->
+          val shop =
+              shopRepository.createShop(
+                  owner = shopOwnerAccount,
+                  name = "Multi Shop $i",
+                  address = testLocation,
+                  openingHours = testOpeningHours)
+          shops.add(shop.id)
+        }
+
+        refreshContent()
+
+        singleClusterViewModel.startGeoQuery(
+            testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
+        delay(1500)
+
+        val clusters = singleClusterViewModel.getClusters()
+        assertEquals(1, clusters.size)
+        assertTrue(clusters[0].items.size >= 5)
+
+        shops.forEach { shopRepository.deleteShop(it) }
+      }
+    }
+
+    checkpoint("filter_affectsClusterContents") {
+      runBlocking {
+        val shop =
+            shopRepository.createShop(
+                owner = shopOwnerAccount,
+                name = "Filter Cluster Shop",
+                address = testLocation,
+                openingHours = testOpeningHours)
+
+        val space =
+            spaceRenterRepository.createSpaceRenter(
+                owner = spaceRenterAccount,
+                name = "Filter Cluster Space",
+                address = testLocation,
+                openingHours = testOpeningHours,
+                spaces = listOf(Space(seats = 10, costPerHour = 25.0)))
+
+        refreshContent()
+
+        singleClusterViewModel.startGeoQuery(
+            testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
+        delay(1500)
+
+        val allTypeClusters = singleClusterViewModel.getClusters()
+        assertTrue(allTypeClusters[0].items.size >= 2)
+
+        // Filter to only shops
+        composeRule.onNodeWithTag(MapScreenTestTags.FILTER_BUTTON).performClick()
+        composeRule.onNodeWithTag(MapScreenTestTags.FILTER_SPACE_CHIP).performClick()
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+          !singleClusterViewModel.uiState.value.activeFilters.contains(PinType.SPACE)
+        }
+
+        val shopOnlyClusters = singleClusterViewModel.getClusters()
+        assertTrue(shopOnlyClusters[0].items.all { it.geoPin.type == PinType.SHOP })
+
+        shopRepository.deleteShop(shop.id)
+        spaceRenterRepository.deleteSpaceRenter(space.id)
+      }
+    }
+
+    checkpoint("zoomLevel_affectsClustering") {
+      runBlocking {
+        // Shops are spaced by ~500m around center
+        val shop1 =
+            shopRepository.createShop(
+                owner = shopOwnerAccount,
+                name = "Zoom Test Shop 1",
+                address = Location(testLocation.latitude + 0.0000, testLocation.longitude, "Z1"),
+                openingHours = testOpeningHours)
+
+        val shop2 =
+            shopRepository.createShop(
+                owner = shopOwnerAccount,
+                name = "Zoom Test Shop 2",
+                address = Location(testLocation.latitude + 0.0045, testLocation.longitude, "Z2"),
+                openingHours = testOpeningHours)
+
+        val shop3 =
+            shopRepository.createShop(
+                owner = shopOwnerAccount,
+                name = "Zoom Test Shop 3",
+                address = Location(testLocation.latitude, testLocation.longitude + 0.0045, "Z3"),
+                openingHours = testOpeningHours)
+
+        refreshContent()
+
+        // Use actual simplified viewmodel for distance-based clustering strategy
+        val mapViewModel =
+            MapViewModel(
+                clusterManager =
+                    ClusterManager(
+                        DistanceBasedClusterStrategy(
+                            baseThresholdKm = 1.0,
+                            zoomToThreshold = { zoom -> if (zoom <= 10f) 1.0 else 0.1 })))
+
+        mapViewModel.startGeoQuery(
+            testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
+        delay(1500)
+
+        val initialZoom = 8f // Threshold = 1.0 km
+        val newZoom = 14f // Threshold = 0.1 km
+
+        mapViewModel.updateZoomLevel(initialZoom)
+        delay(500)
+        val clustersAtInitialZoom = mapViewModel.getClusters()
+
+        // Change zoom level
+        mapViewModel.updateZoomLevel(newZoom)
+        delay(500)
+        val clustersAtNewZoom = mapViewModel.getClusters()
+
+        val state = mapViewModel.uiState.value
+        assertEquals(newZoom, state.currentZoomLevel)
+
+        // Test clustering granularity
+        assertEquals(1, clustersAtInitialZoom.size)
+        assertEquals(3, clustersAtNewZoom.size)
+
+        shopRepository.deleteShop(shop1.id)
+        shopRepository.deleteShop(shop2.id)
+        shopRepository.deleteShop(shop3.id)
+      }
     }
   }
 

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/MapScreenTest.kt
@@ -21,7 +21,6 @@ import com.github.meeplemeet.model.account.Account
 import com.github.meeplemeet.model.map.MapViewModel
 import com.github.meeplemeet.model.map.PinType
 import com.github.meeplemeet.model.map.cluster.Cluster
-import com.github.meeplemeet.model.map.cluster.ClusterItem
 import com.github.meeplemeet.model.map.cluster.ClusterManager
 import com.github.meeplemeet.model.map.cluster.ClusterStrategy
 import com.github.meeplemeet.model.map.cluster.DistanceBasedClusterStrategy
@@ -94,28 +93,18 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
   private var renderTrigger by mutableStateOf(0)
 
   // Cluster strategies for testing
-  private val singleClusterStrategy =
-      object : ClusterStrategy {
-        override fun clusterize(
-            items: List<ClusterItem>,
-            zoomLevel: Float
-        ): List<Cluster<ClusterItem>> {
-          if (items.isEmpty()) return emptyList()
-          val centerLat = items.map { it.lat }.average()
-          val centerLng = items.map { it.lng }.average()
-          return listOf(Cluster(centerLat, centerLng, items))
-        }
-      }
+  private val singleClusterStrategy = ClusterStrategy { items, _ ->
+    if (items.isEmpty()) emptyList()
+    else {
+      val centerLat = items.map { it.lat }.average()
+      val centerLng = items.map { it.lng }.average()
+      listOf(Cluster(centerLat, centerLng, items))
+    }
+  }
 
-  private val noClusterStrategy =
-      object : ClusterStrategy {
-        override fun clusterize(
-            items: List<ClusterItem>,
-            zoomLevel: Float
-        ): List<Cluster<ClusterItem>> {
-          return items.map { Cluster(it.lat, it.lng, listOf(it)) }
-        }
-      }
+  private val noClusterStrategy = ClusterStrategy { items, _ ->
+    items.map { Cluster(it.lat, it.lng, listOf(it)) }
+  }
 
   @Before
   fun setup() {

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/MapScreenTest.kt
@@ -341,8 +341,7 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
             testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
         delay(2000)
 
-        val state = mapViewModel.uiState.value
-        val pin = state.geoPins.find { it.geoPin.uid == shop.id }
+        val pin = mapViewModel.getFilteredPins().find { it.geoPin.uid == shop.id }
         assertNotNull(pin)
 
         mapViewModel.selectPin(pin!!)
@@ -377,8 +376,7 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
             testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
         delay(2000)
 
-        val state = mapViewModel.uiState.value
-        val pin = state.geoPins.find { it.geoPin.uid == spaceRenter.id }
+        val pin = mapViewModel.getFilteredPins().find { it.geoPin.uid == spaceRenter.id }
         assertNotNull(pin)
 
         mapViewModel.selectPin(pin!!)
@@ -437,8 +435,7 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
             testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
         delay(2000)
 
-        val state = mapViewModel.uiState.value
-        val pin = state.geoPins.find { it.geoPin.uid == discussion.uid }
+        val pin = mapViewModel.getFilteredPins().find { it.geoPin.uid == discussion.uid }
         assertNotNull(pin)
 
         mapViewModel.selectPin(pin!!)
@@ -478,8 +475,7 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
             testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
         delay(2000)
 
-        val state = mapViewModel.uiState.value
-        val pin = state.geoPins.find { it.geoPin.uid == shop.id }
+        val pin = mapViewModel.getFilteredPins().find { it.geoPin.uid == shop.id }
         assertNotNull(pin)
 
         mapViewModel.selectPin(pin!!)
@@ -510,8 +506,7 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
             testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
         delay(2000)
 
-        val state = mapViewModel.uiState.value
-        val pin = state.geoPins.find { it.geoPin.uid == shop.id }
+        val pin = mapViewModel.getFilteredPins().find { it.geoPin.uid == shop.id }
         assertNotNull(pin)
 
         mapViewModel.selectPin(pin!!)
@@ -551,8 +546,7 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
             testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = shopOwnerAccount.uid)
         delay(2000)
 
-        val state = mapViewModel.uiState.value
-        val pin = state.geoPins.find { it.geoPin.uid == shop.id }
+        val pin = mapViewModel.getFilteredPins().find { it.geoPin.uid == shop.id }
         assertNotNull(pin)
 
         mapViewModel.selectPin(pin!!)
@@ -596,8 +590,7 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
             testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
         delay(2000)
 
-        val state = mapViewModel.uiState.value
-        val initialCount = state.geoPins.size
+        val initialCount = mapViewModel.getFilteredPins().size
         assert(initialCount >= 2)
 
         composeRule.onNodeWithTag(MapScreenTestTags.FILTER_BUTTON).performClick()
@@ -606,17 +599,15 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
           !mapViewModel.uiState.value.activeFilters.contains(PinType.SHOP)
         }
 
-        val stateWithFilter = mapViewModel.uiState.value
-        assert(stateWithFilter.geoPins.size < initialCount)
-        assert(stateWithFilter.geoPins.none { it.geoPin.type == PinType.SHOP })
+        assert(mapViewModel.getFilteredPins().size < initialCount)
+        assert(mapViewModel.getFilteredPins().none { it.geoPin.type == PinType.SHOP })
 
         composeRule.onNodeWithTag(MapScreenTestTags.FILTER_SHOP_CHIP).performClick()
         composeRule.waitUntil(timeoutMillis = 5_000) {
           mapViewModel.uiState.value.activeFilters.contains(PinType.SHOP)
         }
 
-        val stateWithoutFilter = mapViewModel.uiState.value
-        assert(stateWithoutFilter.geoPins.size == initialCount)
+        assert(mapViewModel.getFilteredPins().size == initialCount)
 
         shopRepository.deleteShop(shop.id)
         spaceRenterRepository.deleteSpaceRenter(spaceRenter.id)
@@ -639,7 +630,7 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
         delay(2000)
 
         val state = mapViewModel.uiState.value
-        assert(state.geoPins.isNotEmpty())
+        assert(mapViewModel.getFilteredPins().isNotEmpty())
         assert(state.allGeoPins.isNotEmpty())
 
         composeRule.onNodeWithTag(MapScreenTestTags.FILTER_BUTTON).performClick()
@@ -654,7 +645,7 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
 
         val filteredState = mapViewModel.uiState.value
 
-        assert(filteredState.geoPins.isEmpty())
+        assert(mapViewModel.getFilteredPins().isEmpty())
         assert(filteredState.allGeoPins.isNotEmpty())
 
         shopRepository.deleteShop(shop.id)
@@ -676,8 +667,7 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
             testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
         delay(2000)
 
-        val state = mapViewModel.uiState.value
-        val pin = state.geoPins.find { it.geoPin.uid == shop.id }
+        val pin = mapViewModel.getFilteredPins().find { it.geoPin.uid == shop.id }
         assertNotNull(pin)
 
         // Marker do not expose tag to compose => fix later if possible, but assertNotNull is enough
@@ -709,8 +699,7 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
             testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
         delay(2000)
 
-        val state = mapViewModel.uiState.value
-        assert(state.geoPins.size >= 2)
+        assert(mapViewModel.getFilteredPins().size >= 2)
 
         shopRepository.deleteShop(shop1.id)
         shopRepository.deleteShop(shop2.id)
@@ -753,8 +742,7 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
             testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
         delay(2000)
 
-        var state = mapViewModel.uiState.value
-        var sessionPin = state.geoPins.find { it.geoPin.uid == discussion.uid }
+        var sessionPin = mapViewModel.getFilteredPins().find { it.geoPin.uid == discussion.uid }
         assertNull(sessionPin)
 
         mapViewModel.stopGeoQuery()
@@ -764,8 +752,7 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
             testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = shopOwnerAccount.uid)
         delay(2000)
 
-        state = ownerViewModel.uiState.value
-        sessionPin = state.geoPins.find { it.geoPin.uid == discussion.uid }
+        sessionPin = mapViewModel.getFilteredPins().find { it.geoPin.uid == discussion.uid }
         assertNotNull(sessionPin)
 
         // cleanup
@@ -789,8 +776,7 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
             testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
         delay(2000)
 
-        val state = mapViewModel.uiState.value
-        val pin = state.geoPins.find { it.geoPin.uid == shop.id }
+        val pin = mapViewModel.getFilteredPins().find { it.geoPin.uid == shop.id }
         assertNotNull(pin)
 
         mapViewModel.selectPin(pin!!)

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/MapScreenTest.kt
@@ -23,7 +23,6 @@ import com.github.meeplemeet.model.map.PinType
 import com.github.meeplemeet.model.map.cluster.Cluster
 import com.github.meeplemeet.model.map.cluster.ClusterManager
 import com.github.meeplemeet.model.map.cluster.ClusterStrategy
-import com.github.meeplemeet.model.map.cluster.DistanceBasedClusterStrategy
 import com.github.meeplemeet.model.shared.game.GAMES_COLLECTION_PATH
 import com.github.meeplemeet.model.shared.game.GameNoUid
 import com.github.meeplemeet.model.shared.location.Location
@@ -863,20 +862,14 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
         refreshContent()
 
         // Use actual simplified viewmodel for distance-based clustering strategy
-        val mapViewModel =
-            MapViewModel(
-                clusterManager =
-                    ClusterManager(
-                        DistanceBasedClusterStrategy(
-                            baseThresholdKm = 1.0,
-                            zoomToThreshold = { zoom -> if (zoom <= 10f) 1.0 else 0.1 })))
+        val mapViewModel = MapViewModel()
 
         mapViewModel.startGeoQuery(
             testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
         delay(1500)
 
-        val initialZoom = 8f // Threshold = 1.0 km
-        val newZoom = 14f // Threshold = 0.1 km
+        val initialZoom = 10f // Threshold = 5 km
+        val newZoom = 18f // Threshold = 50 m
 
         mapViewModel.updateZoomLevel(initialZoom)
         delay(500)

--- a/app/src/main/java/com/github/meeplemeet/model/map/MapViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/map/MapViewModel.kt
@@ -371,7 +371,7 @@ class MapViewModel(
    */
   fun selectPin(pin: GeoPinWithLocation) {
     viewModelScope.launch {
-      _uiState.update { it.copy(isLoadingPreview = true, selectedGeoPin = pin.geoPin) }
+      _uiState.update { it.copy(isLoadingPreview = true) }
       try {
         val preview = markerPreviewRepo.getMarkerPreview(pin.geoPin)
         _uiState.update {

--- a/app/src/main/java/com/github/meeplemeet/model/map/MapViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/map/MapViewModel.kt
@@ -36,9 +36,6 @@ data class MapUIState(
     get() = allGeoPins.filter { it.geoPin.type in activeFilters }
 }
 
-/** A geo-pin along with its current geographic location. */
-data class GeoPinWithLocation(val geoPin: StorableGeoPin, val location: GeoPoint)
-
 /**
  * ViewModel responsible for managing and observing geographically indexed map data (geo-pins).
  *

--- a/app/src/main/java/com/github/meeplemeet/model/map/MapViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/map/MapViewModel.kt
@@ -2,6 +2,7 @@
 
 package com.github.meeplemeet.model.map
 
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.github.meeplemeet.RepositoryProvider
@@ -21,20 +22,15 @@ import org.imperiumlabs.geofirestore.listeners.GeoQueryEventListener
 /**
  * Represents the UI state of the map, including currently visible geo-pins, any selected
  * pin/preview, loading state, and error messages.
- *
- * @property geoPins The filtered list of geo-pins, based on [activeFilters].
  */
 data class MapUIState(
-    val allGeoPins: List<GeoPinWithLocation> = emptyList(),
+    internal val allGeoPins: List<GeoPinWithLocation> = emptyList(),
     val activeFilters: Set<PinType> = PinType.entries.toSet(),
     val errorMsg: String? = null,
     val selectedMarkerPreview: MarkerPreview? = null,
     val selectedGeoPin: StorableGeoPin? = null,
-    val isLoadingPreview: Boolean = false
-) {
-  val geoPins: List<GeoPinWithLocation>
-    get() = allGeoPins.filter { it.geoPin.type in activeFilters }
-}
+    val isLoadingPreview: Boolean = false,
+)
 
 /**
  * ViewModel responsible for managing and observing geographically indexed map data (geo-pins).
@@ -204,8 +200,7 @@ class MapViewModel(
   }
 
   /**
-   * Updates the set of active pin type filters applied to the map. This affects the
-   * [MapUIState.geoPins] property, which is the filtered view used by the UI.
+   * Updates the set of active pin type filters applied to the map.
    *
    * @param newFilters The new set of [PinType] to display.
    */
@@ -287,5 +282,12 @@ class MapViewModel(
   override fun onCleared() {
     stopGeoQuery()
     super.onCleared()
+  }
+
+  // Access the filtered pins, for tests backward compatibility
+  @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+  fun getFilteredPins(): List<GeoPinWithLocation> {
+    val state = _uiState.value
+    return state.allGeoPins.filter { it.geoPin.type in state.activeFilters }
   }
 }

--- a/app/src/main/java/com/github/meeplemeet/model/map/StorableGeoPin.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/map/StorableGeoPin.kt
@@ -1,5 +1,6 @@
 package com.github.meeplemeet.model.map
 
+import com.google.firebase.firestore.GeoPoint
 import kotlinx.serialization.Serializable
 
 /** Enum representing the type of entity linked to a map pin. */
@@ -16,6 +17,9 @@ enum class PinType {
  * @property type Type of the pin (e.g. SHOP, SESSION, SPACE).
  */
 data class StorableGeoPin(val uid: String, val type: PinType)
+
+/** A geo-pin along with its current geographic location. */
+data class GeoPinWithLocation(val geoPin: StorableGeoPin, val location: GeoPoint)
 
 /**
  * Minimal serializable form of [StorableGeoPin] without the UID, used for Firestore storage.

--- a/app/src/main/java/com/github/meeplemeet/model/map/cluster/ClusterManager.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/map/cluster/ClusterManager.kt
@@ -1,0 +1,36 @@
+package com.github.meeplemeet.model.map.cluster
+
+/**
+ * Manager responsible for clustering items using a specified [ClusterStrategy].
+ *
+ * This class is generic and can cluster any type of items, as long as a mapper from the item type
+ * to [ClusterItem] is provided.
+ *
+ * @property strategy The clustering strategy to use.
+ */
+class ClusterManager(private val strategy: ClusterStrategy) {
+
+  /**
+   * Clusters a list of items based on their mapped geolocation.
+   *
+   * @param items The list of items to cluster.
+   * @param zoomLevel The current zoom level of the map. Can be used by the strategy to adjust
+   *   cluster density.
+   * @param mapper Function that maps an item [T] to a [ClusterItem] containing its geolocation for
+   *   clustering.
+   * @return A list of [Cluster] objects, each containing the original items of type [T].
+   */
+  fun <T> cluster(items: List<T>, zoomLevel: Float, mapper: (T) -> ClusterItem): List<Cluster<T>> {
+    // Map each original item to a ClusterItem containing only location info
+    val clusterItems = items.map { mapper(it) }
+
+    // Use the clustering strategy to group ClusterItems into clusters
+    val clustersOfItems = strategy.clusterize(clusterItems, zoomLevel)
+
+    // Map back from ClusterItem clusters to clusters of original items
+    return clustersOfItems.map { cluster ->
+      val originalItems = items.filter { mapper(it) in cluster.items }
+      Cluster(cluster.centerLat, cluster.centerLng, originalItems)
+    }
+  }
+}

--- a/app/src/main/java/com/github/meeplemeet/model/map/cluster/ClusterModels.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/map/cluster/ClusterModels.kt
@@ -9,10 +9,11 @@ package com.github.meeplemeet.model.map.cluster
 data class ClusterItem(val lat: Double, val lng: Double)
 
 /**
- * Represents a group of clustered items, along with the geographic center of the cluster.
+ * Represents a group of items clustered together on a map, along with the geographic center.
  *
+ * @param T The type of the items contained in the cluster.
  * @property centerLat The latitude of the cluster's center, in degrees.
  * @property centerLng The longitude of the cluster's center, in degrees.
- * @property items The list of items contained in this cluster.
+ * @property items The list of items contained in this cluster. Can be of any type [T].
  */
-data class Cluster(val centerLat: Double, val centerLng: Double, val items: List<ClusterItem>)
+data class Cluster<T>(val centerLat: Double, val centerLng: Double, val items: List<T>)

--- a/app/src/main/java/com/github/meeplemeet/model/map/cluster/ClusterModels.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/map/cluster/ClusterModels.kt
@@ -1,0 +1,18 @@
+package com.github.meeplemeet.model.map.cluster
+
+/**
+ * Represents a single geolocated element that can be clustered.
+ *
+ * @property lat The latitude of the item, in degrees.
+ * @property lng The longitude of the item, in degrees.
+ */
+data class ClusterItem(val lat: Double, val lng: Double)
+
+/**
+ * Represents a group of clustered items, along with the geographic center of the cluster.
+ *
+ * @property centerLat The latitude of the cluster's center, in degrees.
+ * @property centerLng The longitude of the cluster's center, in degrees.
+ * @property items The list of items contained in this cluster.
+ */
+data class Cluster(val centerLat: Double, val centerLng: Double, val items: List<ClusterItem>)

--- a/app/src/main/java/com/github/meeplemeet/model/map/cluster/ClusterStrategy.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/map/cluster/ClusterStrategy.kt
@@ -1,0 +1,95 @@
+package com.github.meeplemeet.model.map.cluster
+
+import kotlin.math.asin
+import kotlin.math.cos
+import kotlin.math.pow
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+/**
+ * Strategy interface for clustering a list of items on a map. Implementations define the clustering
+ * algorithm.
+ */
+@FunctionalInterface
+interface ClusterStrategy {
+
+  /**
+   * Groups the given items into clusters based on the strategy.
+   *
+   * @param items The list of items to cluster.
+   * @param zoomLevel The current map zoom level. Can be used to adjust clustering density.
+   * @return A list of clusters.
+   */
+  fun clusterize(items: List<ClusterItem>, zoomLevel: Float): List<Cluster>
+}
+
+private const val DEFAULT_THRESHOLD_KM = 1.0
+
+/**
+ * A simple distance-based clustering strategy.
+ *
+ * Items closer than a threshold (adjusted for zoom) are grouped into clusters.
+ *
+ * @property baseThresholdKm Base distance threshold in kilometers.
+ * @property zoomToThreshold Function to compute the effective threshold based on zoom.
+ */
+class DistanceBasedClusterStrategy(
+    private val baseThresholdKm: Double = DEFAULT_THRESHOLD_KM,
+    private val zoomToThreshold: (Float) -> Double = { zoom ->
+      baseThresholdKm / 2.0.pow(zoom / 5.0)
+    }
+) : ClusterStrategy {
+
+  /**
+   * Clusters the given items based on distance and zoom level.
+   *
+   * @param items The list of items to cluster.
+   * @param zoomLevel Current map zoom level.
+   * @return List of clusters.
+   */
+  override fun clusterize(items: List<ClusterItem>, zoomLevel: Float): List<Cluster> {
+    val threshold = zoomToThreshold(zoomLevel)
+    val clusters = mutableListOf<Cluster>()
+    val remaining = items.toMutableList()
+
+    while (remaining.isNotEmpty()) {
+      val base = remaining.removeFirst()
+      val clusterItems = mutableListOf(base)
+
+      val iterator = remaining.iterator()
+      while (iterator.hasNext()) {
+        val other = iterator.next()
+        if (distanceKm(base, other) <= threshold) {
+          clusterItems.add(other)
+          iterator.remove()
+        }
+      }
+
+      val centerLat = clusterItems.map { it.lat }.average()
+      val centerLng = clusterItems.map { it.lng }.average()
+      clusters.add(Cluster(centerLat, centerLng, clusterItems))
+    }
+
+    return clusters
+  }
+
+  /**
+   * Computes the distance in kilometers between two geographical points.
+   *
+   * Uses the Haversine formula to calculate great-circle distance.
+   *
+   * @param a First point
+   * @param b Second point
+   * @return Distance in kilometers
+   */
+  private fun distanceKm(a: ClusterItem, b: ClusterItem): Double {
+    val r = 6371.0 // Earth radius
+    val dLat = Math.toRadians(b.lat - a.lat)
+    val dLng = Math.toRadians(b.lng - a.lng)
+    val lat1 = Math.toRadians(a.lat)
+    val lat2 = Math.toRadians(b.lat)
+
+    val haversine = sin(dLat / 2).pow(2.0) + sin(dLng / 2).pow(2.0) * cos(lat1) * cos(lat2)
+    return 2 * r * asin(sqrt(haversine))
+  }
+}

--- a/app/src/main/java/com/github/meeplemeet/model/map/cluster/ClusterStrategy.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/map/cluster/ClusterStrategy.kt
@@ -9,6 +9,8 @@ import kotlin.math.sqrt
 /**
  * Strategy interface for clustering a list of items on a map. Implementations define the clustering
  * algorithm.
+ *
+ * The strategy operates on [ClusterItem]s and returns clusters that group items of the same type.
  */
 @FunctionalInterface
 interface ClusterStrategy {
@@ -18,9 +20,9 @@ interface ClusterStrategy {
    *
    * @param items The list of items to cluster.
    * @param zoomLevel The current map zoom level. Can be used to adjust clustering density.
-   * @return A list of clusters.
+   * @return A list of [Cluster]s containing the input items.
    */
-  fun clusterize(items: List<ClusterItem>, zoomLevel: Float): List<Cluster>
+  fun clusterize(items: List<ClusterItem>, zoomLevel: Float): List<Cluster<ClusterItem>>
 }
 
 private const val DEFAULT_THRESHOLD_KM = 1.0
@@ -45,11 +47,11 @@ class DistanceBasedClusterStrategy(
    *
    * @param items The list of items to cluster.
    * @param zoomLevel Current map zoom level.
-   * @return List of clusters.
+   * @return List of [Cluster]s containing the clustered [ClusterItem]s.
    */
-  override fun clusterize(items: List<ClusterItem>, zoomLevel: Float): List<Cluster> {
+  override fun clusterize(items: List<ClusterItem>, zoomLevel: Float): List<Cluster<ClusterItem>> {
     val threshold = zoomToThreshold(zoomLevel)
-    val clusters = mutableListOf<Cluster>()
+    val clusters = mutableListOf<Cluster<ClusterItem>>()
     val remaining = items.toMutableList()
 
     while (remaining.isNotEmpty()) {

--- a/app/src/main/java/com/github/meeplemeet/model/map/cluster/ClusterStrategy.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/map/cluster/ClusterStrategy.kt
@@ -12,8 +12,7 @@ import kotlin.math.sqrt
  *
  * The strategy operates on [ClusterItem]s and returns clusters that group items of the same type.
  */
-@FunctionalInterface
-interface ClusterStrategy {
+fun interface ClusterStrategy {
 
   /**
    * Groups the given items into clusters based on the strategy.

--- a/app/src/main/java/com/github/meeplemeet/ui/MapScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/MapScreen.kt
@@ -5,7 +5,6 @@ package com.github.meeplemeet.ui
 import android.Manifest
 import android.annotation.SuppressLint
 import android.content.pm.PackageManager
-import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.Typeface
@@ -1070,7 +1069,7 @@ private fun rememberClusterIcon(size: Int, diameterDp: Int = 64): BitmapDescript
     val diameterPx = with(density) { diameterDp.dp.toPx() }.toInt()
 
     // Create a bitmap
-    val bitmap = Bitmap.createBitmap(diameterPx, diameterPx, Bitmap.Config.ARGB_8888)
+    val bitmap = createBitmap(diameterPx, diameterPx)
     val canvas = Canvas(bitmap)
 
     // Background circle

--- a/app/src/main/java/com/github/meeplemeet/ui/MapScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/MapScreen.kt
@@ -375,7 +375,8 @@ fun MapScreen(
                 val pinPriority = listOf(PinType.SESSION, PinType.SHOP, PinType.SPACE)
 
                 val uniquePins =
-                    uiState.geoPins
+                    viewModel
+                        .getFilteredPins() // TODO Remove ASAP
                         .groupBy { it.location }
                         .mapValues { (_, pins) ->
                           pins.minByOrNull { pinPriority.indexOf(it.geoPin.type) }!!

--- a/app/src/main/java/com/github/meeplemeet/ui/MapScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/MapScreen.kt
@@ -1091,7 +1091,7 @@ private fun rememberMarkerIcon(
  * number is drawn centered in white text.
  *
  * @param size number of items in the cluster
- * @param diameterDp diameter of the cluster icon in dp (default is 64dp)
+ * @param diameterDp diameter of the cluster icon in dp (default is 32dp)
  * @return a [BitmapDescriptor] usable as a Google Maps marker icon
  */
 @Composable

--- a/app/src/test/java/com/github/meeplemeet/model/ClusterManagerTest.kt
+++ b/app/src/test/java/com/github/meeplemeet/model/ClusterManagerTest.kt
@@ -3,7 +3,6 @@ package com.github.meeplemeet.model
 import com.github.meeplemeet.model.map.cluster.Cluster
 import com.github.meeplemeet.model.map.cluster.ClusterItem
 import com.github.meeplemeet.model.map.cluster.ClusterManager
-import com.github.meeplemeet.model.map.cluster.ClusterStrategy
 import junit.framework.TestCase.assertEquals
 import kotlin.test.Test
 
@@ -11,20 +10,14 @@ class ClusterManagerTest {
 
   private val clusterManager =
       ClusterManager(
-          strategy =
-              object : ClusterStrategy {
-                override fun clusterize(
-                    items: List<ClusterItem>,
-                    zoomLevel: Float
-                ): List<Cluster<ClusterItem>> {
-                  if (items.isEmpty()) return emptyList()
-
-                  // Regroup all items into a single cluster
-                  val centerLat = items.map { it.lat }.average()
-                  val centerLng = items.map { it.lng }.average()
-                  return listOf(Cluster(centerLat, centerLng, items))
-                }
-              })
+          strategy = { items, _ ->
+            if (items.isEmpty()) emptyList()
+            else {
+              val centerLat = items.map { it.lat }.average()
+              val centerLng = items.map { it.lng }.average()
+              listOf(Cluster(centerLat, centerLng, items))
+            }
+          })
 
   data class TestItem(val id: Int, val lat: Double, val lng: Double)
 

--- a/app/src/test/java/com/github/meeplemeet/model/ClusterManagerTest.kt
+++ b/app/src/test/java/com/github/meeplemeet/model/ClusterManagerTest.kt
@@ -1,0 +1,57 @@
+package com.github.meeplemeet.model
+
+import com.github.meeplemeet.model.map.cluster.Cluster
+import com.github.meeplemeet.model.map.cluster.ClusterItem
+import com.github.meeplemeet.model.map.cluster.ClusterManager
+import com.github.meeplemeet.model.map.cluster.ClusterStrategy
+import junit.framework.TestCase.assertEquals
+import kotlin.test.Test
+
+class ClusterManagerTest {
+
+  private val clusterManager =
+      ClusterManager(
+          strategy =
+              object : ClusterStrategy {
+                override fun clusterize(
+                    items: List<ClusterItem>,
+                    zoomLevel: Float
+                ): List<Cluster<ClusterItem>> {
+                  if (items.isEmpty()) return emptyList()
+
+                  // Regroup all items into a single cluster
+                  val centerLat = items.map { it.lat }.average()
+                  val centerLng = items.map { it.lng }.average()
+                  return listOf(Cluster(centerLat, centerLng, items))
+                }
+              })
+
+  data class TestItem(val id: Int, val lat: Double, val lng: Double)
+
+  @Test
+  fun clusterShouldMapAndRemapItemsCorrectly() {
+    val items = listOf(TestItem(1, 0.0, 0.0), TestItem(2, 1.0, 1.0), TestItem(3, 2.0, 2.0))
+
+    val clusters =
+        clusterManager.cluster(items, zoomLevel = 10f) { item -> ClusterItem(item.lat, item.lng) }
+
+    assertEquals(1, clusters.size)
+
+    val cluster = clusters.first()
+    assertEquals(items.sortedBy { it.id }, cluster.items.sortedBy { it.id })
+
+    val expectedLat = items.map { it.lat }.average()
+    val expectedLng = items.map { it.lng }.average()
+    assertEquals(expectedLat, cluster.centerLat)
+    assertEquals(expectedLng, cluster.centerLng)
+  }
+
+  @Test
+  fun clusterShouldHandleEmptyList() {
+    val clusters =
+        clusterManager.cluster(emptyList<TestItem>(), zoomLevel = 5f) { item ->
+          ClusterItem(item.lat, item.lng)
+        }
+    assertEquals(0, clusters.size)
+  }
+}

--- a/app/src/test/java/com/github/meeplemeet/model/DistanceBasedClusterStrategyTest.kt
+++ b/app/src/test/java/com/github/meeplemeet/model/DistanceBasedClusterStrategyTest.kt
@@ -1,0 +1,247 @@
+package com.github.meeplemeet.model
+
+import com.github.meeplemeet.model.map.cluster.ClusterItem
+import com.github.meeplemeet.model.map.cluster.DistanceBasedClusterStrategy
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertTrue
+import kotlin.test.Test
+
+class DistanceBasedClusterStrategyTest {
+
+  /**
+   * Utility to move items by dx, dy expressed in KM. 1° latitude ~= 111 km → used for synthetic
+   * test points.
+   */
+  private fun km(dx: Double, dy: Double) = ClusterItem(lat = dx / 111.0, lng = dy / 111.0)
+
+  @Test
+  fun emptyInputList() {
+    val strategy = DistanceBasedClusterStrategy()
+    val result = strategy.clusterize(emptyList(), 5f)
+    assertTrue(result.isEmpty())
+  }
+
+  @Test
+  fun singleItemCluster() {
+    val strategy = DistanceBasedClusterStrategy()
+    val item = km(0.0, 0.0)
+    val result = strategy.clusterize(listOf(item), 0f)
+
+    assertEquals(1, result.size)
+    assertEquals(1, result[0].items.size)
+    assertEquals(item, result[0].items.first())
+  }
+
+  @Test
+  fun twoItemsFarApartProduceTwoClusters() {
+    val strategy = DistanceBasedClusterStrategy(baseThresholdKm = 1.0)
+
+    val a = km(0.0, 0.0)
+    val b = km(10.0, 0.0) // 10 km apart
+
+    val result = strategy.clusterize(listOf(a, b), 0f)
+    assertEquals(2, result.size)
+  }
+
+  @Test
+  fun twoItemsCloseProduceOneCluster() {
+    val strategy = DistanceBasedClusterStrategy(baseThresholdKm = 1.0)
+
+    val a = km(0.0, 0.0)
+    val b = km(0.5, 0.0) // ~0.5 km
+
+    val result = strategy.clusterize(listOf(a, b), 0f)
+    assertEquals(1, result.size)
+    assertEquals(2, result[0].items.size)
+  }
+
+  @Test
+  fun centroidIsAverage() {
+    val strategy = DistanceBasedClusterStrategy(baseThresholdKm = 5.0)
+
+    // Two points close enough to be clustered
+    val a = km(0.0, 0.0) // origin
+    val b = km(2.0, 2.0) // 2 km east and 2 km north
+
+    val result = strategy.clusterize(listOf(a, b), 0f)
+    val cluster = result.first()
+
+    // The cluster center should be the average of lat/lng
+    val expectedLat = (a.lat + b.lat) / 2
+    val expectedLng = (a.lng + b.lng) / 2
+
+    assertEquals(expectedLat, cluster.centerLat, 1e-6)
+    assertEquals(expectedLng, cluster.centerLng, 1e-6)
+  }
+
+  @Test
+  fun identicalItemsProduceZeroDistance() {
+    val strategy = DistanceBasedClusterStrategy()
+
+    val a = ClusterItem(46.5191, 6.6323)
+    val b = ClusterItem(46.5191, 6.6323)
+
+    val result = strategy.clusterize(listOf(a, b), 0f)
+
+    assertEquals(1, result.size)
+    assertEquals(2, result[0].items.size)
+  }
+
+  @Test
+  fun negativeCoordinatesAreHandled() {
+    val strategy = DistanceBasedClusterStrategy(baseThresholdKm = 2.0)
+
+    val a = ClusterItem(-10.0, -20.0)
+    val b = ClusterItem(-10.01, -20.01)
+
+    val result = strategy.clusterize(listOf(a, b), 0f)
+
+    assertEquals(1, result.size)
+  }
+
+  @Test
+  fun clusteringIsOrderIndependent() {
+    val strategy = DistanceBasedClusterStrategy(baseThresholdKm = 1.0)
+
+    val items = listOf(km(0.0, 0.0), km(0.5, 0.0), km(1.0, 0.0))
+
+    val normal = strategy.clusterize(items, 0f)
+    val reversed = strategy.clusterize(items.reversed(), 0f)
+
+    assertEquals(normal.size, reversed.size)
+    assertEquals(normal[0].items.size, reversed[0].items.size)
+  }
+
+  /**
+   * Test the default zoomToThreshold indirectly: We feed two points whose distance is known, and
+   * check at which zoom they cluster or separate.
+   */
+  @Test
+  fun zoomLowersThresholdExponentially() {
+    val a = km(0.0, 0.0)
+    val b = km(7.9, 0.0) // slightly below 8 km
+
+    val strategy = DistanceBasedClusterStrategy(baseThresholdKm = 16.0)
+
+    // Zoom 0 → threshold = 16 km → they cluster
+    val clusterZoom0 = strategy.clusterize(listOf(a, b), 0f)
+    assertEquals(1, clusterZoom0.size)
+
+    // Zoom 5 → threshold = 8 km → still cluster
+    val clusterZoom5 = strategy.clusterize(listOf(a, b), 5f)
+    assertEquals(1, clusterZoom5.size)
+
+    // Zoom 10 → threshold = 4 km → they split
+    val clusterZoom10 = strategy.clusterize(listOf(a, b), 10f)
+    assertEquals(2, clusterZoom10.size)
+  }
+
+  @Test
+  fun customZoomThresholdIsUsed() {
+    var called = false
+
+    val strategy =
+        DistanceBasedClusterStrategy(
+            baseThresholdKm = 1.0,
+            zoomToThreshold = {
+              called = true
+              123.0
+            })
+
+    strategy.clusterize(listOf(km(0.0, 0.0)), 42f)
+    assertTrue(called)
+  }
+
+  @Test
+  fun zoomEffectMakesClustersSmallerAtHighZoom() {
+    val strategy = DistanceBasedClusterStrategy(baseThresholdKm = 10.0)
+
+    val close = km(0.0, 0.0)
+    val medium = km(5.0, 0.0) // 5 km
+    val far = km(20.0, 0.0) // 20 km
+
+    val items = listOf(close, medium, far)
+
+    val lowZoom = strategy.clusterize(items, 0f)
+    val highZoom = strategy.clusterize(items, 10f)
+
+    assertEquals(2, lowZoom.size) // close+medium, then far
+    assertEquals(3, highZoom.size) // all separate
+  }
+
+  @Test
+  fun manyItemsRandomScatter() {
+    val strategy = DistanceBasedClusterStrategy(baseThresholdKm = 1.0)
+
+    val items =
+        List(20) { i ->
+          km(i.toDouble(), i.toDouble()) // spread diagonally
+        }
+
+    val result = strategy.clusterize(items, 0f)
+
+    assertEquals(20, result.size)
+  }
+
+  @Test
+  fun thresholdBoundaryIncluded() {
+    val strategy = DistanceBasedClusterStrategy(baseThresholdKm = 1.0)
+
+    val a = km(0.0, 0.0)
+    val b = km(0.9, 0.0) // slightly below 1 km
+
+    val result = strategy.clusterize(listOf(a, b), 0f)
+
+    assertEquals(1, result.size) // <= threshold → same cluster
+  }
+
+  @Test
+  fun manyRandomItemsProduceManyClusters() {
+    val strategy = DistanceBasedClusterStrategy(baseThresholdKm = 1.0)
+
+    // 200 items spaced by 1 km → none should merge
+    val items = List(200) { i -> km(i.toDouble(), 0.0) }
+
+    val result = strategy.clusterize(items, 0f)
+    assertEquals(200, result.size)
+  }
+
+  @Test
+  fun largeDenseCloudProducesSingleCluster() {
+    val strategy = DistanceBasedClusterStrategy(baseThresholdKm = 0.5) // 500m
+
+    // 300 points inside an area of approximately 200m
+    val items =
+        List(300) { i ->
+          val dx = (i % 20) * 0.01 // ~10m steps
+          val dy = (i / 20) * 0.01
+          km(dx, dy)
+        }
+
+    val result = strategy.clusterize(items, 0f)
+
+    assertEquals(1, result.size)
+    assertEquals(300, result[0].items.size)
+  }
+
+  @Test
+  fun twoLargeGroupsFormTwoClusters() {
+    val strategy = DistanceBasedClusterStrategy(baseThresholdKm = 1.0)
+
+    // First dense group
+    val groupA = List(100) { km(it * 0.005, 0.0) } // ~0.5 km span
+
+    // Second dense group located 10 km further
+    val groupB = List(100) { km(10.0 + it * 0.005, 0.0) }
+
+    val items = groupA + groupB
+
+    val result = strategy.clusterize(items, 0f)
+
+    assertEquals(2, result.size)
+
+    // Each cluster must contain exactly 100 items
+    assertTrue(result.any { it.items.size == 100 })
+    assertTrue(result.any { it.items.size == 100 })
+  }
+}

--- a/app/src/test/java/com/github/meeplemeet/model/DistanceBasedClusterStrategyTest.kt
+++ b/app/src/test/java/com/github/meeplemeet/model/DistanceBasedClusterStrategyTest.kt
@@ -1,6 +1,7 @@
 package com.github.meeplemeet.model
 
 import com.github.meeplemeet.model.map.cluster.ClusterItem
+import com.github.meeplemeet.model.map.cluster.ClusterThresholds
 import com.github.meeplemeet.model.map.cluster.DistanceBasedClusterStrategy
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertTrue
@@ -14,10 +15,14 @@ class DistanceBasedClusterStrategyTest {
    */
   private fun km(dx: Double, dy: Double) = ClusterItem(lat = dx / 111.0, lng = dy / 111.0)
 
+  // ============================================================================
+  // BASIC CLUSTERING TESTS
+  // ============================================================================
+
   @Test
   fun emptyInputList() {
     val strategy = DistanceBasedClusterStrategy()
-    val result = strategy.clusterize(emptyList(), 5f)
+    val result = strategy.clusterize(emptyList(), 14f)
     assertTrue(result.isEmpty())
   }
 
@@ -25,7 +30,7 @@ class DistanceBasedClusterStrategyTest {
   fun singleItemCluster() {
     val strategy = DistanceBasedClusterStrategy()
     val item = km(0.0, 0.0)
-    val result = strategy.clusterize(listOf(item), 0f)
+    val result = strategy.clusterize(listOf(item), 14f)
 
     assertEquals(1, result.size)
     assertEquals(1, result[0].items.size)
@@ -34,39 +39,40 @@ class DistanceBasedClusterStrategyTest {
 
   @Test
   fun twoItemsFarApartProduceTwoClusters() {
-    val strategy = DistanceBasedClusterStrategy(baseThresholdKm = 1.0)
+    // Use a fixed threshold of 1km via custom lambda
+    val strategy = DistanceBasedClusterStrategy(zoomToThreshold = { 1.0 })
 
     val a = km(0.0, 0.0)
     val b = km(10.0, 0.0) // 10 km apart
 
-    val result = strategy.clusterize(listOf(a, b), 0f)
+    val result = strategy.clusterize(listOf(a, b), 14f)
     assertEquals(2, result.size)
   }
 
   @Test
   fun twoItemsCloseProduceOneCluster() {
-    val strategy = DistanceBasedClusterStrategy(baseThresholdKm = 1.0)
+    // Fixed threshold 1km
+    val strategy = DistanceBasedClusterStrategy(zoomToThreshold = { 1.0 })
 
     val a = km(0.0, 0.0)
     val b = km(0.5, 0.0) // ~0.5 km
 
-    val result = strategy.clusterize(listOf(a, b), 0f)
+    val result = strategy.clusterize(listOf(a, b), 14f)
     assertEquals(1, result.size)
     assertEquals(2, result[0].items.size)
   }
 
   @Test
   fun centroidIsAverage() {
-    val strategy = DistanceBasedClusterStrategy(baseThresholdKm = 5.0)
+    // Fixed threshold 5km
+    val strategy = DistanceBasedClusterStrategy(zoomToThreshold = { 5.0 })
 
-    // Two points close enough to be clustered
     val a = km(0.0, 0.0) // origin
     val b = km(2.0, 2.0) // 2 km east and 2 km north
 
-    val result = strategy.clusterize(listOf(a, b), 0f)
+    val result = strategy.clusterize(listOf(a, b), 14f)
     val cluster = result.first()
 
-    // The cluster center should be the average of lat/lng
     val expectedLat = (a.lat + b.lat) / 2
     val expectedLng = (a.lng + b.lng) / 2
 
@@ -81,7 +87,7 @@ class DistanceBasedClusterStrategyTest {
     val a = ClusterItem(46.5191, 6.6323)
     val b = ClusterItem(46.5191, 6.6323)
 
-    val result = strategy.clusterize(listOf(a, b), 0f)
+    val result = strategy.clusterize(listOf(a, b), 14f)
 
     assertEquals(1, result.size)
     assertEquals(2, result[0].items.size)
@@ -89,126 +95,126 @@ class DistanceBasedClusterStrategyTest {
 
   @Test
   fun negativeCoordinatesAreHandled() {
-    val strategy = DistanceBasedClusterStrategy(baseThresholdKm = 2.0)
+    // Fixed threshold 2km
+    val strategy = DistanceBasedClusterStrategy(zoomToThreshold = { 2.0 })
 
     val a = ClusterItem(-10.0, -20.0)
     val b = ClusterItem(-10.01, -20.01)
 
-    val result = strategy.clusterize(listOf(a, b), 0f)
+    val result = strategy.clusterize(listOf(a, b), 14f)
 
     assertEquals(1, result.size)
   }
 
   @Test
   fun clusteringIsOrderIndependent() {
-    val strategy = DistanceBasedClusterStrategy(baseThresholdKm = 1.0)
+    val strategy = DistanceBasedClusterStrategy(zoomToThreshold = { 1.0 })
 
     val items = listOf(km(0.0, 0.0), km(0.5, 0.0), km(1.0, 0.0))
 
-    val normal = strategy.clusterize(items, 0f)
-    val reversed = strategy.clusterize(items.reversed(), 0f)
+    val normal = strategy.clusterize(items, 14f)
+    val reversed = strategy.clusterize(items.reversed(), 14f)
 
     assertEquals(normal.size, reversed.size)
     assertEquals(normal[0].items.size, reversed[0].items.size)
   }
 
-  /**
-   * Test the default zoomToThreshold indirectly: We feed two points whose distance is known, and
-   * check at which zoom they cluster or separate.
-   */
-  @Test
-  fun zoomLowersThresholdExponentially() {
-    val a = km(0.0, 0.0)
-    val b = km(7.9, 0.0) // slightly below 8 km
-
-    val strategy = DistanceBasedClusterStrategy(baseThresholdKm = 16.0)
-
-    // Zoom 0 → threshold = 16 km → they cluster
-    val clusterZoom0 = strategy.clusterize(listOf(a, b), 0f)
-    assertEquals(1, clusterZoom0.size)
-
-    // Zoom 5 → threshold = 8 km → still cluster
-    val clusterZoom5 = strategy.clusterize(listOf(a, b), 5f)
-    assertEquals(1, clusterZoom5.size)
-
-    // Zoom 10 → threshold = 4 km → they split
-    val clusterZoom10 = strategy.clusterize(listOf(a, b), 10f)
-    assertEquals(2, clusterZoom10.size)
-  }
-
-  @Test
-  fun customZoomThresholdIsUsed() {
-    var called = false
-
-    val strategy =
-        DistanceBasedClusterStrategy(
-            baseThresholdKm = 1.0,
-            zoomToThreshold = {
-              called = true
-              123.0
-            })
-
-    strategy.clusterize(listOf(km(0.0, 0.0)), 42f)
-    assertTrue(called)
-  }
-
-  @Test
-  fun zoomEffectMakesClustersSmallerAtHighZoom() {
-    val strategy = DistanceBasedClusterStrategy(baseThresholdKm = 10.0)
-
-    val close = km(0.0, 0.0)
-    val medium = km(5.0, 0.0) // 5 km
-    val far = km(20.0, 0.0) // 20 km
-
-    val items = listOf(close, medium, far)
-
-    val lowZoom = strategy.clusterize(items, 0f)
-    val highZoom = strategy.clusterize(items, 10f)
-
-    assertEquals(2, lowZoom.size) // close+medium, then far
-    assertEquals(3, highZoom.size) // all separate
-  }
-
-  @Test
-  fun manyItemsRandomScatter() {
-    val strategy = DistanceBasedClusterStrategy(baseThresholdKm = 1.0)
-
-    val items =
-        List(20) { i ->
-          km(i.toDouble(), i.toDouble()) // spread diagonally
-        }
-
-    val result = strategy.clusterize(items, 0f)
-
-    assertEquals(20, result.size)
-  }
-
   @Test
   fun thresholdBoundaryIncluded() {
-    val strategy = DistanceBasedClusterStrategy(baseThresholdKm = 1.0)
+    val strategy = DistanceBasedClusterStrategy(zoomToThreshold = { 1.0 })
 
     val a = km(0.0, 0.0)
     val b = km(0.9, 0.0) // slightly below 1 km
 
-    val result = strategy.clusterize(listOf(a, b), 0f)
+    val result = strategy.clusterize(listOf(a, b), 14f)
 
     assertEquals(1, result.size) // <= threshold → same cluster
   }
 
+  // ============================================================================
+  // ZOOM-DEPENDENT CLUSTERING TESTS
+  // ============================================================================
+
+  @Test
+  fun defaultStrategy_lowerZoomCreatesLargerClusters() {
+    val strategy = DistanceBasedClusterStrategy() // Uses default piecewiseExponentialScaling
+
+    val a = km(0.0, 0.0)
+    val b = km(3.0, 0.0) // 3 km apart
+
+    // Low zoom (10) → large threshold → cluster together
+    val lowZoom = strategy.clusterize(listOf(a, b), 10f)
+    assertEquals(1, lowZoom.size)
+
+    // High zoom (18) → small threshold → separate clusters
+    val highZoom = strategy.clusterize(listOf(a, b), 18f)
+    assertEquals(2, highZoom.size)
+  }
+
+  @Test
+  fun customZoomThresholdIsUsed() {
+    var capturedZoom = 0f
+
+    val strategy =
+        DistanceBasedClusterStrategy(
+            zoomToThreshold = { zoom ->
+              capturedZoom = zoom
+              100.0 // Very large threshold
+            })
+
+    strategy.clusterize(listOf(km(0.0, 0.0)), 42f)
+    assertEquals(42f, capturedZoom)
+  }
+
+  @Test
+  fun zoomEffectMakesClustersSmallerAtHighZoom() {
+    val strategy = DistanceBasedClusterStrategy() // Default strategy
+
+    val close = km(0.0, 0.0)
+    val medium = km(2.0, 0.0) // 2 km
+    val far = km(8.0, 0.0) // 8 km
+
+    val items = listOf(close, medium, far)
+
+    // Low zoom → large threshold → fewer clusters
+    val lowZoom = strategy.clusterize(items, 10f)
+    assertTrue(lowZoom.size < 3)
+
+    // High zoom → small threshold → more clusters
+    val highZoom = strategy.clusterize(items, 18f)
+    assertEquals(3, highZoom.size)
+  }
+
+  // ============================================================================
+  // LARGE-SCALE CLUSTERING TESTS
+  // ============================================================================
+
+  @Test
+  fun manyItemsRandomScatter() {
+    val strategy = DistanceBasedClusterStrategy(zoomToThreshold = { 1.0 })
+
+    val items = List(20) { i -> km(i.toDouble(), i.toDouble()) } // spread diagonally
+
+    val result = strategy.clusterize(items, 14f)
+
+    // Each point is ~1.41 km from next (diagonal), so with threshold 1km they should separate
+    assertEquals(20, result.size)
+  }
+
   @Test
   fun manyRandomItemsProduceManyClusters() {
-    val strategy = DistanceBasedClusterStrategy(baseThresholdKm = 1.0)
+    val strategy = DistanceBasedClusterStrategy(zoomToThreshold = { 1.0 })
 
     // 200 items spaced by 1 km → none should merge
     val items = List(200) { i -> km(i.toDouble(), 0.0) }
 
-    val result = strategy.clusterize(items, 0f)
+    val result = strategy.clusterize(items, 14f)
     assertEquals(200, result.size)
   }
 
   @Test
   fun largeDenseCloudProducesSingleCluster() {
-    val strategy = DistanceBasedClusterStrategy(baseThresholdKm = 0.5) // 500m
+    val strategy = DistanceBasedClusterStrategy(zoomToThreshold = { 0.5 }) // 500m
 
     // 300 points inside an area of approximately 200m
     val items =
@@ -218,7 +224,7 @@ class DistanceBasedClusterStrategyTest {
           km(dx, dy)
         }
 
-    val result = strategy.clusterize(items, 0f)
+    val result = strategy.clusterize(items, 14f)
 
     assertEquals(1, result.size)
     assertEquals(300, result[0].items.size)
@@ -226,7 +232,7 @@ class DistanceBasedClusterStrategyTest {
 
   @Test
   fun twoLargeGroupsFormTwoClusters() {
-    val strategy = DistanceBasedClusterStrategy(baseThresholdKm = 1.0)
+    val strategy = DistanceBasedClusterStrategy(zoomToThreshold = { 1.0 })
 
     // First dense group
     val groupA = List(100) { km(it * 0.005, 0.0) } // ~0.5 km span
@@ -236,12 +242,190 @@ class DistanceBasedClusterStrategyTest {
 
     val items = groupA + groupB
 
-    val result = strategy.clusterize(items, 0f)
+    val result = strategy.clusterize(items, 14f)
 
     assertEquals(2, result.size)
 
     // Each cluster must contain exactly 100 items
-    assertTrue(result.any { it.items.size == 100 })
-    assertTrue(result.any { it.items.size == 100 })
+    assertTrue(result.all { it.items.size == 100 })
+  }
+
+  // ============================================================================
+  // CLUSTER THRESHOLD STRATEGY TESTS
+  // ============================================================================
+
+  @Test
+  fun linearScaling_decreasesThresholdWithZoom() {
+    val strategy = DistanceBasedClusterStrategy(zoomToThreshold = ClusterThresholds.linearScaling)
+
+    val a = km(0.0, 0.0)
+    val b = km(0.5, 0.0) // 0.5 km apart
+
+    // At low zoom (10), threshold is ~1km → cluster
+    val lowZoom = strategy.clusterize(listOf(a, b), 10f)
+    assertEquals(1, lowZoom.size)
+
+    // At high zoom (18), threshold is ~0.04km → separate
+    val highZoom = strategy.clusterize(listOf(a, b), 18f)
+    assertEquals(2, highZoom.size)
+  }
+
+  @Test
+  fun piecewiseLinearScaling_behavesCorrectly() {
+    val strategy =
+        DistanceBasedClusterStrategy(zoomToThreshold = ClusterThresholds.piecewiseLinearScaling)
+
+    val a = km(0.0, 0.0)
+    val b = km(1.5, 0.0) // 1.5 km apart
+
+    // At zoom 10, threshold is ~2km → cluster
+    val zoom10 = strategy.clusterize(listOf(a, b), 10f)
+    assertEquals(1, zoom10.size)
+
+    // At zoom 16, threshold is ~0.15km → separate
+    val zoom16 = strategy.clusterize(listOf(a, b), 16f)
+    assertEquals(2, zoom16.size)
+  }
+
+  @Test
+  fun exponentialScaling_decreasesRapidly() {
+    val strategy =
+        DistanceBasedClusterStrategy(zoomToThreshold = ClusterThresholds.exponentialScaling)
+
+    val a = km(0.0, 0.0)
+    val b = km(5.0, 0.0) // 5 km apart
+
+    // At zoom 10, threshold is ~16km → cluster
+    val zoom10 = strategy.clusterize(listOf(a, b), 10f)
+    assertEquals(1, zoom10.size)
+
+    // At zoom 14, threshold is ~1km → separate
+    val zoom14 = strategy.clusterize(listOf(a, b), 14f)
+    assertEquals(2, zoom14.size)
+
+    // At zoom 18, threshold is ~0.06km → definitely separate
+    val zoom18 = strategy.clusterize(listOf(a, b), 18f)
+    assertEquals(2, zoom18.size)
+  }
+
+  @Test
+  fun piecewiseExponentialScaling_defaultBehavior() {
+    val strategy = DistanceBasedClusterStrategy() // Default uses piecewiseExponentialScaling
+
+    val a = km(0.0, 0.0)
+    val b = km(2.0, 0.0) // 2 km apart
+
+    // At zoom 10, threshold is ~5km → cluster
+    val zoom10 = strategy.clusterize(listOf(a, b), 10f)
+    assertEquals(1, zoom10.size)
+
+    // At zoom 14, threshold is ~1km → separate
+    val zoom14 = strategy.clusterize(listOf(a, b), 14f)
+    assertEquals(2, zoom14.size)
+
+    // At zoom 18, threshold is ~0.06km → separate
+    val zoom18 = strategy.clusterize(listOf(a, b), 18f)
+    assertEquals(2, zoom18.size)
+  }
+
+  @Test
+  fun allScalingStrategies_produceSmallerThresholdsAtHigherZoom() {
+    val strategies =
+        listOf(
+            ClusterThresholds.linearScaling,
+            ClusterThresholds.piecewiseLinearScaling,
+            ClusterThresholds.exponentialScaling,
+            ClusterThresholds.piecewiseExponentialScaling)
+
+    strategies.forEach { thresholdFn ->
+      val threshold10 = thresholdFn(10f)
+      val threshold14 = thresholdFn(14f)
+      val threshold18 = thresholdFn(18f)
+
+      assertTrue("Threshold should decrease with zoom", threshold10 > threshold14)
+      assertTrue("Threshold should decrease with zoom", threshold14 > threshold18)
+    }
+  }
+
+  @Test
+  fun linearScaling_hasMinimumThreshold() {
+    val threshold = ClusterThresholds.linearScaling(100f) // Very high zoom
+    assertTrue("Linear scaling should have a minimum threshold", threshold >= 0.03)
+  }
+
+  @Test
+  fun scalingStrategies_produceReasonableValues() {
+    val zoom14 = 14f
+
+    val linear = ClusterThresholds.linearScaling(zoom14)
+    val piecewiseLinear = ClusterThresholds.piecewiseLinearScaling(zoom14)
+    val exponential = ClusterThresholds.exponentialScaling(zoom14)
+    val piecewiseExponential = ClusterThresholds.piecewiseExponentialScaling(zoom14)
+
+    // All should be positive
+    assertTrue(linear > 0)
+    assertTrue(piecewiseLinear > 0)
+    assertTrue(exponential > 0)
+    assertTrue(piecewiseExponential > 0)
+
+    // All should be reasonable (between 10m and 10km)
+    assertTrue(linear in 0.01..10.0)
+    assertTrue(piecewiseLinear in 0.01..10.0)
+    assertTrue(exponential in 0.01..10.0)
+    assertTrue(piecewiseExponential in 0.01..10.0)
+  }
+
+  // ============================================================================
+  // EDGE CASES & BOUNDARY CONDITIONS
+  // ============================================================================
+
+  @Test
+  fun extremelyHighZoom_producesVerySmallThreshold() {
+    val strategy = DistanceBasedClusterStrategy()
+
+    val a = km(0.0, 0.0)
+    val b = km(0.01, 0.0) // 10 meters apart
+
+    // At zoom 22 (very high), even 10m should separate
+    val result = strategy.clusterize(listOf(a, b), 22f)
+    assertEquals(2, result.size)
+  }
+
+  @Test
+  fun extremelyLowZoom_clustersEverything() {
+    val strategy = DistanceBasedClusterStrategy()
+
+    val a = km(0.0, 0.0)
+    val b = km(100.0, 0.0) // 100 km apart
+
+    // At zoom 1 (very low), even 100km should cluster
+    val result = strategy.clusterize(listOf(a, b), 1f)
+    assertEquals(1, result.size)
+  }
+
+  @Test
+  fun zeroZoom_handledGracefully() {
+    val strategy = DistanceBasedClusterStrategy()
+
+    val items = listOf(km(0.0, 0.0), km(50.0, 0.0))
+
+    val result = strategy.clusterize(items, 0f)
+
+    // Should not crash, should produce valid clusters
+    assertTrue(result.isNotEmpty())
+    assertTrue(result.all { it.items.isNotEmpty() })
+  }
+
+  @Test
+  fun negativeZoom_handledGracefully() {
+    val strategy = DistanceBasedClusterStrategy()
+
+    val items = listOf(km(0.0, 0.0), km(10.0, 0.0))
+
+    val result = strategy.clusterize(items, -5f)
+
+    // Should not crash, should produce valid clusters
+    assertTrue(result.isNotEmpty())
+    assertTrue(result.all { it.items.isNotEmpty() })
   }
 }


### PR DESCRIPTION
Introduce a flexible **clustering system** for map pins and add **cluster preview functionality** to display aggregated pins. Refactor `MapViewModel` and tests for efficiency and clarity.

### Cluster Strategy
- Introduce `ClusterStrategy` interface for pluggable clustering algorithms.
- Implement `DistanceBasedClusterStrategy` that groups pins based on proximity and supports zoom-level-dependent clustering.

### ClusterManager
- Acts as a bridge between the ViewModel and the cluster strategy.
- Responsible for computing clusters efficiently and provides a clean API for querying clusters by zoom level.

### MapViewModel Refactor
- Optimized pin handling with **debounced updates** for `allGeoPins`.
- Cluster cache added to reduce recomputation on frequent updates.
- Add methods for managing **cluster selection and previews**: `selectCluster()`, `selectPinFromCluster()`, `clearSelectedCluster()`.
- Cluster cache is invalidated when filters or zoom changes.
- Remove direct use of `geoPins` in favor of `getClusters()`, ensuring clustering is always applied.

### UI & Previews
- Supports **preview fetching per cluster or per pin**.
- Selected cluster previews are exposed in `uiState.selectedClusterPreviews`.
- Single-pin selection clears cluster selection and vice versa.

### Tests
- Add tests covering cluster computation, pin addition/removal with radius updates, and cluster preview selection.
- Remove redundant tests that were verifying `geoPins` logic.


https://github.com/user-attachments/assets/7de7ff64-bbb8-4116-9826-d70575245492


