### PR TITLE
Feat/session photo

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/integration/ImageRepositoryTests.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/ImageRepositoryTests.kt
@@ -1107,5 +1107,46 @@ class ImageRepositoryTests : FirestoreTests() {
         }
       }
     }
+
+    // ========================================================================
+    // Session Photo Tests
+    // ========================================================================
+
+    checkpoint("Save session photo succeeds") {
+      runTest {
+        val discussionId = "test_discussion_${System.currentTimeMillis()}"
+        val testImagePath = createTestImage("session_photo.jpg", 100, 100, Color.GREEN)
+        val url = imageRepository.saveSessionPhoto(context, discussionId, testImagePath)
+        assertNotNull(url)
+        assertTrue(url.contains(discussionId))
+      }
+    }
+
+    checkpoint("Load session photo returns correct data") {
+      runTest {
+        val discussionId = "test_discussion_${System.currentTimeMillis()}"
+        val testImagePath = createTestImage("session_photo_load.jpg", 100, 100, Color.YELLOW)
+        imageRepository.saveSessionPhoto(context, discussionId, testImagePath)
+        val bytes = imageRepository.loadSessionPhoto(context, discussionId)
+        assertNotNull(bytes)
+        assertTrue(bytes.isNotEmpty())
+      }
+    }
+
+    checkpoint("Delete session photo succeeds") {
+      runTest {
+        val discussionId = "test_discussion_${System.currentTimeMillis()}"
+        val testImagePath = createTestImage("session_photo_delete.jpg", 100, 100, Color.RED)
+        imageRepository.saveSessionPhoto(context, discussionId, testImagePath)
+        imageRepository.deleteSessionPhoto(context, discussionId)
+        // Try to load after delete, should throw RemoteStorageException or DiskStorageException
+        val result = runCatching { imageRepository.loadSessionPhoto(context, discussionId) }
+        assertTrue(result.isFailure)
+        val exception = result.exceptionOrNull()
+        assertTrue(
+            exception is com.github.meeplemeet.model.RemoteStorageException ||
+                exception is com.github.meeplemeet.model.DiskStorageException)
+      }
+    }
   }
 }

