### PR TITLE
Feat/session photos refactor

### DIFF
--- a/app/src/main/java/com/github/meeplemeet/model/sessions/Session.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/sessions/Session.kt
@@ -15,6 +15,7 @@ import kotlinx.serialization.Serializable
  * @property date The scheduled date and time of the session
  * @property location The physical or virtual location where the session will take place
  * @property participants List of participant IDs (typically user IDs) who are part of this session
+ * @property sessionPhotos List of SessionPhoto objects (UUID + URL) associated with this session
  */
 @Serializable
 data class Session(
@@ -22,5 +23,6 @@ data class Session(
     val gameId: String = "",
     val date: Timestamp = Timestamp.now(),
     val location: Location = Location(),
-    val participants: List<String> = emptyList()
+    val participants: List<String> = emptyList(),
+    val sessionPhotos: List<SessionPhoto> = emptyList()
 )

--- a/app/src/main/java/com/github/meeplemeet/model/sessions/SessionOverviewViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/sessions/SessionOverviewViewModel.kt
@@ -1,14 +1,21 @@
 package com.github.meeplemeet.model.sessions
 
+import android.content.Context
+import androidx.lifecycle.viewModelScope
 import com.github.meeplemeet.RepositoryProvider
+import com.github.meeplemeet.model.images.ImageRepository
 import com.github.meeplemeet.model.shared.game.GameRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
 
 class SessionOverviewViewModel(
     private val sessionRepository: SessionRepository = RepositoryProvider.sessions,
-    private val gameRepository: GameRepository = RepositoryProvider.games
+    private val gameRepository: GameRepository = RepositoryProvider.games,
+    private val imageRepository: ImageRepository = RepositoryProvider.images
 ) : CreateSessionViewModel() {
   suspend fun getGameNameByGameId(gameId: String): String? =
       kotlin.runCatching { gameRepository.getGameById(gameId).name }.getOrNull()
@@ -28,4 +35,80 @@ class SessionOverviewViewModel(
                 .mapValues { it.value!! }
           }
           .flowOn(Dispatchers.IO)
+
+  /**
+   * Loads all SessionPhoto objects for a user across all past sessions.
+   *
+   * Fetches all past sessions and collects their SessionPhoto objects (UUID + URL).
+   * Individual session failures are handled gracefully and don't prevent loading other photos.
+   *
+   * @param userId The ID of the user whose session photos are to be loaded
+   * @param onResult Callback invoked with Result containing the list of SessionPhoto objects, or an exception
+   */
+  fun loadAllPhotosForAUser(
+      userId: String,
+      onResult: (Result<List<SessionPhoto>>) -> Unit
+  ) {
+    viewModelScope.launch {
+      try {
+        val sessionIds = sessionRepository.getPastSessionIdsForUser(userId)
+
+        // Load photos from all sessions in parallel
+        val allPhotos = sessionIds.map { sessionId ->
+          async {
+            try {
+              // Get session to retrieve SessionPhoto objects
+              val session = sessionRepository.getSession(sessionId)
+              session?.sessionPhotos ?: emptyList()
+            } catch (e: Exception) {
+              // Continue with other sessions if one fails
+              emptyList<SessionPhoto>()
+            }
+          }
+        }.awaitAll().flatten()
+
+        onResult(Result.success(allPhotos))
+      } catch (e: Exception) {
+        onResult(Result.failure(e))
+      }
+    }
+  }
+
+  /**
+   * Retrieves the session that contains the specified photo UUID for a given user.
+   *
+   * Searches through all past sessions in parallel to find the one containing the specified photo.
+   *
+   * @param userId The ID of the user
+   * @param photoUuid The UUID of the photo to search for
+   * @param onResult Callback invoked with Result containing the found Session (or null if not found), or an exception
+   */
+  fun getSessionFromPhoto(userId: String, photoUuid: String, onResult: (Result<Session?>) -> Unit) {
+    viewModelScope.launch {
+      try {
+        val sessionIds = sessionRepository.getPastSessionIdsForUser(userId)
+
+        // Search all sessions in parallel and return first match
+        val foundSession = sessionIds.map { sessionId ->
+          async {
+            try {
+              val session = sessionRepository.getSession(sessionId)
+              // Check if any SessionPhoto has matching UUID
+              if (session?.sessionPhotos?.any { it.uuid == photoUuid } == true) {
+                session
+              } else {
+                null
+              }
+            } catch (e: Exception) {
+              null
+            }
+          }
+        }.awaitAll().firstOrNull { it != null }
+
+        onResult(Result.success(foundSession))
+      } catch (e: Exception) {
+        onResult(Result.failure(e))
+      }
+    }
+  }
 }

--- a/app/src/main/java/com/github/meeplemeet/model/sessions/SessionPhoto.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/sessions/SessionPhoto.kt
@@ -1,0 +1,20 @@
+package com.github.meeplemeet.model.sessions
+// AI was used in this file
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents a photo attached to a session.
+ *
+ * Stores both UUID (for tracking/deletion) and URL (for frontend display).
+ * This enables simple frontend image loading via AsyncImage while maintaining
+ * the ability to perform reverse lookups (photo → session) via UUID.
+ *
+ * @property uuid Unique identifier for the photo (used for deletion and tracking)
+ * @property url Firebase Storage download URL for the photo (used for display)
+ */
+@Serializable
+data class SessionPhoto(
+    val uuid: String = "",
+    val url: String = ""
+)

--- a/app/src/main/java/com/github/meeplemeet/model/sessions/SessionPhoto.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/sessions/SessionPhoto.kt
@@ -6,15 +6,11 @@ import kotlinx.serialization.Serializable
 /**
  * Represents a photo attached to a session.
  *
- * Stores both UUID (for tracking/deletion) and URL (for frontend display).
- * This enables simple frontend image loading via AsyncImage while maintaining
- * the ability to perform reverse lookups (photo → session) via UUID.
+ * Stores both UUID (for tracking/deletion) and URL (for frontend display). This enables simple
+ * frontend image loading via AsyncImage while maintaining the ability to perform reverse lookups
+ * (photo → session) via UUID.
  *
  * @property uuid Unique identifier for the photo (used for deletion and tracking)
  * @property url Firebase Storage download URL for the photo (used for display)
  */
-@Serializable
-data class SessionPhoto(
-    val uuid: String = "",
-    val url: String = ""
-)
+@Serializable data class SessionPhoto(val uuid: String = "", val url: String = "")

--- a/app/src/main/java/com/github/meeplemeet/model/sessions/SessionRepository.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/sessions/SessionRepository.kt
@@ -218,7 +218,10 @@ class SessionRepository(
    */
   suspend fun addSessionPhotos(discussionId: String, photos: List<SessionPhoto>) {
     val sessionPhotosField = "session.sessionPhotos"
-    discussions.document(discussionId).update(sessionPhotosField, FieldValue.arrayUnion(*photos.toTypedArray())).await()
+    discussions
+        .document(discussionId)
+        .update(sessionPhotosField, FieldValue.arrayUnion(*photos.toTypedArray()))
+        .await()
   }
 
   /**
@@ -233,11 +236,8 @@ class SessionRepository(
   suspend fun removeSessionPhoto(discussionId: String, photoUuid: String) {
     val session = getSession(discussionId) ?: return
     val updatedPhotos = session.sessionPhotos.filterNot { it.uuid == photoUuid }
-    
+
     val sessionPhotosField = "session.sessionPhotos"
-    discussions
-        .document(discussionId)
-        .update(sessionPhotosField, updatedPhotos)
-        .await()
+    discussions.document(discussionId).update(sessionPhotosField, updatedPhotos).await()
   }
 }

--- a/app/src/main/java/com/github/meeplemeet/model/sessions/SessionViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/sessions/SessionViewModel.kt
@@ -128,10 +128,9 @@ class SessionViewModel(
   /**
    * Adds photos to a gaming session.
    *
-   * Uploads photos to Firebase Storage, retrieves their URLs, and updates the session's photo
-   * list in Firestore with SessionPhoto objects (containing UUID and URL). The operation is 
-   * performed asynchronously in the viewModelScope. Errors are communicated via [errorMessage] 
-   * StateFlow.
+   * Uploads photos to Firebase Storage, retrieves their URLs, and updates the session's photo list
+   * in Firestore with SessionPhoto objects (containing UUID and URL). The operation is performed
+   * asynchronously in the viewModelScope. Errors are communicated via [errorMessage] StateFlow.
    *
    * @param context Android context for accessing storage
    * @param discussionId The unique identifier of the discussion containing the session
@@ -198,9 +197,9 @@ class SessionViewModel(
           onResult(Result.success(emptyList()))
           return@launch
         }
-        
+
         val photoUuids = session.sessionPhotos.map { it.uuid }
-        
+
         // Load images from image repository
         val photos = imageRepository.loadSessionPhotos(context, discussionId, photoUuids)
         onResult(Result.success(photos))

--- a/app/src/test/java/com/github/meeplemeet/model/ImageRepositoryTest.kt
+++ b/app/src/test/java/com/github/meeplemeet/model/ImageRepositoryTest.kt
@@ -7,13 +7,10 @@ import com.github.meeplemeet.model.images.ImageRepository
 import com.github.meeplemeet.model.sessions.SessionRepository
 import com.google.android.gms.tasks.Task
 import com.google.firebase.storage.FirebaseStorage
-import com.google.firebase.storage.ListResult
 import com.google.firebase.storage.StorageReference
-import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
@@ -77,15 +74,15 @@ class ImageRepositoryTest {
         val mockUrl = "https://firebase.storage.com/image.webp"
 
         // Mock saveImage to succeed
-        coEvery { 
-          imageRepository["saveImage"](mockContext, any<String>(), any<String>()) 
-        } returns mockUrl
-        
+        coEvery { imageRepository["saveImage"](mockContext, any<String>(), any<String>()) } returns
+            mockUrl
+
         // Mock Firebase Storage downloadUrl
         val mockStorageRef = mockk<StorageReference>(relaxed = true)
-        val mockDownloadUrlTask = mockk<com.google.android.gms.tasks.Task<android.net.Uri>>(relaxed = true)
+        val mockDownloadUrlTask =
+            mockk<com.google.android.gms.tasks.Task<android.net.Uri>>(relaxed = true)
         val mockUri = mockk<android.net.Uri>(relaxed = true)
-        
+
         every { mockStorage.reference } returns rootReference
         every { rootReference.child(any()) } returns mockStorageRef
         every { mockStorageRef.downloadUrl } returns mockDownloadUrlTask
@@ -96,20 +93,22 @@ class ImageRepositoryTest {
 
         // Result should be a list of 2 SessionPhoto objects
         assertEquals(2, result.size)
-        
+
         // Verify each SessionPhoto has valid UUID and URL
         result.forEach { photo ->
           // Check UUID format (36 characters with dashes)
           assertEquals(36, photo.uuid.length)
-          assert(photo.uuid.matches(Regex("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")))
-          
+          assert(
+              photo.uuid.matches(
+                  Regex("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")))
+
           // Check URL is set
           assertEquals(mockUrl, photo.url)
         }
-        
+
         // Verify saveImage was called twice (once per input)
-        coVerify(exactly = 2) { 
-          imageRepository["saveImage"](mockContext, any<String>(), any<String>()) 
+        coVerify(exactly = 2) {
+          imageRepository["saveImage"](mockContext, any<String>(), any<String>())
         }
       }
 
@@ -145,8 +144,6 @@ class ImageRepositoryTest {
         imageRepository.saveSessionPhotos(mockContext, discussionId, *inputs)
       }
 
-
-
   @Test(expected = RuntimeException::class)
   fun `deleteSessionPhoto propagates exception when storage fails`() =
       runTest(testDispatcher) {
@@ -172,8 +169,6 @@ class ImageRepositoryTest {
         val result = imageRepository.deleteSessionPhoto(mockContext, discussionId, photoUuid)
 
         assertEquals(photoUuid, result)
-        coVerify {
-          imageRepository["deleteImages"](mockContext, arrayOf(expectedPath))
-        }
+        coVerify { imageRepository["deleteImages"](mockContext, arrayOf(expectedPath)) }
       }
 }

--- a/app/src/test/java/com/github/meeplemeet/model/ImageRepositoryTest.kt
+++ b/app/src/test/java/com/github/meeplemeet/model/ImageRepositoryTest.kt
@@ -1,0 +1,179 @@
+package com.github.meeplemeet.model
+
+import android.content.Context
+import com.github.meeplemeet.FirebaseProvider
+import com.github.meeplemeet.RepositoryProvider
+import com.github.meeplemeet.model.images.ImageRepository
+import com.github.meeplemeet.model.sessions.SessionRepository
+import com.google.android.gms.tasks.Task
+import com.google.firebase.storage.FirebaseStorage
+import com.google.firebase.storage.ListResult
+import com.google.firebase.storage.StorageReference
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.spyk
+import io.mockk.unmockkAll
+import kotlin.test.assertEquals
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ImageRepositoryTest {
+
+  private val testDispatcher = StandardTestDispatcher()
+
+  private lateinit var imageRepository: ImageRepository
+  private lateinit var sessionRepository: SessionRepository
+  private lateinit var mockContext: Context
+  private lateinit var mockStorage: FirebaseStorage
+  private lateinit var rootReference: StorageReference
+
+  @Before
+  fun setUp() {
+    Dispatchers.setMain(testDispatcher)
+
+    mockContext = mockk(relaxed = true)
+    mockStorage = mockk(relaxed = true)
+    rootReference = mockk(relaxed = true)
+
+    mockkObject(FirebaseProvider)
+    every { FirebaseProvider.storage } returns mockStorage
+    every { mockStorage.reference } returns rootReference
+
+    mockkObject(RepositoryProvider)
+    sessionRepository = mockk(relaxed = true)
+    every { RepositoryProvider.sessions } returns sessionRepository
+
+    imageRepository = spyk(ImageRepository(testDispatcher), recordPrivateCalls = true)
+
+    mockkStatic("kotlinx.coroutines.tasks.TasksKt")
+  }
+
+  @After
+  fun tearDown() {
+    Dispatchers.resetMain()
+    unmockkAll()
+  }
+
+  @Test
+  fun `saveSessionPhotos generates SessionPhoto objects with UUID and URL`() =
+      runTest(testDispatcher) {
+        val discussionId = "discussion-1"
+        val inputs = arrayOf("/tmp/a.jpg", "/tmp/b.jpg")
+        val mockUrl = "https://firebase.storage.com/image.webp"
+
+        // Mock saveImage to succeed
+        coEvery { 
+          imageRepository["saveImage"](mockContext, any<String>(), any<String>()) 
+        } returns mockUrl
+        
+        // Mock Firebase Storage downloadUrl
+        val mockStorageRef = mockk<StorageReference>(relaxed = true)
+        val mockDownloadUrlTask = mockk<com.google.android.gms.tasks.Task<android.net.Uri>>(relaxed = true)
+        val mockUri = mockk<android.net.Uri>(relaxed = true)
+        
+        every { mockStorage.reference } returns rootReference
+        every { rootReference.child(any()) } returns mockStorageRef
+        every { mockStorageRef.downloadUrl } returns mockDownloadUrlTask
+        coEvery { mockDownloadUrlTask.await() } returns mockUri
+        every { mockUri.toString() } returns mockUrl
+
+        val result = imageRepository.saveSessionPhotos(mockContext, discussionId, *inputs)
+
+        // Result should be a list of 2 SessionPhoto objects
+        assertEquals(2, result.size)
+        
+        // Verify each SessionPhoto has valid UUID and URL
+        result.forEach { photo ->
+          // Check UUID format (36 characters with dashes)
+          assertEquals(36, photo.uuid.length)
+          assert(photo.uuid.matches(Regex("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")))
+          
+          // Check URL is set
+          assertEquals(mockUrl, photo.url)
+        }
+        
+        // Verify saveImage was called twice (once per input)
+        coVerify(exactly = 2) { 
+          imageRepository["saveImage"](mockContext, any<String>(), any<String>()) 
+        }
+      }
+
+  @Test
+  fun `loadSessionPhotos loads images for given uuids`() =
+      runTest(testDispatcher) {
+        val discussionId = "discussion-2"
+        val photoUuids = listOf("uuid-1", "uuid-2")
+
+        val bytes1 = byteArrayOf(1)
+        val bytes2 = byteArrayOf(2)
+        coEvery {
+          imageRepository["loadImage"](mockContext, "discussions/$discussionId/session/uuid-1.webp")
+        } returns bytes1
+        coEvery {
+          imageRepository["loadImage"](mockContext, "discussions/$discussionId/session/uuid-2.webp")
+        } returns bytes2
+
+        val result = imageRepository.loadSessionPhotos(mockContext, discussionId, photoUuids)
+
+        assertEquals(listOf("uuid-1" to bytes1, "uuid-2" to bytes2), result)
+      }
+
+  @Test(expected = RuntimeException::class)
+  fun `saveSessionPhotos propagates exception when storage fails`() =
+      runTest(testDispatcher) {
+        val discussionId = "discussion-1"
+        val inputs = arrayOf("/tmp/a.jpg")
+
+        coEvery { imageRepository["saveImage"](mockContext, any<String>(), any<String>()) } throws
+            RuntimeException("Storage failed")
+
+        imageRepository.saveSessionPhotos(mockContext, discussionId, *inputs)
+      }
+
+
+
+  @Test(expected = RuntimeException::class)
+  fun `deleteSessionPhoto propagates exception when storage fails`() =
+      runTest(testDispatcher) {
+        val discussionId = "discussion-1"
+        val photoUuid = "uuid-1"
+        val expectedPath = "discussions/$discussionId/session/$photoUuid.webp"
+
+        coEvery { imageRepository["deleteImages"](mockContext, arrayOf(expectedPath)) } throws
+            RuntimeException("Delete failed")
+
+        imageRepository.deleteSessionPhoto(mockContext, discussionId, photoUuid)
+      }
+
+  @Test
+  fun `deleteSessionPhoto deletes from storage and returns uuid`() =
+      runTest(testDispatcher) {
+        val discussionId = "discussion-1"
+        val photoUuid = "uuid-1"
+        val expectedPath = "discussions/$discussionId/session/$photoUuid.webp"
+
+        coEvery { imageRepository["deleteImages"](mockContext, arrayOf(expectedPath)) } returns Unit
+
+        val result = imageRepository.deleteSessionPhoto(mockContext, discussionId, photoUuid)
+
+        assertEquals(photoUuid, result)
+        coVerify {
+          imageRepository["deleteImages"](mockContext, arrayOf(expectedPath))
+        }
+      }
+}

--- a/app/src/test/java/com/github/meeplemeet/model/SessionOverviewViewModelTest.kt
+++ b/app/src/test/java/com/github/meeplemeet/model/SessionOverviewViewModelTest.kt
@@ -80,22 +80,28 @@ class SessionOverviewViewModelTest {
       runTest(testDispatcher) {
         val userId = "user-123"
         val sessionIds = listOf("session-1", "session-2")
-        val photo1 = com.github.meeplemeet.model.sessions.SessionPhoto("uuid-1", "https://example.com/photo1.webp")
-        val photo2 = com.github.meeplemeet.model.sessions.SessionPhoto("uuid-2", "https://example.com/photo2.webp")
-        val session1 = Session(
-            name = "Game Night 1",
-            gameId = "game-1",
-            date = Timestamp.now(),
-            location = Location(0.0, 0.0, "Location 1"),
-            participants = listOf(userId),
-            sessionPhotos = listOf(photo1))
-        val session2 = Session(
-            name = "Game Night 2",
-            gameId = "game-2",
-            date = Timestamp.now(),
-            location = Location(0.0, 0.0, "Location 2"),
-            participants = listOf(userId),
-            sessionPhotos = listOf(photo2))
+        val photo1 =
+            com.github.meeplemeet.model.sessions.SessionPhoto(
+                "uuid-1", "https://example.com/photo1.webp")
+        val photo2 =
+            com.github.meeplemeet.model.sessions.SessionPhoto(
+                "uuid-2", "https://example.com/photo2.webp")
+        val session1 =
+            Session(
+                name = "Game Night 1",
+                gameId = "game-1",
+                date = Timestamp.now(),
+                location = Location(0.0, 0.0, "Location 1"),
+                participants = listOf(userId),
+                sessionPhotos = listOf(photo1))
+        val session2 =
+            Session(
+                name = "Game Night 2",
+                gameId = "game-2",
+                date = Timestamp.now(),
+                location = Location(0.0, 0.0, "Location 2"),
+                participants = listOf(userId),
+                sessionPhotos = listOf(photo2))
         var result: Result<List<com.github.meeplemeet.model.sessions.SessionPhoto>>? = null
 
         coEvery { mockSessionRepository.getPastSessionIdsForUser(userId) } returns sessionIds
@@ -132,20 +138,22 @@ class SessionOverviewViewModelTest {
       runTest(testDispatcher) {
         val userId = "user-123"
         val sessionIds = listOf("session-1", "session-2")
-        val session1 = Session(
-            name = "Game Night 1",
-            gameId = "game-1",
-            date = Timestamp.now(),
-            location = Location(0.0, 0.0, "Location 1"),
-            participants = listOf(userId),
-            sessionPhotos = emptyList())
-        val session2 = Session(
-            name = "Game Night 2",
-            gameId = "game-2",
-            date = Timestamp.now(),
-            location = Location(0.0, 0.0, "Location 2"),
-            participants = listOf(userId),
-            sessionPhotos = emptyList())
+        val session1 =
+            Session(
+                name = "Game Night 1",
+                gameId = "game-1",
+                date = Timestamp.now(),
+                location = Location(0.0, 0.0, "Location 1"),
+                participants = listOf(userId),
+                sessionPhotos = emptyList())
+        val session2 =
+            Session(
+                name = "Game Night 2",
+                gameId = "game-2",
+                date = Timestamp.now(),
+                location = Location(0.0, 0.0, "Location 2"),
+                participants = listOf(userId),
+                sessionPhotos = emptyList())
         var result: Result<List<com.github.meeplemeet.model.sessions.SessionPhoto>>? = null
 
         coEvery { mockSessionRepository.getPastSessionIdsForUser(userId) } returns sessionIds
@@ -165,8 +173,12 @@ class SessionOverviewViewModelTest {
         val userId = "user-123"
         val photoUuid = "photo-uuid-1"
         val sessionIds = listOf("session-1", "session-2")
-        val photo1 = com.github.meeplemeet.model.sessions.SessionPhoto(photoUuid, "https://example.com/photo1.webp")
-        val photo2 = com.github.meeplemeet.model.sessions.SessionPhoto("other-uuid", "https://example.com/photo2.webp")
+        val photo1 =
+            com.github.meeplemeet.model.sessions.SessionPhoto(
+                photoUuid, "https://example.com/photo1.webp")
+        val photo2 =
+            com.github.meeplemeet.model.sessions.SessionPhoto(
+                "other-uuid", "https://example.com/photo2.webp")
         val session1 =
             Session(
                 name = "Game Night 1",
@@ -203,8 +215,12 @@ class SessionOverviewViewModelTest {
         val userId = "user-123"
         val photoUuid = "non-existent-uuid"
         val sessionIds = listOf("session-1", "session-2")
-        val photo1 = com.github.meeplemeet.model.sessions.SessionPhoto("other-uuid-1", "https://example.com/photo1.webp")
-        val photo2 = com.github.meeplemeet.model.sessions.SessionPhoto("other-uuid-2", "https://example.com/photo2.webp")
+        val photo1 =
+            com.github.meeplemeet.model.sessions.SessionPhoto(
+                "other-uuid-1", "https://example.com/photo1.webp")
+        val photo2 =
+            com.github.meeplemeet.model.sessions.SessionPhoto(
+                "other-uuid-2", "https://example.com/photo2.webp")
         val session1 =
             Session(
                 name = "Game Night 1",
@@ -256,9 +272,15 @@ class SessionOverviewViewModelTest {
         val userId = "user-123"
         val photoUuid = "photo-uuid"
         val sessionIds = listOf("session-1", "session-2", "session-3")
-        val photo1 = com.github.meeplemeet.model.sessions.SessionPhoto("other-uuid", "https://example.com/photo1.webp")
-        val photo2 = com.github.meeplemeet.model.sessions.SessionPhoto(photoUuid, "https://example.com/photo2.webp")
-        val photo3 = com.github.meeplemeet.model.sessions.SessionPhoto("another-uuid", "https://example.com/photo3.webp")
+        val photo1 =
+            com.github.meeplemeet.model.sessions.SessionPhoto(
+                "other-uuid", "https://example.com/photo1.webp")
+        val photo2 =
+            com.github.meeplemeet.model.sessions.SessionPhoto(
+                photoUuid, "https://example.com/photo2.webp")
+        val photo3 =
+            com.github.meeplemeet.model.sessions.SessionPhoto(
+                "another-uuid", "https://example.com/photo3.webp")
         val session1 =
             Session(
                 name = "Game Night 1",

--- a/app/src/test/java/com/github/meeplemeet/model/SessionOverviewViewModelTest.kt
+++ b/app/src/test/java/com/github/meeplemeet/model/SessionOverviewViewModelTest.kt
@@ -1,0 +1,305 @@
+package com.github.meeplemeet.model
+
+import android.content.Context
+import com.github.meeplemeet.RepositoryProvider
+import com.github.meeplemeet.model.images.ImageRepository
+import com.github.meeplemeet.model.sessions.Session
+import com.github.meeplemeet.model.sessions.SessionOverviewViewModel
+import com.github.meeplemeet.model.sessions.SessionRepository
+import com.github.meeplemeet.model.shared.game.GameRepository
+import com.github.meeplemeet.model.shared.location.Location
+import com.google.firebase.Timestamp
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SessionOverviewViewModelTest {
+
+  private val testDispatcher = StandardTestDispatcher()
+  private lateinit var viewModel: SessionOverviewViewModel
+  private lateinit var mockSessionRepository: SessionRepository
+  private lateinit var mockGameRepository: GameRepository
+  private lateinit var mockImageRepository: ImageRepository
+  private lateinit var mockContext: Context
+
+  @Before
+  fun setUp() {
+    Dispatchers.setMain(testDispatcher)
+
+    mockSessionRepository = mockk(relaxed = true)
+    mockGameRepository = mockk(relaxed = true)
+    mockImageRepository = mockk(relaxed = true)
+    mockContext = mockk(relaxed = true)
+
+    mockkStatic("com.google.firebase.FirebaseApp")
+    mockkStatic("com.google.firebase.firestore.FirebaseFirestore")
+    mockkStatic("com.google.firebase.storage.FirebaseStorage")
+
+    every { com.google.firebase.FirebaseApp.initializeApp(any()) } returns mockk()
+    every { com.google.firebase.FirebaseApp.getInstance() } returns mockk()
+
+    every { com.google.firebase.firestore.FirebaseFirestore.getInstance() } returns
+        mockk(relaxed = true)
+    every { com.google.firebase.storage.FirebaseStorage.getInstance() } returns
+        mockk(relaxed = true)
+
+    mockkObject(RepositoryProvider)
+    every { RepositoryProvider.sessions } returns mockSessionRepository
+    every { RepositoryProvider.images } returns mockImageRepository
+    every { RepositoryProvider.discussions } returns mockk(relaxed = true)
+    every { RepositoryProvider.geoPins } returns mockk(relaxed = true)
+
+    viewModel =
+        SessionOverviewViewModel(mockSessionRepository, mockGameRepository, mockImageRepository)
+  }
+
+  @After
+  fun tearDown() {
+    Dispatchers.resetMain()
+    unmockkAll()
+  }
+
+  @Test
+  fun `loadAllPhotosForAUser loads photos from all past sessions`() =
+      runTest(testDispatcher) {
+        val userId = "user-123"
+        val sessionIds = listOf("session-1", "session-2")
+        val photo1 = com.github.meeplemeet.model.sessions.SessionPhoto("uuid-1", "https://example.com/photo1.webp")
+        val photo2 = com.github.meeplemeet.model.sessions.SessionPhoto("uuid-2", "https://example.com/photo2.webp")
+        val session1 = Session(
+            name = "Game Night 1",
+            gameId = "game-1",
+            date = Timestamp.now(),
+            location = Location(0.0, 0.0, "Location 1"),
+            participants = listOf(userId),
+            sessionPhotos = listOf(photo1))
+        val session2 = Session(
+            name = "Game Night 2",
+            gameId = "game-2",
+            date = Timestamp.now(),
+            location = Location(0.0, 0.0, "Location 2"),
+            participants = listOf(userId),
+            sessionPhotos = listOf(photo2))
+        var result: Result<List<com.github.meeplemeet.model.sessions.SessionPhoto>>? = null
+
+        coEvery { mockSessionRepository.getPastSessionIdsForUser(userId) } returns sessionIds
+        coEvery { mockSessionRepository.getSession("session-1") } returns session1
+        coEvery { mockSessionRepository.getSession("session-2") } returns session2
+
+        viewModel.loadAllPhotosForAUser(userId) { result = it }
+        advanceUntilIdle()
+
+        assertEquals(true, result?.isSuccess)
+        val photos = result?.getOrNull()
+        assertEquals(2, photos?.size)
+        assertEquals("uuid-1", photos?.get(0)?.uuid)
+        assertEquals("uuid-2", photos?.get(1)?.uuid)
+      }
+
+  @Test
+  fun `loadAllPhotosForAUser returns empty list when user has no sessions`() =
+      runTest(testDispatcher) {
+        val userId = "user-123"
+        var result: Result<List<com.github.meeplemeet.model.sessions.SessionPhoto>>? = null
+
+        coEvery { mockSessionRepository.getPastSessionIdsForUser(userId) } returns emptyList()
+
+        viewModel.loadAllPhotosForAUser(userId) { result = it }
+        advanceUntilIdle()
+
+        assertEquals(true, result?.isSuccess)
+        assertEquals(emptyList(), result?.getOrNull())
+      }
+
+  @Test
+  fun `loadAllPhotosForAUser handles sessions with no photos`() =
+      runTest(testDispatcher) {
+        val userId = "user-123"
+        val sessionIds = listOf("session-1", "session-2")
+        val session1 = Session(
+            name = "Game Night 1",
+            gameId = "game-1",
+            date = Timestamp.now(),
+            location = Location(0.0, 0.0, "Location 1"),
+            participants = listOf(userId),
+            sessionPhotos = emptyList())
+        val session2 = Session(
+            name = "Game Night 2",
+            gameId = "game-2",
+            date = Timestamp.now(),
+            location = Location(0.0, 0.0, "Location 2"),
+            participants = listOf(userId),
+            sessionPhotos = emptyList())
+        var result: Result<List<com.github.meeplemeet.model.sessions.SessionPhoto>>? = null
+
+        coEvery { mockSessionRepository.getPastSessionIdsForUser(userId) } returns sessionIds
+        coEvery { mockSessionRepository.getSession("session-1") } returns session1
+        coEvery { mockSessionRepository.getSession("session-2") } returns session2
+
+        viewModel.loadAllPhotosForAUser(userId) { result = it }
+        advanceUntilIdle()
+
+        assertEquals(true, result?.isSuccess)
+        assertEquals(emptyList(), result?.getOrNull())
+      }
+
+  @Test
+  fun `getSessionFromPhoto finds session containing the photo`() =
+      runTest(testDispatcher) {
+        val userId = "user-123"
+        val photoUuid = "photo-uuid-1"
+        val sessionIds = listOf("session-1", "session-2")
+        val photo1 = com.github.meeplemeet.model.sessions.SessionPhoto(photoUuid, "https://example.com/photo1.webp")
+        val photo2 = com.github.meeplemeet.model.sessions.SessionPhoto("other-uuid", "https://example.com/photo2.webp")
+        val session1 =
+            Session(
+                name = "Game Night 1",
+                gameId = "game-1",
+                date = Timestamp.now(),
+                location = Location(0.0, 0.0, "Location 1"),
+                participants = listOf(userId),
+                sessionPhotos = listOf(photo1))
+        val session2 =
+            Session(
+                name = "Game Night 2",
+                gameId = "game-2",
+                date = Timestamp.now(),
+                location = Location(0.0, 0.0, "Location 2"),
+                participants = listOf(userId),
+                sessionPhotos = listOf(photo2))
+        var result: Result<Session?>? = null
+
+        coEvery { mockSessionRepository.getPastSessionIdsForUser(userId) } returns sessionIds
+        coEvery { mockSessionRepository.getSession("session-1") } returns session1
+        coEvery { mockSessionRepository.getSession("session-2") } returns session2
+
+        viewModel.getSessionFromPhoto(userId, photoUuid) { result = it }
+        advanceUntilIdle()
+
+        assertEquals(true, result?.isSuccess)
+        assertEquals(session1, result?.getOrNull())
+        assertEquals("Game Night 1", result?.getOrNull()?.name)
+      }
+
+  @Test
+  fun `getSessionFromPhoto returns null when photo not found`() =
+      runTest(testDispatcher) {
+        val userId = "user-123"
+        val photoUuid = "non-existent-uuid"
+        val sessionIds = listOf("session-1", "session-2")
+        val photo1 = com.github.meeplemeet.model.sessions.SessionPhoto("other-uuid-1", "https://example.com/photo1.webp")
+        val photo2 = com.github.meeplemeet.model.sessions.SessionPhoto("other-uuid-2", "https://example.com/photo2.webp")
+        val session1 =
+            Session(
+                name = "Game Night 1",
+                gameId = "game-1",
+                date = Timestamp.now(),
+                location = Location(0.0, 0.0, "Location 1"),
+                participants = listOf(userId),
+                sessionPhotos = listOf(photo1))
+        val session2 =
+            Session(
+                name = "Game Night 2",
+                gameId = "game-2",
+                date = Timestamp.now(),
+                location = Location(0.0, 0.0, "Location 2"),
+                participants = listOf(userId),
+                sessionPhotos = listOf(photo2))
+        var result: Result<Session?>? = null
+
+        coEvery { mockSessionRepository.getPastSessionIdsForUser(userId) } returns sessionIds
+        coEvery { mockSessionRepository.getSession("session-1") } returns session1
+        coEvery { mockSessionRepository.getSession("session-2") } returns session2
+
+        viewModel.getSessionFromPhoto(userId, photoUuid) { result = it }
+        advanceUntilIdle()
+
+        assertEquals(true, result?.isSuccess)
+        assertNull(result?.getOrNull())
+      }
+
+  @Test
+  fun `getSessionFromPhoto returns null when user has no sessions`() =
+      runTest(testDispatcher) {
+        val userId = "user-123"
+        val photoUuid = "photo-uuid"
+        var result: Result<Session?>? = null
+
+        coEvery { mockSessionRepository.getPastSessionIdsForUser(userId) } returns emptyList()
+
+        viewModel.getSessionFromPhoto(userId, photoUuid) { result = it }
+        advanceUntilIdle()
+
+        assertEquals(true, result?.isSuccess)
+        assertNull(result?.getOrNull())
+      }
+
+  @Test
+  fun `getSessionFromPhoto searches all sessions in parallel`() =
+      runTest(testDispatcher) {
+        val userId = "user-123"
+        val photoUuid = "photo-uuid"
+        val sessionIds = listOf("session-1", "session-2", "session-3")
+        val photo1 = com.github.meeplemeet.model.sessions.SessionPhoto("other-uuid", "https://example.com/photo1.webp")
+        val photo2 = com.github.meeplemeet.model.sessions.SessionPhoto(photoUuid, "https://example.com/photo2.webp")
+        val photo3 = com.github.meeplemeet.model.sessions.SessionPhoto("another-uuid", "https://example.com/photo3.webp")
+        val session1 =
+            Session(
+                name = "Game Night 1",
+                gameId = "game-1",
+                date = Timestamp.now(),
+                location = Location(0.0, 0.0, "Location 1"),
+                participants = listOf(userId),
+                sessionPhotos = listOf(photo1))
+        val session2 =
+            Session(
+                name = "Game Night 2",
+                gameId = "game-2",
+                date = Timestamp.now(),
+                location = Location(0.0, 0.0, "Location 2"),
+                participants = listOf(userId),
+                sessionPhotos = listOf(photo2))
+        val session3 =
+            Session(
+                name = "Game Night 3",
+                gameId = "game-3",
+                date = Timestamp.now(),
+                location = Location(0.0, 0.0, "Location 3"),
+                participants = listOf(userId),
+                sessionPhotos = listOf(photo3))
+        var result: Result<Session?>? = null
+
+        coEvery { mockSessionRepository.getPastSessionIdsForUser(userId) } returns sessionIds
+        coEvery { mockSessionRepository.getSession("session-1") } returns session1
+        coEvery { mockSessionRepository.getSession("session-2") } returns session2
+        coEvery { mockSessionRepository.getSession("session-3") } returns session3
+
+        viewModel.getSessionFromPhoto(userId, photoUuid) { result = it }
+        advanceUntilIdle()
+
+        assertEquals(true, result?.isSuccess)
+        assertEquals(session2, result?.getOrNull())
+        assertEquals("Game Night 2", result?.getOrNull()?.name)
+
+        // Verify all sessions were checked (parallel search)
+        io.mockk.coVerify { mockSessionRepository.getSession("session-1") }
+        io.mockk.coVerify { mockSessionRepository.getSession("session-2") }
+        io.mockk.coVerify { mockSessionRepository.getSession("session-3") }
+      }
+}

--- a/app/src/test/java/com/github/meeplemeet/model/SessionRepositoryTest.kt
+++ b/app/src/test/java/com/github/meeplemeet/model/SessionRepositoryTest.kt
@@ -1,0 +1,190 @@
+package com.github.meeplemeet.model
+
+import com.github.meeplemeet.RepositoryProvider
+import com.github.meeplemeet.model.discussions.DiscussionRepository
+import com.github.meeplemeet.model.sessions.SessionRepository
+import com.google.android.gms.tasks.Task
+import com.google.firebase.Timestamp
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.FieldPath
+import com.google.firebase.firestore.FieldValue
+import com.google.firebase.firestore.Query
+import com.google.firebase.firestore.QuerySnapshot
+import com.google.firebase.firestore.snapshots
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import kotlin.test.assertEquals
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SessionRepositoryTest {
+
+  private val testDispatcher = StandardTestDispatcher()
+  private lateinit var sessionRepository: SessionRepository
+  private lateinit var discussionRepository: DiscussionRepository
+  private lateinit var collectionReference: CollectionReference
+
+  @Before
+  fun setUp() {
+    Dispatchers.setMain(testDispatcher)
+    mockkObject(RepositoryProvider)
+    discussionRepository = mockk(relaxed = true)
+    collectionReference = mockk(relaxed = true)
+
+    every { RepositoryProvider.discussions } returns discussionRepository
+    every { discussionRepository.collection } returns collectionReference
+    every { RepositoryProvider.geoPins } returns mockk(relaxed = true)
+
+    sessionRepository = SessionRepository(discussionRepository)
+
+    mockkStatic("kotlinx.coroutines.tasks.TasksKt")
+    mockkStatic("com.google.firebase.firestore.FirestoreKt")
+    mockkStatic(FieldPath::class)
+    mockkStatic(FieldValue::class)
+  }
+
+  @After
+  fun tearDown() {
+    Dispatchers.resetMain()
+    unmockkAll()
+  }
+
+  @Test
+  fun `getUpcomingSessionIdsForUserFlow filters for future sessions`() =
+      runTest(testDispatcher) {
+        val userId = "user1"
+        val query1 = mockk<Query>()
+        val query2 = mockk<Query>()
+        val snapshot = mockk<QuerySnapshot>()
+        val doc1 = mockk<DocumentSnapshot>()
+
+        // Mock the chain: whereArrayContains -> whereGreaterThan(now) -> snapshots
+        every { collectionReference.whereArrayContains("session.participants", userId) } returns
+            query1
+
+        // Verify that we are filtering by date > now
+        every { query1.whereGreaterThan(eq("session.date"), any<Timestamp>()) } returns query2
+        every { query2.snapshots() } returns flowOf(snapshot)
+
+        every { snapshot.documents } returns listOf(doc1)
+        every { doc1.id } returns "futureSession"
+
+        val result = sessionRepository.getUpcomingSessionIdsForUserFlow(userId).toList()
+
+        assertEquals(1, result.size)
+        assertEquals(listOf("futureSession"), result[0])
+
+        // Verify the specific query construction
+        io.mockk.verify { query1.whereGreaterThan(eq("session.date"), any<Timestamp>()) }
+      }
+
+  @Test
+  fun `getPastSessionIdsForUser filters for past sessions`() =
+      runTest(testDispatcher) {
+        val userId = "user1"
+        val query1 = mockk<Query>()
+        val query2 = mockk<Query>()
+        val query3 = mockk<Query>()
+        val query4 = mockk<Query>()
+        val query5 = mockk<Query>()
+        val task = mockk<Task<QuerySnapshot>>()
+        val snapshot = mockk<QuerySnapshot>()
+        val doc1 = mockk<DocumentSnapshot>()
+
+        // Mock the chain: whereArrayContains -> whereLessThan(now) -> orderBy(date) -> orderBy(id) -> limit -> get
+        every { collectionReference.whereArrayContains("session.participants", userId) } returns
+            query1
+
+        // Verify that we are filtering by date < now
+        every { query1.whereLessThan(eq("session.date"), any<Timestamp>()) } returns query2
+        every { query2.orderBy("session.date") } returns query3
+        every { query3.orderBy(any<FieldPath>()) } returns query4
+        every { query4.limit(any()) } returns query5
+        every { query5.get() } returns task
+        coEvery { task.await() } returns snapshot
+
+        every { snapshot.isEmpty } returns false
+        every { snapshot.documents } returns listOf(doc1)
+        every { snapshot.size() } returns 1
+        every { doc1.id } returns "pastSession"
+
+        val result = sessionRepository.getPastSessionIdsForUser(userId)
+
+        assertEquals(listOf("pastSession"), result)
+
+        // Verify the specific query construction includes orderBy date
+        io.mockk.verify { 
+          query1.whereLessThan(eq("session.date"), any<Timestamp>())
+          query2.orderBy("session.date")
+        }
+      }
+
+  @Test
+  fun `addSessionPhotos updates session with new photos`() =
+      runTest(testDispatcher) {
+        val discussionId = "discussion-1"
+        val photos = listOf(
+            com.github.meeplemeet.model.sessions.SessionPhoto("uuid-1", "url-1"),
+            com.github.meeplemeet.model.sessions.SessionPhoto("uuid-2", "url-2")
+        )
+        val docRef = mockk<com.google.firebase.firestore.DocumentReference>(relaxed = true)
+        val mockFieldValue = mockk<FieldValue>()
+
+        every { collectionReference.document(discussionId) } returns docRef
+        every { FieldValue.arrayUnion(*anyVararg()) } returns mockFieldValue
+        coEvery { docRef.update(any<String>(), any()).await() } returns mockk()
+
+        sessionRepository.addSessionPhotos(discussionId, photos)
+
+        io.mockk.verify {
+          docRef.update("session.sessionPhotos", mockFieldValue)
+        }
+        io.mockk.verify {
+          FieldValue.arrayUnion(*photos.toTypedArray())
+        }
+      }
+
+  @Test
+  fun `removeSessionPhoto removes photo from session`() =
+      runTest(testDispatcher) {
+        val discussionId = "discussion-1"
+        val photoUuid = "uuid-1"
+        val docRef = mockk<com.google.firebase.firestore.DocumentReference>(relaxed = true)
+        val snapshot = mockk<DocumentSnapshot>()
+        val session = com.github.meeplemeet.model.sessions.Session(
+            sessionPhotos = listOf(
+                com.github.meeplemeet.model.sessions.SessionPhoto("uuid-1", "url-1"),
+                com.github.meeplemeet.model.sessions.SessionPhoto("uuid-2", "url-2")
+            )
+        )
+        val discussionNoUid = com.github.meeplemeet.model.discussions.DiscussionNoUid(session = session)
+
+        every { collectionReference.document(discussionId) } returns docRef
+        coEvery { docRef.get().await() } returns snapshot
+        every { snapshot.exists() } returns true
+        every { snapshot.toObject(com.github.meeplemeet.model.discussions.DiscussionNoUid::class.java) } returns discussionNoUid
+        coEvery { docRef.update(any<String>(), any()).await() } returns mockk()
+
+        sessionRepository.removeSessionPhoto(discussionId, photoUuid)
+
+        io.mockk.verify {
+          docRef.update("session.sessionPhotos", listOf(com.github.meeplemeet.model.sessions.SessionPhoto("uuid-2", "url-2")))
+        }
+      }
+}

--- a/app/src/test/java/com/github/meeplemeet/model/SessionViewModelTest.kt
+++ b/app/src/test/java/com/github/meeplemeet/model/SessionViewModelTest.kt
@@ -1,0 +1,187 @@
+package com.github.meeplemeet.model
+
+import android.content.Context
+import com.github.meeplemeet.RepositoryProvider
+import com.github.meeplemeet.model.images.ImageRepository
+import com.github.meeplemeet.model.sessions.SessionRepository
+import com.github.meeplemeet.model.sessions.SessionViewModel
+import io.mockk.Awaits
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SessionViewModelTest {
+  private val testDispatcher = StandardTestDispatcher()
+  private lateinit var sessionViewModel: SessionViewModel
+  private lateinit var mockSessionRepository: SessionRepository
+  private lateinit var mockImageRepository: ImageRepository
+  private lateinit var mockContext: Context
+
+  @Before
+  fun setUp() {
+    Dispatchers.setMain(testDispatcher)
+
+    mockkObject(RepositoryProvider)
+    mockSessionRepository = mockk(relaxed = true)
+    mockImageRepository = mockk(relaxed = true)
+    mockContext = mockk(relaxed = true)
+
+    mockkStatic("com.google.firebase.FirebaseApp")
+    mockkStatic("com.google.firebase.firestore.FirebaseFirestore")
+    mockkStatic("com.google.firebase.storage.FirebaseStorage")
+
+    every { com.google.firebase.FirebaseApp.initializeApp(any()) } returns mockk()
+    every { com.google.firebase.FirebaseApp.getInstance() } returns mockk()
+
+    every { com.google.firebase.firestore.FirebaseFirestore.getInstance() } returns
+        mockk(relaxed = true)
+    every { com.google.firebase.storage.FirebaseStorage.getInstance() } returns
+        mockk(relaxed = true)
+
+    every { RepositoryProvider.sessions } returns mockSessionRepository
+    every { RepositoryProvider.images } returns mockImageRepository
+    every { RepositoryProvider.discussions } returns mockk(relaxed = true)
+    every { RepositoryProvider.geoPins } returns mockk(relaxed = true)
+
+    sessionViewModel =
+        SessionViewModel(
+            sessionRepository = mockSessionRepository, imageRepository = mockImageRepository)
+  }
+
+  @After
+  fun tearDown() {
+    Dispatchers.resetMain()
+    unmockkAll()
+  }
+
+  @Test
+  fun `addSessionPhotos successfully adds photo and clears error`() =
+      runTest(testDispatcher) {
+        val discussionId = "disc-123"
+        val photoPath = "/path/to/photo.jpg"
+        val expectedPhotos = listOf(
+            com.github.meeplemeet.model.sessions.SessionPhoto("uuid-1", "https://example.com/photo.webp")
+        )
+
+        coEvery {
+          mockImageRepository.saveSessionPhotos(mockContext, discussionId, photoPath)
+        } returns expectedPhotos
+
+        sessionViewModel.addSessionPhotos(mockContext, discussionId, photoPath)
+        advanceUntilIdle()
+
+        assertNull(sessionViewModel.errorMessage.value)
+        coVerify { mockImageRepository.saveSessionPhotos(mockContext, discussionId, photoPath) }
+        coVerify { mockSessionRepository.addSessionPhotos(discussionId, expectedPhotos) }
+      }
+
+  @Test
+  fun `addSessionPhotos sets error message on failure`() =
+      runTest(testDispatcher) {
+        val discussionId = "disc-123"
+        val photoPath = "/path/to/photo.jpg"
+        val errorMessage = "Upload failed"
+
+        coEvery {
+          mockImageRepository.saveSessionPhotos(mockContext, discussionId, photoPath)
+        } throws RuntimeException(errorMessage)
+
+        sessionViewModel.addSessionPhotos(mockContext, discussionId, photoPath)
+        advanceUntilIdle()
+
+        assertEquals("Failed to add photo: $errorMessage", sessionViewModel.errorMessage.value)
+      }
+
+  @Test
+  fun `removeSessionPhoto successfully removes photo and clears error`() =
+      runTest(testDispatcher) {
+        val discussionId = "disc-123"
+        val photoUuid = "uuid-1"
+
+        coEvery {
+          mockImageRepository.deleteSessionPhoto(mockContext, discussionId, photoUuid)
+        } just Awaits
+
+        sessionViewModel.removeSessionPhoto(mockContext, discussionId, photoUuid)
+        advanceUntilIdle()
+
+        assertNull(sessionViewModel.errorMessage.value)
+        coVerify { mockImageRepository.deleteSessionPhoto(mockContext, discussionId, photoUuid) }
+      }
+
+  @Test
+  fun `removeSessionPhoto sets error message on failure`() =
+      runTest(testDispatcher) {
+        val discussionId = "disc-123"
+        val photoUuid = "uuid-1"
+        val errorMessage = "Delete failed"
+
+        coEvery {
+          mockImageRepository.deleteSessionPhoto(mockContext, discussionId, photoUuid)
+        } throws RuntimeException(errorMessage)
+
+        sessionViewModel.removeSessionPhoto(mockContext, discussionId, photoUuid)
+        advanceUntilIdle()
+
+        assertEquals("Failed to delete photo: $errorMessage", sessionViewModel.errorMessage.value)
+      }
+
+  @Test
+  fun `loadSessionPhotos returns failure result on error`() =
+      runTest(testDispatcher) {
+        val discussionId = "disc-123"
+        val errorMessage = "Load failed"
+        var result: Result<List<Pair<String, ByteArray>>>? = null
+
+        coEvery { mockSessionRepository.getSession(discussionId) } throws
+            RuntimeException(errorMessage)
+
+        sessionViewModel.loadSessionPhotos(mockContext, discussionId) { result = it }
+        advanceUntilIdle()
+
+        assertEquals(true, result?.isFailure)
+        assertEquals(errorMessage, result?.exceptionOrNull()?.message)
+      }
+
+  @Test
+  fun `clearError resets error message to null`() =
+      runTest(testDispatcher) {
+        val discussionId = "disc-123"
+        val photoPath = "/path/to/photo.jpg"
+
+        coEvery {
+          mockImageRepository.saveSessionPhotos(mockContext, discussionId, photoPath)
+        } throws RuntimeException("Test error")
+
+        sessionViewModel.addSessionPhotos(mockContext, discussionId, photoPath)
+        advanceUntilIdle()
+
+        // Verify error is set
+        assertEquals("Failed to add photo: Test error", sessionViewModel.errorMessage.value)
+
+        // Clear error
+        sessionViewModel.clearError()
+
+        // Verify error is cleared
+        assertNull(sessionViewModel.errorMessage.value)
+      }
+}

--- a/app/src/test/java/com/github/meeplemeet/model/SessionViewModelTest.kt
+++ b/app/src/test/java/com/github/meeplemeet/model/SessionViewModelTest.kt
@@ -6,7 +6,6 @@ import com.github.meeplemeet.model.images.ImageRepository
 import com.github.meeplemeet.model.sessions.SessionRepository
 import com.github.meeplemeet.model.sessions.SessionViewModel
 import io.mockk.Awaits
-import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -78,9 +77,10 @@ class SessionViewModelTest {
       runTest(testDispatcher) {
         val discussionId = "disc-123"
         val photoPath = "/path/to/photo.jpg"
-        val expectedPhotos = listOf(
-            com.github.meeplemeet.model.sessions.SessionPhoto("uuid-1", "https://example.com/photo.webp")
-        )
+        val expectedPhotos =
+            listOf(
+                com.github.meeplemeet.model.sessions.SessionPhoto(
+                    "uuid-1", "https://example.com/photo.webp"))
 
         coEvery {
           mockImageRepository.saveSessionPhotos(mockContext, discussionId, photoPath)


### PR DESCRIPTION
**Summary :**
This pull request introduces comprehensive support for session photo attachments in the app. It adds the ability to upload, retrieve, and manage photos associated with game sessions, including backend storage, frontend data models, and new repository/viewmodel logic. The changes affect several core files and extend the session data model to include images, enabling features like photo galleries per session and user-centric photo queries.

**Description :**
* SessionPhoto : I created a new class to have the uuid and the url of a photo, this is so that from clicking on a photo, we have a way to look for the session storing that photo, so we have to store a uuid too.
* ImageRepository : I added functions to save, load, delete photos from the firebase storage via the path to the session and the uuid
* SessionRepository : I created functions to store the photo obejct (uuid, url) into the firestore database in the session
* View models : I added functions calling the functions from both repositories to have consistency between the firestore databse and the firebase storage