--- a/app/src/androidTest/java/com/github/meeplemeet/integration/SessionViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/SessionViewModelTest.kt
@@ -1,0 +1,201 @@
+package com.github.meeplemeet.integration
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import androidx.test.platform.app.InstrumentationRegistry
+import com.github.meeplemeet.model.PermissionDeniedException
+import com.github.meeplemeet.model.account.Account
+import com.github.meeplemeet.model.discussions.Discussion
+import com.github.meeplemeet.model.discussions.DiscussionNoUid
+import com.github.meeplemeet.model.discussions.fromNoUid
+import com.github.meeplemeet.model.sessions.Session
+import com.github.meeplemeet.model.sessions.SessionViewModel
+import com.github.meeplemeet.utils.FirestoreTests
+import java.io.File
+import java.io.FileOutputStream
+import junit.framework.TestCase.*
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.tasks.await
+import org.junit.Before
+import org.junit.Test
+
+class SessionViewModelTest : FirestoreTests() {
+
+  private lateinit var viewModel: SessionViewModel
+  private lateinit var adminAccount: Account
+  private lateinit var nonAdminAccount: Account
+  private lateinit var discussion: Discussion
+  private lateinit var testImageFile: File
+
+  @Before
+  fun setUp() = runBlocking {
+    viewModel = SessionViewModel()
+
+    // Sign in anonymously for Firebase Storage access
+    auth.signInAnonymously().await()
+
+    // Create test accounts
+    adminAccount =
+        Account(
+            uid = "admin-uid",
+            handle = "adminHandle",
+            name = "Admin User",
+            email = "admin@test.com",
+            previews = emptyMap(),
+            photoUrl = null,
+            description = "Test admin user",
+            shopOwner = false,
+            spaceRenter = false,
+            relationships = emptyMap(),
+            notifications = emptyList())
+
+    nonAdminAccount =
+        Account(
+            uid = "non-admin-uid",
+            handle = "nonAdminHandle",
+            name = "NonAdmin User",
+            email = "nonadmin@test.com",
+            previews = emptyMap(),
+            photoUrl = null,
+            description = "Test non-admin user",
+            shopOwner = false,
+            spaceRenter = false,
+            relationships = emptyMap(),
+            notifications = emptyList())
+
+    // Create test discussion with session
+    discussion =
+        Discussion(
+            uid = "test-discussion-${System.currentTimeMillis()}",
+            creatorId = adminAccount.uid,
+            name = "Test Discussion",
+            description = "A test discussion",
+            participants = listOf(adminAccount.uid, nonAdminAccount.uid),
+            admins = listOf(adminAccount.uid),
+            session = Session(name = "Test Session"))
+
+    // Create a test image file
+    val context = InstrumentationRegistry.getInstrumentation().targetContext
+    testImageFile = File(context.cacheDir, "test_image.png")
+    val bitmap = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888)
+    bitmap.eraseColor(Color.BLUE)
+    FileOutputStream(testImageFile).use { out ->
+      bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+    }
+
+    // Save the discussion to Firestore
+    db.collection("discussions").document(discussion.uid).set(discussion).await()
+    delay(500) // Wait for write to propagate
+  }
+
+  @Test
+  fun testSaveSessionPhotoAsAdmin() = runBlocking {
+    val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    // Save session photo as admin
+    viewModel.saveSessionPhoto(adminAccount, discussion, context, testImageFile.absolutePath)
+
+    delay(3000) // Wait for upload and Firestore update
+
+    // Verify the photo URL was updated in Firestore
+    val doc = db.collection("discussions").document(discussion.uid).get().await()
+    val discussionNoUid = doc.toObject(DiscussionNoUid::class.java)
+    val updatedDiscussion = fromNoUid(doc.id, discussionNoUid!!)
+
+    assertNotNull(updatedDiscussion)
+    assertNotNull(updatedDiscussion.session)
+    assertNotNull(updatedDiscussion.session?.photoUrl)
+    assertTrue(updatedDiscussion.session?.photoUrl?.isNotEmpty() == true)
+  }
+
+  @Test
+  fun testSaveSessionPhotoAsNonAdminThrowsException() = runBlocking {
+    val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    // Attempt to save session photo as non-admin should throw exception
+    try {
+      viewModel.saveSessionPhoto(nonAdminAccount, discussion, context, testImageFile.absolutePath)
+      delay(1000)
+      fail("Expected PermissionDeniedException to be thrown")
+    } catch (e: PermissionDeniedException) {
+      assertEquals("Only discussion admins can perform this operation", e.message)
+    }
+  }
+
+  @Test
+  fun testDeleteSessionPhotoAsAdmin() = runBlocking {
+    val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    // First, save a photo
+    viewModel.saveSessionPhoto(adminAccount, discussion, context, testImageFile.absolutePath)
+    delay(3000) // Wait for upload
+
+    // Verify photo was saved
+    val docAfterSave = db.collection("discussions").document(discussion.uid).get().await()
+    val discussionNoUidAfterSave = docAfterSave.toObject(DiscussionNoUid::class.java)
+    val discussionAfterSave = fromNoUid(docAfterSave.id, discussionNoUidAfterSave!!)
+
+    assertNotNull(discussionAfterSave.session?.photoUrl)
+    assertTrue(discussionAfterSave.session?.photoUrl?.isNotEmpty() == true)
+
+    // Delete the photo
+    viewModel.deleteSessionPhoto(adminAccount, discussion, context)
+    delay(2000) // Wait for deletion and Firestore update
+
+    // Verify the photo URL was set to empty string
+    val docAfterDelete = db.collection("discussions").document(discussion.uid).get().await()
+    val discussionNoUidAfterDelete = docAfterDelete.toObject(DiscussionNoUid::class.java)
+    val discussionAfterDelete = fromNoUid(docAfterDelete.id, discussionNoUidAfterDelete!!)
+
+    assertNotNull(discussionAfterDelete)
+    assertNotNull(discussionAfterDelete.session)
+    assertEquals(null, discussionAfterDelete.session?.photoUrl)
+  }
+
+  @Test
+  fun testDeleteSessionPhotoAsNonAdminThrowsException() = runBlocking {
+    val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    // Attempt to delete session photo as non-admin should throw exception
+    try {
+      viewModel.deleteSessionPhoto(nonAdminAccount, discussion, context)
+      delay(1000)
+      fail("Expected PermissionDeniedException to be thrown")
+    } catch (e: PermissionDeniedException) {
+      assertEquals("Only discussion admins can perform this operation", e.message)
+    }
+  }
+
+  @Test
+  fun testLoadSessionPhoto() = runBlocking {
+    val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    // First, save a photo
+    viewModel.saveSessionPhoto(adminAccount, discussion, context, testImageFile.absolutePath)
+    delay(3000) // Wait for upload
+
+    // Load the photo (no admin check for read operation)
+    val loadedPhotoBytes = viewModel.loadSessionPhoto(discussion, context)
+
+    // Verify the photo was loaded successfully
+    assertNotNull(loadedPhotoBytes)
+    assertTrue(loadedPhotoBytes.isNotEmpty())
+  }
+
+  @Test
+  fun testLoadSessionPhotoAsNonAdmin() = runBlocking {
+    val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    // First, save a photo as admin
+    viewModel.saveSessionPhoto(adminAccount, discussion, context, testImageFile.absolutePath)
+    delay(3000) // Wait for upload
+
+    // Non-admin should be able to load the photo (read operation)
+    val loadedPhotoBytes = viewModel.loadSessionPhoto(discussion, context)
+
+    // Verify the photo was loaded successfully
+    assertNotNull(loadedPhotoBytes)
+    assertTrue(loadedPhotoBytes.isNotEmpty())
+  }
+}

--- a/app/src/main/java/com/github/meeplemeet/model/images/ImageRepository.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/images/ImageRepository.kt
@@ -99,7 +99,7 @@ class ImageRepository(private val dispatcher: CoroutineDispatcher = Dispatchers.
 
   private fun discussionProfilePath(id: String) = "${discussionBasePath(id)}/profile.webp"
 
-  private fun sessionPhotoPath(id: String) = "discussions/${id}/session/photo.webp"
+  private fun sessionPhotoPath(id: String) = "${discussionBasePath(id)}/session.webp"
 
   private fun discussionMessagesDir(id: String) = "${discussionBasePath(id)}/messages"
 

--- a/app/src/main/java/com/github/meeplemeet/model/images/ImageRepository.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/images/ImageRepository.kt
@@ -99,6 +99,8 @@ class ImageRepository(private val dispatcher: CoroutineDispatcher = Dispatchers.
 
   private fun discussionProfilePath(id: String) = "${discussionBasePath(id)}/profile.webp"
 
+  private fun sessionPhotoPath(id: String) = "discussions/${id}/session/photo.webp"
+
   private fun discussionMessagesDir(id: String) = "${discussionBasePath(id)}/messages"
 
   private fun discussionMessagePath(id: String) =
@@ -206,6 +208,64 @@ class ImageRepository(private val dispatcher: CoroutineDispatcher = Dispatchers.
    */
   suspend fun loadDiscussionProfilePicture(context: Context, discussionId: String): ByteArray =
       loadImage(context, discussionProfilePath(discussionId))
+
+  /**
+   * Saves a session photo to Firebase Storage and local cache.
+   *
+   * Session photos are stored at a fixed path `discussions/{discussionId}/session/photo.webp`. This
+   * operation requires admin privileges in the discussion (enforced by caller).
+   *
+   * ## Usage
+   * Typically called by [SessionViewModel.saveSessionPhoto], which handles permission checks and
+   * updates the session document with the returned photo URL.
+   *
+   * @param context Android context for accessing cache directory
+   * @param discussionId The unique identifier for the discussion containing the session
+   * @param inputPath Absolute path to the source image file (from gallery or camera)
+   * @return The public HTTPS download URL of the saved session photo
+   * @throws ImageProcessingException if image encoding fails
+   * @throws DiskStorageException if disk write fails
+   * @throws RemoteStorageException if Firebase Storage upload fails
+   * @see SessionViewModel.saveSessionPhoto for high-level API
+   * @see loadSessionPhoto to retrieve the session photo
+   * @see deleteSessionPhoto to delete the session photo
+   */
+  suspend fun saveSessionPhoto(context: Context, discussionId: String, inputPath: String): String =
+      saveImage(context, inputPath, sessionPhotoPath(discussionId))
+
+  /**
+   * Deletes the session photo from both cache and Firebase Storage.
+   *
+   * Removes the session photo stored at `discussions/{discussionId}/session/photo.webp`. This
+   * operation requires admin privileges in the discussion (enforced by caller).
+   *
+   * @param context Android context for accessing cache directory
+   * @param discussionId The unique identifier for the discussion containing the session
+   * @throws DiskStorageException if disk delete fails
+   * @throws RemoteStorageException if Firebase Storage delete fails
+   * @see SessionViewModel.deleteSessionPhoto for high-level API
+   * @see saveSessionPhoto to upload a session photo
+   */
+  suspend fun deleteSessionPhoto(context: Context, discussionId: String) =
+      deleteImages(context, sessionPhotoPath(discussionId))
+
+  /**
+   * Loads the session photo from cache or Firebase Storage.
+   *
+   * Checks local cache first; on cache miss, downloads from Firebase Storage and caches locally.
+   * The image is returned as a byte array in WebP format.
+   *
+   * @param context Android context for accessing cache directory
+   * @param discussionId The unique identifier for the discussion containing the session
+   * @return The image as a byte array in WebP format
+   * @throws DiskStorageException if disk read fails
+   * @throws RemoteStorageException if Firebase Storage download fails or session photo doesn't
+   *   exist
+   * @see SessionViewModel.loadSessionPhoto for high-level API
+   * @see saveSessionPhoto to upload a session photo
+   */
+  suspend fun loadSessionPhoto(context: Context, discussionId: String): ByteArray =
+      loadImage(context, sessionPhotoPath(discussionId))
 
   /**
    * Saves discussion message photos to Firebase Storage under unique names and returns their URLs.

--- a/app/src/main/java/com/github/meeplemeet/model/sessions/Session.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/sessions/Session.kt
@@ -15,6 +15,7 @@ import kotlinx.serialization.Serializable
  * @property date The scheduled date and time of the session
  * @property location The physical or virtual location where the session will take place
  * @property participants List of participant IDs (typically user IDs) who are part of this session
+ * @property photoUrl Optional URL to the session photo stored in Firebase Storage
  */
 @Serializable
 data class Session(
@@ -22,5 +23,6 @@ data class Session(
     val gameId: String = "",
     val date: Timestamp = Timestamp.now(),
     val location: Location = Location(),
-    val participants: List<String> = emptyList()
+    val participants: List<String> = emptyList(),
+    val photoUrl: String? = null
 )

--- a/app/src/main/java/com/github/meeplemeet/model/sessions/SessionRepository.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/sessions/SessionRepository.kt
@@ -8,6 +8,7 @@ import com.github.meeplemeet.model.map.PinType
 import com.github.meeplemeet.model.shared.location.Location
 import com.google.firebase.Timestamp
 import com.google.firebase.firestore.FieldPath
+import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.snapshots
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -58,7 +59,8 @@ class SessionRepository(
       gameId: String? = null,
       date: Timestamp? = null,
       location: Location? = null,
-      newParticipantList: List<String>? = null
+      newParticipantList: List<String>? = null,
+      photoUrl: String? = null
   ): Discussion {
     val updates = mutableMapOf<String, Any>()
 
@@ -68,6 +70,11 @@ class SessionRepository(
     location?.let { updates["${DiscussionNoUid::session.name}.${Session::location.name}"] = it }
     newParticipantList?.let {
       updates["${DiscussionNoUid::session.name}.${Session::participants.name}"] = it
+    }
+    photoUrl?.let {
+      // Use FieldValue.delete() to clear the field when empty string is passed
+      val value = if (it.isEmpty()) FieldValue.delete() else it
+      updates["${DiscussionNoUid::session.name}.${Session::photoUrl.name}"] = value
     }
 
     if (updates.isEmpty())

--- a/app/src/main/java/com/github/meeplemeet/model/sessions/SessionViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/sessions/SessionViewModel.kt
@@ -1,4 +1,5 @@
 package com.github.meeplemeet.model.sessions
+// AI was used in this file
 
 import android.content.Context
 import androidx.lifecycle.viewModelScope

--- a/app/src/main/java/com/github/meeplemeet/model/sessions/SessionViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/sessions/SessionViewModel.kt
@@ -1,10 +1,12 @@
 package com.github.meeplemeet.model.sessions
 
+import android.content.Context
 import androidx.lifecycle.viewModelScope
 import com.github.meeplemeet.RepositoryProvider
 import com.github.meeplemeet.model.PermissionDeniedException
 import com.github.meeplemeet.model.account.Account
 import com.github.meeplemeet.model.discussions.Discussion
+import com.github.meeplemeet.model.images.ImageRepository
 import com.github.meeplemeet.model.shared.location.Location
 import com.google.firebase.Timestamp
 import kotlinx.coroutines.launch
@@ -19,6 +21,7 @@ import kotlinx.coroutines.launch
  */
 class SessionViewModel(
     private val sessionRepository: SessionRepository = RepositoryProvider.sessions,
+    private val imageRepository: ImageRepository = ImageRepository()
 ) : CreateSessionViewModel() {
   /**
    * Checks if an account has admin privileges for a discussion.
@@ -107,5 +110,68 @@ class SessionViewModel(
         throw PermissionDeniedException("Only discussion admins can perform this operation")
 
     viewModelScope.launch { sessionRepository.deleteSession(discussion.uid) }
+  }
+
+  /**
+   * Saves a photo to the session and updates the session document.
+   *
+   * Requires admin privileges (requester must be a discussion admin). The photo is uploaded to
+   * Firebase Storage at `discussions/{discussionId}/session/photo.webp` and the returned URL is
+   * stored in the session's photoUrl field.
+   *
+   * @param requester The account requesting to save the photo
+   * @param discussion The discussion containing the session
+   * @param context Android context for accessing cache directory
+   * @param inputPath Absolute path to the source image file (from gallery or camera)
+   * @throws PermissionDeniedException if requester is not a discussion admin
+   */
+  fun saveSessionPhoto(
+      requester: Account,
+      discussion: Discussion,
+      context: Context,
+      inputPath: String
+  ) {
+    if (!isAdmin(requester, discussion))
+        throw PermissionDeniedException("Only discussion admins can perform this operation")
+
+    viewModelScope.launch {
+      val photoUrl = imageRepository.saveSessionPhoto(context, discussion.uid, inputPath)
+      sessionRepository.updateSession(discussion.uid, photoUrl = photoUrl)
+    }
+  }
+
+  /**
+   * Deletes the photo from the session and updates the session document.
+   *
+   * Requires admin privileges (requester must be a discussion admin). The photo is deleted from
+   * Firebase Storage and local cache, and the session's photoUrl field is set to null.
+   *
+   * @param requester The account requesting to delete the photo
+   * @param discussion The discussion containing the session
+   * @param context Android context for accessing cache directory
+   * @throws PermissionDeniedException if requester is not a discussion admin
+   */
+  fun deleteSessionPhoto(requester: Account, discussion: Discussion, context: Context) {
+    if (!isAdmin(requester, discussion))
+        throw PermissionDeniedException("Only discussion admins can perform this operation")
+
+    viewModelScope.launch {
+      imageRepository.deleteSessionPhoto(context, discussion.uid)
+      sessionRepository.updateSession(discussion.uid, photoUrl = "")
+    }
+  }
+
+  /**
+   * Loads the session photo from cache or Firebase Storage.
+   *
+   * This is a read operation and does not require admin privileges. The photo is returned as a byte
+   * array in WebP format.
+   *
+   * @param discussion The discussion containing the session
+   * @param context Android context for accessing cache directory
+   * @return The image as a byte array in WebP format
+   */
+  suspend fun loadSessionPhoto(discussion: Discussion, context: Context): ByteArray {
+    return imageRepository.loadSessionPhoto(context, discussion.uid)
   }
 }

--- a/app/src/main/java/com/github/meeplemeet/model/sessions/SessionViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/sessions/SessionViewModel.kt
@@ -109,8 +109,7 @@ class SessionViewModel(
    * @throws PermissionDeniedException if requester is not a discussion admin
    */
   fun deleteSession(requester: Account, discussion: Discussion) {
-    if (!isAdmin(requester, discussion))
-        throw PermissionDeniedException(onlyAdminErrorText)
+    if (!isAdmin(requester, discussion)) throw PermissionDeniedException(onlyAdminErrorText)
 
     viewModelScope.launch { sessionRepository.deleteSession(discussion.uid) }
   }
@@ -134,8 +133,7 @@ class SessionViewModel(
       context: Context,
       inputPath: String
   ) {
-    if (!isAdmin(requester, discussion))
-        throw PermissionDeniedException(onlyAdminErrorText)
+    if (!isAdmin(requester, discussion)) throw PermissionDeniedException(onlyAdminErrorText)
 
     viewModelScope.launch {
       val photoUrl = imageRepository.saveSessionPhoto(context, discussion.uid, inputPath)

--- a/app/src/main/java/com/github/meeplemeet/model/sessions/SessionViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/sessions/SessionViewModel.kt
@@ -12,6 +12,8 @@ import com.github.meeplemeet.model.shared.location.Location
 import com.google.firebase.Timestamp
 import kotlinx.coroutines.launch
 
+private val onlyAdminErrorText: String = "Only discussion admins can perform this operation"
+
 /**
  * ViewModel for managing gaming sessions within a discussion.
  *
@@ -72,7 +74,7 @@ class SessionViewModel(
               location == null
 
       if (!isRemovingSelfOnly) {
-        throw PermissionDeniedException("Only discussion admins can perform this operation")
+        throw PermissionDeniedException(onlyAdminErrorText)
       }
     }
 
@@ -108,7 +110,7 @@ class SessionViewModel(
    */
   fun deleteSession(requester: Account, discussion: Discussion) {
     if (!isAdmin(requester, discussion))
-        throw PermissionDeniedException("Only discussion admins can perform this operation")
+        throw PermissionDeniedException(onlyAdminErrorText)
 
     viewModelScope.launch { sessionRepository.deleteSession(discussion.uid) }
   }
@@ -133,7 +135,7 @@ class SessionViewModel(
       inputPath: String
   ) {
     if (!isAdmin(requester, discussion))
-        throw PermissionDeniedException("Only discussion admins can perform this operation")
+        throw PermissionDeniedException(onlyAdminErrorText)
 
     viewModelScope.launch {
       val photoUrl = imageRepository.saveSessionPhoto(context, discussion.uid, inputPath)


### PR DESCRIPTION
**Summary :**
This PR introduces support for storing, retrieving, and deleting session photos for discussions. The changes add a new `photoUrl` field to the session model, implement the necessary repository and view model methods, and provide comprehensive tests for these operations. This enables admins to manage session photos, which are stored in Firebase Storage and referenced in the session document.

**Description :**
* I added a field for every session to have a photo URL
* In Image Repository i create new functions on the temmplate of already existing functions and i created the view model functions callign them