### PR TITLE
Feat/profile screen main tab

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/end2end/E2E_M1.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/end2end/E2E_M1.kt
@@ -2,7 +2,6 @@ package com.github.meeplemeet.end2end
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
-import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -12,7 +11,6 @@ import androidx.test.espresso.Espresso
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.meeplemeet.MainActivity
 import com.github.meeplemeet.ui.auth.SignInScreenTestTags
-import com.github.meeplemeet.ui.navigation.MeepleMeetScreen
 import com.github.meeplemeet.ui.navigation.NavigationTestTags
 import com.github.meeplemeet.utils.AuthUtils.signInUser
 import com.github.meeplemeet.utils.AuthUtils.signOutWithBottomBar

--- a/app/src/androidTest/java/com/github/meeplemeet/end2end/E2E_M1.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/end2end/E2E_M1.kt
@@ -46,12 +46,6 @@ class E2E_M1 : FirestoreTests() {
     composeTestRule.onNodeWithTag(NavigationTestTags.DISCUSSIONS_TAB).assertExists().performClick()
     composeTestRule.onNodeWithTag(NavigationTestTags.PROFILE_TAB).assertExists().performClick()
 
-    // Verify profile screen shows
-    composeTestRule
-        .onNodeWithTag(NavigationTestTags.SCREEN_TITLE)
-        .assertIsDisplayed()
-        .assertTextContains(MeepleMeetScreen.Profile.title)
-
     composeTestRule.signOutWithBottomBar()
   }
 

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/MainTabComposableTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/MainTabComposableTest.kt
@@ -8,8 +8,7 @@ import androidx.test.espresso.Espresso
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.meeplemeet.model.account.Account
 import com.github.meeplemeet.model.account.AccountNoUid
-import com.github.meeplemeet.model.account.CreateAccountViewModel
-import com.github.meeplemeet.model.auth.AuthenticationViewModel
+import com.github.meeplemeet.model.account.ProfileScreenViewModel
 import com.github.meeplemeet.ui.account.MainTab
 import com.github.meeplemeet.ui.account.PrivateInfoTestTags
 import com.github.meeplemeet.ui.account.PublicInfoTestTags
@@ -31,16 +30,14 @@ class MainTabComposableTest : FirestoreTests() {
 
   private fun checkpoint(name: String, block: () -> Unit) = ck.ck(name, block)
 
-  private lateinit var authVm: AuthenticationViewModel
-  private lateinit var createVm: CreateAccountViewModel
+  private lateinit var profileVM: ProfileScreenViewModel
   private lateinit var user: Account
   private lateinit var otherUser: Account
 
   @Before
   fun setup() {
     runBlocking {
-      authVm = AuthenticationViewModel()
-      createVm = CreateAccountViewModel()
+      profileVM = ProfileScreenViewModel()
 
       val uid1 = "test_user_1"
       val uid2 = "test_user_2"
@@ -230,8 +227,7 @@ class MainTabComposableTest : FirestoreTests() {
     compose.setContent {
       AppTheme {
         MainTab(
-            viewModel = authVm,
-            viewModel = createVm,
+            viewModel = profileVM,
             account = accountState.value,
             onFriendsClick = {},
             onNotificationClick = {},

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/MainTabComposableTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/MainTabComposableTest.kt
@@ -1,0 +1,388 @@
+package com.github.meeplemeet.ui
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.espresso.Espresso
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.meeplemeet.model.account.Account
+import com.github.meeplemeet.model.account.AccountNoUid
+import com.github.meeplemeet.model.account.CreateAccountViewModel
+import com.github.meeplemeet.model.auth.AuthenticationViewModel
+import com.github.meeplemeet.ui.account.MainTab
+import com.github.meeplemeet.ui.account.PrivateInfoTestTags
+import com.github.meeplemeet.ui.account.PublicInfoTestTags
+import com.github.meeplemeet.ui.theme.AppTheme
+import com.github.meeplemeet.utils.Checkpoint
+import com.github.meeplemeet.utils.FirestoreTests
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.tasks.await
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MainTabComposableTest : FirestoreTests() {
+
+  @get:Rule val compose = createComposeRule()
+  @get:Rule val ck = Checkpoint.Rule()
+
+  private fun checkpoint(name: String, block: () -> Unit) = ck.ck(name, block)
+
+  private lateinit var authVm: AuthenticationViewModel
+  private lateinit var createVm: CreateAccountViewModel
+  private lateinit var user: Account
+  private lateinit var otherUser: Account
+
+  @Before
+  fun setup() {
+    runBlocking {
+      authVm = AuthenticationViewModel()
+      createVm = CreateAccountViewModel()
+
+      val uid1 = "test_user_1"
+      val uid2 = "test_user_2"
+
+      val payload1 =
+          AccountNoUid(
+              handle = "@tester",
+              name = "testUser",
+              email = "tester@example.com",
+              photoUrl = null,
+              description = null,
+              shopOwner = false,
+              spaceRenter = false)
+
+      val payload2 =
+          AccountNoUid(
+              handle = "@number_1",
+              name = "Existing User",
+              email = "number1@example.com",
+              photoUrl = null,
+              description = null,
+              shopOwner = false,
+              spaceRenter = false)
+
+      db.collection("accounts").document(uid1).set(payload1).await()
+
+      db.collection("accounts").document(uid2).set(payload2).await()
+
+      user = accountRepository.getAccount(uid1)
+      otherUser = accountRepository.getAccount(uid2)
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  /** Shorthand for getting a single node by tag. */
+  private fun ComposeTestRule.onTag(tag: String) = onNodeWithTag(tag, useUnmergedTree = true)
+
+  /** Shorthand for getting multiple nodes by tag. */
+  private fun ComposeTestRule.onTags(tag: String) = onAllNodesWithTag(tag, useUnmergedTree = true)
+
+  /** Scroll to a tag inside scrollable containers. */
+  private fun scrollToTag(tag: String) {
+    try {
+      compose.onTag(PublicInfoTestTags.PUBLIC_INFO).performScrollToNode(hasTestTag(tag))
+      compose.waitForIdle()
+    } catch (_: AssertionError) {
+      // node might already be visible; ignore
+    }
+  }
+
+  /** Ensures a toast is visible and returns the node. */
+  private fun expectToast(tag: String) = compose.onTag(tag).assertExists()
+
+  /** Clears and types text into an input field. */
+  private fun inputText(tag: String, value: String) {
+    compose.onTag(tag).performTextClearance()
+    compose.onTag(tag).performTextInput(value)
+    compose.waitForIdle()
+  }
+
+  /** Returns the given account state as a mutable Compose state holder. */
+  private fun mutableAccount(account: Account) = mutableStateOf(account)
+
+  // -------------------------------------------------------------------------
+  // Element Helpers (one per testTag)
+  // -------------------------------------------------------------------------
+
+  // =======================
+  // PUBLIC INFO ROOT
+  // =======================
+  private fun ComposeTestRule.publicInfoRoot() = onTag(PublicInfoTestTags.PUBLIC_INFO)
+
+  // =======================
+  // AVATAR SECTION
+  // =======================
+  private fun ComposeTestRule.avatarContainer() = onTag(PublicInfoTestTags.AVATAR_CONTAINER)
+
+  private fun ComposeTestRule.avatarImage() = onTag(PublicInfoTestTags.AVATAR_IMAGE)
+
+  private fun ComposeTestRule.avatarPlaceholder() = onTag(PublicInfoTestTags.AVATAR_PLACEHOLDER)
+
+  private fun ComposeTestRule.avatarEditIcon() = onTag(PublicInfoTestTags.AVATAR_EDIT_ICON)
+
+  private fun ComposeTestRule.avatarChooserDialog() =
+      onTag(PublicInfoTestTags.AVATAR_CHOOSER_DIALOG)
+
+  private fun ComposeTestRule.avatarChooserCamera() =
+      onTag(PublicInfoTestTags.AVATAR_CHOOSER_CAMERA)
+
+  private fun ComposeTestRule.avatarChooserGallery() =
+      onTag(PublicInfoTestTags.AVATAR_CHOOSER_GALLERY)
+
+  private fun ComposeTestRule.avatarChooserRemove() =
+      onTag(PublicInfoTestTags.AVATAR_CHOOSER_REMOVE)
+
+  private fun ComposeTestRule.avatarChooserCancel() =
+      onTag(PublicInfoTestTags.AVATAR_CHOOSER_CANCEL)
+
+  private fun ComposeTestRule.cameraPermissionDialog() =
+      onTag(PublicInfoTestTags.CAMERA_PERMISSION_DIALOG)
+
+  private fun ComposeTestRule.cameraPermissionOk() = onTag(PublicInfoTestTags.CAMERA_PERMISSION_OK)
+
+  // =======================
+  // PUBLIC INFO ACTIONS
+  // =======================
+  private fun ComposeTestRule.actionFriends() = onTag(PublicInfoTestTags.ACTION_FRIENDS)
+
+  private fun ComposeTestRule.actionNotifications() = onTag(PublicInfoTestTags.ACTION_NOTIFICATIONS)
+
+  private fun ComposeTestRule.actionLogout() = onTag(PublicInfoTestTags.ACTION_LOGOUT)
+
+  // =======================
+  // PUBLIC INFO INPUTS
+  // =======================
+  private fun ComposeTestRule.usernameField() = onTag(PublicInfoTestTags.INPUT_USERNAME)
+
+  private fun ComposeTestRule.usernameError() = onTag(PublicInfoTestTags.ERROR_USERNAME)
+
+  private fun ComposeTestRule.handleField() = onTag(PublicInfoTestTags.INPUT_HANDLE)
+
+  private fun ComposeTestRule.handleError() = onTag(PublicInfoTestTags.ERROR_HANDLE)
+
+  private fun ComposeTestRule.descriptionField() = onTag(PublicInfoTestTags.INPUT_DESCRIPTION)
+
+  private fun ComposeTestRule.publicInfoToast() = onTag(PublicInfoTestTags.GLOBAL_TOAST)
+
+  // =======================
+  // PRIVATE INFO SECTION
+  // =======================
+  private fun ComposeTestRule.privateInfoRoot() = onTag(PrivateInfoTestTags.PRIVATE_INFO)
+
+  private fun ComposeTestRule.privateInfoTitle() = onTag(PrivateInfoTestTags.PRIVATE_INFO_TITLE)
+
+  // =======================
+  // EMAIL SECTION
+  // =======================
+  private fun ComposeTestRule.emailSection() = onTag(PrivateInfoTestTags.EMAIL_SECTION)
+
+  private fun ComposeTestRule.emailInput() = onTag(PrivateInfoTestTags.EMAIL_INPUT)
+
+  private fun ComposeTestRule.emailVerifiedLabel() = onTag(PrivateInfoTestTags.EMAIL_VERIFIED_LABEL)
+
+  private fun ComposeTestRule.emailNotVerifiedLabel() =
+      onTag(PrivateInfoTestTags.EMAIL_NOT_VERIFIED_LABEL)
+
+  private fun ComposeTestRule.emailSendButton() = onTag(PrivateInfoTestTags.EMAIL_SEND_BUTTON)
+
+  private fun ComposeTestRule.emailToast() = onTag(PrivateInfoTestTags.EMAIL_TOAST)
+
+  // =======================
+  // ROLES SECTION
+  // =======================
+  private fun ComposeTestRule.rolesTitle() = onTag(PrivateInfoTestTags.ROLES_SECTION_TITLE)
+
+  private fun ComposeTestRule.roleShopCheckbox() = onTag(PrivateInfoTestTags.ROLE_SHOP_CHECKBOX)
+
+  private fun ComposeTestRule.roleSpaceCheckbox() = onTag(PrivateInfoTestTags.ROLE_SPACE_CHECKBOX)
+
+  // =======================
+  // ROLE REMOVAL DIALOG
+  // =======================
+  private fun ComposeTestRule.roleDialog() = onTag(PrivateInfoTestTags.ROLE_DIALOG)
+
+  private fun ComposeTestRule.roleDialogConfirm() = onTag(PrivateInfoTestTags.ROLE_DIALOG_CONFIRM)
+
+  private fun ComposeTestRule.roleDialogCancel() = onTag(PrivateInfoTestTags.ROLE_DIALOG_CANCEL)
+
+  private fun ComposeTestRule.rolesDialogText() = onTag(PrivateInfoTestTags.ROLE_DIALOG_TEXT)
+
+  /// Other helpers
+
+  private fun clearFocusWithBack() {
+    Espresso.pressBack()
+    compose.waitForIdle()
+  }
+
+  @Test
+  fun main_tab_full_user_flow() {
+
+    // Local state wrapper so changes propagate to UI as in your other screens
+    val accountState = mutableAccount(user)
+
+    compose.setContent {
+      AppTheme {
+        MainTab(
+            viewModel = authVm,
+            viewModel = createVm,
+            account = accountState.value,
+            onFriendsClick = {},
+            onNotificationClick = {},
+            onSignOut = {})
+      }
+    }
+
+    // ---------------------------------------------------------------------
+    checkpoint("screen_renders_and_prefills") {
+      compose.publicInfoRoot().assertExists()
+
+      // Avatar present (placeholder initially)
+      compose.avatarPlaceholder().assertExists()
+
+      // Inputs prefilled
+      compose.usernameField().assertTextEquals("testUser")
+      compose.handleField().assertTextEquals("@tester")
+      compose.descriptionField().assertTextEquals("")
+    }
+
+    // ---------------------------------------------------------------------
+    checkpoint("avatar_shows_chooser_and_handles_cancel") {
+      scrollToTag(PublicInfoTestTags.AVATAR_CONTAINER)
+      compose.avatarContainer().performClick()
+
+      compose.avatarChooserDialog().assertExists()
+
+      compose.avatarChooserCamera().assertExists()
+      compose.avatarChooserGallery().assertExists()
+      compose.avatarChooserRemove().assertExists().performClick()
+      compose.avatarChooserCancel().assertExists().performClick()
+      compose.avatarChooserDialog().assertDoesNotExist()
+    }
+
+    // ---------------------------------------------------------------------
+    checkpoint("username_blank_shows_error_and_can_be_fixed") {
+      scrollToTag(PublicInfoTestTags.INPUT_USERNAME)
+
+      // Clear username
+      inputText(PublicInfoTestTags.INPUT_USERNAME, "")
+      compose.usernameError().assertExists()
+
+      // Fix the username
+      inputText(PublicInfoTestTags.INPUT_USERNAME, "NewName")
+      compose.usernameError().assertDoesNotExist()
+    }
+
+    // ---------------------------------------------------------------------
+    checkpoint("handle_conflict_shows_error_until_corrected") {
+      scrollToTag(PublicInfoTestTags.INPUT_HANDLE)
+
+      // The VM expects to detect conflicts. Make a value that will trigger one.
+      inputText(PublicInfoTestTags.INPUT_HANDLE, "@number_1") // Assume taken
+      compose.waitForIdle()
+
+      // Expect handle error visible
+      compose.handleError().assertExists("Handle is in use.")
+
+      inputText(PublicInfoTestTags.INPUT_HANDLE, "invalidHandle&*&&(*&*") // Still taken
+      compose.handleError().assertExists()
+
+      // Fix it
+      inputText(PublicInfoTestTags.INPUT_HANDLE, "validHandle")
+      compose.handleError().assertDoesNotExist()
+
+      inputText(PublicInfoTestTags.INPUT_HANDLE, "tester") // Original handle, should be OK
+      compose.handleError().assertDoesNotExist()
+    }
+
+    // ---------------------------------------------------------------------
+    checkpoint("description_updates_without_errors") {
+      scrollToTag(PublicInfoTestTags.INPUT_DESCRIPTION)
+
+      inputText(PublicInfoTestTags.INPUT_DESCRIPTION, "New description here")
+      compose.descriptionField().assertTextEquals("New description here")
+    }
+
+    checkpoint("Private info section renders") {
+      compose.privateInfoRoot().assertExists()
+      compose.privateInfoTitle().assertExists()
+    }
+
+    // ---------------------------------------------------------------------
+    checkpoint("email_change_and_verification_toast") {
+      scrollToTag(PrivateInfoTestTags.EMAIL_SECTION)
+
+      compose.emailNotVerifiedLabel().assertExists()
+
+      inputText(PrivateInfoTestTags.EMAIL_INPUT, "newmail@example.com")
+
+      // Trigger verification
+      compose.emailSendButton().performClick()
+
+      // Toast visible
+      compose.emailToast().assertExists()
+    }
+
+    // ---------------------------------------------------------------------
+    checkpoint("roles_shop_toggle_shows_dialog_cancel_and_confirm") {
+      clearFocusWithBack()
+      scrollToTag(PrivateInfoTestTags.ROLE_SHOP_CHECKBOX)
+
+      compose.waitForIdle()
+      compose.onRoot().performTouchInput { swipeUp() }
+
+      // Toggle on for the first time == no dialog
+      compose.roleShopCheckbox().assertExists().performClick()
+      compose.roleDialog().assertDoesNotExist()
+
+      // Toggle Off == dialog
+      compose.roleShopCheckbox().assertExists().performClick()
+      compose.roleDialog().assertExists()
+      compose.rolesDialogText().assertExists().assertTextContains("shops", substring = true)
+
+      // Cancel
+      compose.roleDialogCancel().performClick()
+      compose.roleDialog().assertDoesNotExist()
+
+      // Toggle OFF again → confirm
+      compose.roleShopCheckbox().performClick()
+      compose.roleDialog().assertExists()
+
+      compose.roleDialogConfirm().performClick()
+      compose.roleDialog().assertDoesNotExist()
+    }
+
+    // ---------------------------------------------------------------------
+    checkpoint("roles_space_toggle_shows_dialog_cancel_and_confirm") {
+      scrollToTag(PrivateInfoTestTags.ROLE_SPACE_CHECKBOX)
+
+      compose.waitForIdle()
+
+      // Toggle on for the first time == no dialog
+      compose.roleSpaceCheckbox().assertExists().performClick()
+      compose.roleDialog().assertDoesNotExist()
+
+      // Toggle Off == dialog
+      compose.roleSpaceCheckbox().assertExists().performClick()
+      compose.roleDialog().assertExists()
+      compose.rolesDialogText().assertExists().assertTextContains("spaces", substring = true)
+
+      // Cancel
+      compose.roleDialogCancel().performClick()
+      compose.roleDialog().assertDoesNotExist()
+
+      // Toggle OFF again → confirm
+      compose.roleSpaceCheckbox().performClick()
+      compose.roleDialog().assertExists()
+
+      compose.roleDialogConfirm().performClick()
+      compose.roleDialog().assertDoesNotExist()
+    }
+  }
+}

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/MainTabComposableTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/MainTabComposableTest.kt
@@ -9,7 +9,9 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.meeplemeet.model.account.Account
 import com.github.meeplemeet.model.account.AccountNoUid
 import com.github.meeplemeet.model.account.ProfileScreenViewModel
+import com.github.meeplemeet.ui.account.DeleteAccSectionTestTags
 import com.github.meeplemeet.ui.account.MainTab
+import com.github.meeplemeet.ui.account.NotificationsSectionTestTags
 import com.github.meeplemeet.ui.account.PrivateInfoTestTags
 import com.github.meeplemeet.ui.account.PublicInfoTestTags
 import com.github.meeplemeet.ui.theme.AppTheme
@@ -91,9 +93,6 @@ class MainTabComposableTest : FirestoreTests() {
     }
   }
 
-  /** Ensures a toast is visible and returns the node. */
-  private fun expectToast(tag: String) = compose.onTag(tag).assertExists()
-
   /** Clears and types text into an input field. */
   private fun inputText(tag: String, value: String) {
     compose.onTag(tag).performTextClearance()
@@ -117,99 +116,79 @@ class MainTabComposableTest : FirestoreTests() {
   // AVATAR SECTION
   // =======================
   private fun ComposeTestRule.avatarContainer() = onTag(PublicInfoTestTags.AVATAR_CONTAINER)
-
-  private fun ComposeTestRule.avatarImage() = onTag(PublicInfoTestTags.AVATAR_IMAGE)
-
   private fun ComposeTestRule.avatarPlaceholder() = onTag(PublicInfoTestTags.AVATAR_PLACEHOLDER)
-
   private fun ComposeTestRule.avatarEditIcon() = onTag(PublicInfoTestTags.AVATAR_EDIT_ICON)
 
   private fun ComposeTestRule.avatarChooserDialog() =
       onTag(PublicInfoTestTags.AVATAR_CHOOSER_DIALOG)
-
   private fun ComposeTestRule.avatarChooserCamera() =
       onTag(PublicInfoTestTags.AVATAR_CHOOSER_CAMERA)
-
   private fun ComposeTestRule.avatarChooserGallery() =
       onTag(PublicInfoTestTags.AVATAR_CHOOSER_GALLERY)
-
   private fun ComposeTestRule.avatarChooserRemove() =
       onTag(PublicInfoTestTags.AVATAR_CHOOSER_REMOVE)
-
   private fun ComposeTestRule.avatarChooserCancel() =
       onTag(PublicInfoTestTags.AVATAR_CHOOSER_CANCEL)
-
-  private fun ComposeTestRule.cameraPermissionDialog() =
-      onTag(PublicInfoTestTags.CAMERA_PERMISSION_DIALOG)
-
-  private fun ComposeTestRule.cameraPermissionOk() = onTag(PublicInfoTestTags.CAMERA_PERMISSION_OK)
 
   // =======================
   // PUBLIC INFO ACTIONS
   // =======================
   private fun ComposeTestRule.actionFriends() = onTag(PublicInfoTestTags.ACTION_FRIENDS)
-
   private fun ComposeTestRule.actionNotifications() = onTag(PublicInfoTestTags.ACTION_NOTIFICATIONS)
-
   private fun ComposeTestRule.actionLogout() = onTag(PublicInfoTestTags.ACTION_LOGOUT)
 
   // =======================
   // PUBLIC INFO INPUTS
   // =======================
   private fun ComposeTestRule.usernameField() = onTag(PublicInfoTestTags.INPUT_USERNAME)
-
   private fun ComposeTestRule.usernameError() = onTag(PublicInfoTestTags.ERROR_USERNAME)
-
   private fun ComposeTestRule.handleField() = onTag(PublicInfoTestTags.INPUT_HANDLE)
-
   private fun ComposeTestRule.handleError() = onTag(PublicInfoTestTags.ERROR_HANDLE)
-
   private fun ComposeTestRule.descriptionField() = onTag(PublicInfoTestTags.INPUT_DESCRIPTION)
-
   private fun ComposeTestRule.publicInfoToast() = onTag(PublicInfoTestTags.GLOBAL_TOAST)
 
   // =======================
   // PRIVATE INFO SECTION
   // =======================
   private fun ComposeTestRule.privateInfoRoot() = onTag(PrivateInfoTestTags.PRIVATE_INFO)
-
   private fun ComposeTestRule.privateInfoTitle() = onTag(PrivateInfoTestTags.PRIVATE_INFO_TITLE)
 
   // =======================
   // EMAIL SECTION
   // =======================
-  private fun ComposeTestRule.emailSection() = onTag(PrivateInfoTestTags.EMAIL_SECTION)
-
-  private fun ComposeTestRule.emailInput() = onTag(PrivateInfoTestTags.EMAIL_INPUT)
-
-  private fun ComposeTestRule.emailVerifiedLabel() = onTag(PrivateInfoTestTags.EMAIL_VERIFIED_LABEL)
-
   private fun ComposeTestRule.emailNotVerifiedLabel() =
       onTag(PrivateInfoTestTags.EMAIL_NOT_VERIFIED_LABEL)
-
   private fun ComposeTestRule.emailSendButton() = onTag(PrivateInfoTestTags.EMAIL_SEND_BUTTON)
-
   private fun ComposeTestRule.emailToast() = onTag(PrivateInfoTestTags.EMAIL_TOAST)
 
   // =======================
   // ROLES SECTION
   // =======================
   private fun ComposeTestRule.rolesTitle() = onTag(PrivateInfoTestTags.ROLES_SECTION_TITLE)
-
   private fun ComposeTestRule.roleShopCheckbox() = onTag(PrivateInfoTestTags.ROLE_SHOP_CHECKBOX)
-
   private fun ComposeTestRule.roleSpaceCheckbox() = onTag(PrivateInfoTestTags.ROLE_SPACE_CHECKBOX)
 
   // =======================
   // ROLE REMOVAL DIALOG
   // =======================
   private fun ComposeTestRule.roleDialog() = onTag(PrivateInfoTestTags.ROLE_DIALOG)
-
   private fun ComposeTestRule.roleDialogConfirm() = onTag(PrivateInfoTestTags.ROLE_DIALOG_CONFIRM)
-
   private fun ComposeTestRule.roleDialogCancel() = onTag(PrivateInfoTestTags.ROLE_DIALOG_CANCEL)
-
   private fun ComposeTestRule.rolesDialogText() = onTag(PrivateInfoTestTags.ROLE_DIALOG_TEXT)
+
+
+    // NOTIFICATION SECTION
+    private fun ComposeTestRule.notifRadioNone() = onTag(NotificationsSectionTestTags.RADIO_NONE)
+    private fun ComposeTestRule.notifTitle() = onTag(NotificationsSectionTestTags.NOTIFICATION_SECTION_TITLE)
+    private fun ComposeTestRule.notifRadioEvery() = onTag(NotificationsSectionTestTags.RADIO_EVERYONE)
+    private fun ComposeTestRule.notifRadioFriends() = onTag(NotificationsSectionTestTags.RADIO_FRIENDS)
+
+    // DELETE ACCOUNT
+
+    private fun ComposeTestRule.delAccountBtn() = onTag(DeleteAccSectionTestTags.BUTTON)
+    private fun ComposeTestRule.delAccountPopup() = onTag(DeleteAccSectionTestTags.POPUP)
+    private fun ComposeTestRule.delAccountPopupConfirm() = onTag(DeleteAccSectionTestTags.CONFIRM)
+    private fun ComposeTestRule.delAccountPopupCancel() = onTag(DeleteAccSectionTestTags.CANCEL)
 
   /// Other helpers
 
@@ -223,15 +202,18 @@ class MainTabComposableTest : FirestoreTests() {
 
     // Local state wrapper so changes propagate to UI as in your other screens
     val accountState = mutableAccount(user)
+      var friendsClicked = false
+      var notifClicked = false
+      var logoutClicked = false
 
     compose.setContent {
       AppTheme {
         MainTab(
             viewModel = profileVM,
             account = accountState.value,
-            onFriendsClick = {},
-            onNotificationClick = {},
-            onSignOut = {})
+            onFriendsClick = {friendsClicked = true},
+            onNotificationClick = {notifClicked = true},
+            onSignOut = {logoutClicked = true})
       }
     }
 
@@ -246,12 +228,15 @@ class MainTabComposableTest : FirestoreTests() {
       compose.usernameField().assertTextEquals("testUser")
       compose.handleField().assertTextEquals("@tester")
       compose.descriptionField().assertTextEquals("")
+        compose.waitForIdle()
+
     }
 
     // ---------------------------------------------------------------------
     checkpoint("avatar_shows_chooser_and_handles_cancel") {
       scrollToTag(PublicInfoTestTags.AVATAR_CONTAINER)
       compose.avatarContainer().performClick()
+        compose.avatarEditIcon().assertExists()
 
       compose.avatarChooserDialog().assertExists()
 
@@ -260,7 +245,21 @@ class MainTabComposableTest : FirestoreTests() {
       compose.avatarChooserRemove().assertExists().performClick()
       compose.avatarChooserCancel().assertExists().performClick()
       compose.avatarChooserDialog().assertDoesNotExist()
+        compose.waitForIdle()
+
     }
+
+      checkpoint("button_callbacks_are_handled")
+      {
+          compose.actionFriends().assertExists().performClick()
+          assert(friendsClicked)
+          compose.actionNotifications().assertExists().performClick()
+          assert(notifClicked)
+          compose.actionLogout().assertExists().performClick()
+          assert(logoutClicked)
+          compose.waitForIdle()
+
+      }
 
     // ---------------------------------------------------------------------
     checkpoint("username_blank_shows_error_and_can_be_fixed") {
@@ -273,6 +272,8 @@ class MainTabComposableTest : FirestoreTests() {
       // Fix the username
       inputText(PublicInfoTestTags.INPUT_USERNAME, "NewName")
       compose.usernameError().assertDoesNotExist()
+        compose.waitForIdle()
+
     }
 
     // ---------------------------------------------------------------------
@@ -295,6 +296,8 @@ class MainTabComposableTest : FirestoreTests() {
 
       inputText(PublicInfoTestTags.INPUT_HANDLE, "tester") // Original handle, should be OK
       compose.handleError().assertDoesNotExist()
+        compose.waitForIdle()
+
     }
 
     // ---------------------------------------------------------------------
@@ -308,6 +311,8 @@ class MainTabComposableTest : FirestoreTests() {
     checkpoint("Private info section renders") {
       compose.privateInfoRoot().assertExists()
       compose.privateInfoTitle().assertExists()
+        compose.waitForIdle()
+
     }
 
     // ---------------------------------------------------------------------
@@ -323,6 +328,8 @@ class MainTabComposableTest : FirestoreTests() {
 
       // Toast visible
       compose.emailToast().assertExists()
+        compose.publicInfoToast().assertExists()
+        compose.waitForIdle()
     }
 
     // ---------------------------------------------------------------------
@@ -333,6 +340,7 @@ class MainTabComposableTest : FirestoreTests() {
       compose.waitForIdle()
       compose.onRoot().performTouchInput { swipeUp() }
 
+        compose.rolesTitle().assertExists()
       // Toggle on for the first time == no dialog
       compose.roleShopCheckbox().assertExists().performClick()
       compose.roleDialog().assertDoesNotExist()
@@ -352,6 +360,8 @@ class MainTabComposableTest : FirestoreTests() {
 
       compose.roleDialogConfirm().performClick()
       compose.roleDialog().assertDoesNotExist()
+        compose.waitForIdle()
+
     }
 
     // ---------------------------------------------------------------------
@@ -379,6 +389,49 @@ class MainTabComposableTest : FirestoreTests() {
 
       compose.roleDialogConfirm().performClick()
       compose.roleDialog().assertDoesNotExist()
+        compose.waitForIdle()
+
     }
+
+      checkpoint("Notifications section exists and works well")
+      {
+          compose.onRoot().performTouchInput {
+              swipeUp()
+          }
+
+          compose.notifTitle().assertExists()
+          compose.notifRadioEvery().assertExists().performClick()
+          compose.notifRadioEvery()
+              .onChildren()
+              .filterToOne(hasClickAction() or hasSetTextAction())
+              .assertIsSelected()
+
+          compose.notifRadioFriends().assertExists().performClick()
+          compose.notifRadioFriends()              .onChildren()
+              .filterToOne(hasClickAction() or hasSetTextAction())
+              .assertIsSelected()
+
+          compose.notifRadioNone().assertExists().performClick()
+          compose.notifRadioNone() .onChildren()
+              .filterToOne(hasClickAction() or hasSetTextAction())
+              .assertIsSelected()
+          compose.waitForIdle()
+
+      }
+
+      checkpoint("Delete button user flow")
+      {
+          compose.onRoot().performTouchInput {
+              swipeUp()
+          }
+
+          compose.delAccountBtn().assertExists().performClick()
+          compose.delAccountPopup().assertExists()
+          compose.delAccountPopupCancel().assertExists().performClick()
+          compose.delAccountPopup().assertDoesNotExist()
+          compose.delAccountBtn().performClick()
+          compose.delAccountPopupConfirm().assertExists().performClick()
+          compose.waitForIdle()
+      }
   }
 }

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/MainTabComposableTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/MainTabComposableTest.kt
@@ -12,6 +12,7 @@ import com.github.meeplemeet.model.account.ProfileScreenViewModel
 import com.github.meeplemeet.ui.account.DeleteAccSectionTestTags
 import com.github.meeplemeet.ui.account.MainTab
 import com.github.meeplemeet.ui.account.NotificationsSectionTestTags
+import com.github.meeplemeet.ui.account.PrivateInfo
 import com.github.meeplemeet.ui.account.PrivateInfoTestTags
 import com.github.meeplemeet.ui.account.PublicInfoTestTags
 import com.github.meeplemeet.ui.theme.AppTheme
@@ -172,9 +173,8 @@ class MainTabComposableTest : FirestoreTests() {
   // =======================
   private fun ComposeTestRule.emailNotVerifiedLabel() =
       onTag(PrivateInfoTestTags.EMAIL_NOT_VERIFIED_LABEL)
-
+    private fun ComposeTestRule.emailErrorLabel() = onTag(PrivateInfoTestTags.EMAIL_ERROR_LABEL)
   private fun ComposeTestRule.emailSendButton() = onTag(PrivateInfoTestTags.EMAIL_SEND_BUTTON)
-
   private fun ComposeTestRule.emailToast() = onTag(PrivateInfoTestTags.EMAIL_TOAST)
 
   // =======================
@@ -233,6 +233,7 @@ class MainTabComposableTest : FirestoreTests() {
     var friendsClicked = false
     var notifClicked = false
     var logoutClicked = false
+      var delClicked = false
 
     compose.setContent {
       AppTheme {
@@ -241,6 +242,7 @@ class MainTabComposableTest : FirestoreTests() {
             account = accountState.value,
             onFriendsClick = { friendsClicked = true },
             onNotificationClick = { notifClicked = true },
+            onDelAcc = { delClicked = true },
             onSignOut = { logoutClicked = true })
       }
     }
@@ -341,13 +343,12 @@ class MainTabComposableTest : FirestoreTests() {
       scrollToTag(PrivateInfoTestTags.EMAIL_SECTION)
 
       compose.emailNotVerifiedLabel().assertExists()
+        inputText(PrivateInfoTestTags.EMAIL_INPUT, "badlyformattedmail")
+        compose.emailErrorLabel().assertExists().assertTextEquals("Invalid Email")
 
-      inputText(PrivateInfoTestTags.EMAIL_INPUT, "newmail@example.com")
+        inputText(PrivateInfoTestTags.EMAIL_INPUT, "newmail@example.com")
+        compose.emailSendButton().performClick()
 
-      // Trigger verification
-      compose.emailSendButton().performClick()
-
-      // Toast visible
       compose.emailToast().assertExists()
       compose.publicInfoToast().assertExists()
       compose.waitForIdle()
@@ -448,6 +449,7 @@ class MainTabComposableTest : FirestoreTests() {
       compose.delAccountPopup().assertDoesNotExist()
       compose.delAccountBtn().performClick()
       compose.delAccountPopupConfirm().assertExists().performClick()
+        assert(delClicked)
       compose.waitForIdle()
     }
   }

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/MainTabComposableTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/MainTabComposableTest.kt
@@ -244,7 +244,7 @@ class MainTabComposableTest : FirestoreTests() {
             account = accountState.value,
             onFriendsClick = { friendsClicked = true },
             onNotificationClick = { notifClicked = true },
-            onDelAcc = { delClicked = true },
+            onDelete = { delClicked = true },
             onSignOutOrDel = { logoutClicked = true })
       }
     }
@@ -346,7 +346,7 @@ class MainTabComposableTest : FirestoreTests() {
 
       compose.emailNotVerifiedLabel().assertExists()
       inputText(PrivateInfoTestTags.EMAIL_INPUT, "badlyformattedmail")
-      compose.emailErrorLabel().assertExists().assertTextEquals("Invalid Email")
+      compose.emailErrorLabel().assertExists().assertTextEquals("Invalid Email Format")
 
       inputText(PrivateInfoTestTags.EMAIL_INPUT, "newmail@example.com")
       compose.emailSendButton().performClick()

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/MainTabComposableTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/MainTabComposableTest.kt
@@ -245,7 +245,7 @@ class MainTabComposableTest : FirestoreTests() {
             onFriendsClick = { friendsClicked = true },
             onNotificationClick = { notifClicked = true },
             onDelAcc = { delClicked = true },
-            onSignOut = { logoutClicked = true })
+            onSignOutOrDel = { logoutClicked = true })
       }
     }
 

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/MainTabComposableTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/MainTabComposableTest.kt
@@ -116,17 +116,23 @@ class MainTabComposableTest : FirestoreTests() {
   // AVATAR SECTION
   // =======================
   private fun ComposeTestRule.avatarContainer() = onTag(PublicInfoTestTags.AVATAR_CONTAINER)
+
   private fun ComposeTestRule.avatarPlaceholder() = onTag(PublicInfoTestTags.AVATAR_PLACEHOLDER)
+
   private fun ComposeTestRule.avatarEditIcon() = onTag(PublicInfoTestTags.AVATAR_EDIT_ICON)
 
   private fun ComposeTestRule.avatarChooserDialog() =
       onTag(PublicInfoTestTags.AVATAR_CHOOSER_DIALOG)
+
   private fun ComposeTestRule.avatarChooserCamera() =
       onTag(PublicInfoTestTags.AVATAR_CHOOSER_CAMERA)
+
   private fun ComposeTestRule.avatarChooserGallery() =
       onTag(PublicInfoTestTags.AVATAR_CHOOSER_GALLERY)
+
   private fun ComposeTestRule.avatarChooserRemove() =
       onTag(PublicInfoTestTags.AVATAR_CHOOSER_REMOVE)
+
   private fun ComposeTestRule.avatarChooserCancel() =
       onTag(PublicInfoTestTags.AVATAR_CHOOSER_CANCEL)
 
@@ -134,23 +140,31 @@ class MainTabComposableTest : FirestoreTests() {
   // PUBLIC INFO ACTIONS
   // =======================
   private fun ComposeTestRule.actionFriends() = onTag(PublicInfoTestTags.ACTION_FRIENDS)
+
   private fun ComposeTestRule.actionNotifications() = onTag(PublicInfoTestTags.ACTION_NOTIFICATIONS)
+
   private fun ComposeTestRule.actionLogout() = onTag(PublicInfoTestTags.ACTION_LOGOUT)
 
   // =======================
   // PUBLIC INFO INPUTS
   // =======================
   private fun ComposeTestRule.usernameField() = onTag(PublicInfoTestTags.INPUT_USERNAME)
+
   private fun ComposeTestRule.usernameError() = onTag(PublicInfoTestTags.ERROR_USERNAME)
+
   private fun ComposeTestRule.handleField() = onTag(PublicInfoTestTags.INPUT_HANDLE)
+
   private fun ComposeTestRule.handleError() = onTag(PublicInfoTestTags.ERROR_HANDLE)
+
   private fun ComposeTestRule.descriptionField() = onTag(PublicInfoTestTags.INPUT_DESCRIPTION)
+
   private fun ComposeTestRule.publicInfoToast() = onTag(PublicInfoTestTags.GLOBAL_TOAST)
 
   // =======================
   // PRIVATE INFO SECTION
   // =======================
   private fun ComposeTestRule.privateInfoRoot() = onTag(PrivateInfoTestTags.PRIVATE_INFO)
+
   private fun ComposeTestRule.privateInfoTitle() = onTag(PrivateInfoTestTags.PRIVATE_INFO_TITLE)
 
   // =======================
@@ -158,37 +172,51 @@ class MainTabComposableTest : FirestoreTests() {
   // =======================
   private fun ComposeTestRule.emailNotVerifiedLabel() =
       onTag(PrivateInfoTestTags.EMAIL_NOT_VERIFIED_LABEL)
+
   private fun ComposeTestRule.emailSendButton() = onTag(PrivateInfoTestTags.EMAIL_SEND_BUTTON)
+
   private fun ComposeTestRule.emailToast() = onTag(PrivateInfoTestTags.EMAIL_TOAST)
 
   // =======================
   // ROLES SECTION
   // =======================
   private fun ComposeTestRule.rolesTitle() = onTag(PrivateInfoTestTags.ROLES_SECTION_TITLE)
+
   private fun ComposeTestRule.roleShopCheckbox() = onTag(PrivateInfoTestTags.ROLE_SHOP_CHECKBOX)
+
   private fun ComposeTestRule.roleSpaceCheckbox() = onTag(PrivateInfoTestTags.ROLE_SPACE_CHECKBOX)
 
   // =======================
   // ROLE REMOVAL DIALOG
   // =======================
   private fun ComposeTestRule.roleDialog() = onTag(PrivateInfoTestTags.ROLE_DIALOG)
+
   private fun ComposeTestRule.roleDialogConfirm() = onTag(PrivateInfoTestTags.ROLE_DIALOG_CONFIRM)
+
   private fun ComposeTestRule.roleDialogCancel() = onTag(PrivateInfoTestTags.ROLE_DIALOG_CANCEL)
+
   private fun ComposeTestRule.rolesDialogText() = onTag(PrivateInfoTestTags.ROLE_DIALOG_TEXT)
 
+  // NOTIFICATION SECTION
+  private fun ComposeTestRule.notifRadioNone() = onTag(NotificationsSectionTestTags.RADIO_NONE)
 
-    // NOTIFICATION SECTION
-    private fun ComposeTestRule.notifRadioNone() = onTag(NotificationsSectionTestTags.RADIO_NONE)
-    private fun ComposeTestRule.notifTitle() = onTag(NotificationsSectionTestTags.NOTIFICATION_SECTION_TITLE)
-    private fun ComposeTestRule.notifRadioEvery() = onTag(NotificationsSectionTestTags.RADIO_EVERYONE)
-    private fun ComposeTestRule.notifRadioFriends() = onTag(NotificationsSectionTestTags.RADIO_FRIENDS)
+  private fun ComposeTestRule.notifTitle() =
+      onTag(NotificationsSectionTestTags.NOTIFICATION_SECTION_TITLE)
 
-    // DELETE ACCOUNT
+  private fun ComposeTestRule.notifRadioEvery() = onTag(NotificationsSectionTestTags.RADIO_EVERYONE)
 
-    private fun ComposeTestRule.delAccountBtn() = onTag(DeleteAccSectionTestTags.BUTTON)
-    private fun ComposeTestRule.delAccountPopup() = onTag(DeleteAccSectionTestTags.POPUP)
-    private fun ComposeTestRule.delAccountPopupConfirm() = onTag(DeleteAccSectionTestTags.CONFIRM)
-    private fun ComposeTestRule.delAccountPopupCancel() = onTag(DeleteAccSectionTestTags.CANCEL)
+  private fun ComposeTestRule.notifRadioFriends() =
+      onTag(NotificationsSectionTestTags.RADIO_FRIENDS)
+
+  // DELETE ACCOUNT
+
+  private fun ComposeTestRule.delAccountBtn() = onTag(DeleteAccSectionTestTags.BUTTON)
+
+  private fun ComposeTestRule.delAccountPopup() = onTag(DeleteAccSectionTestTags.POPUP)
+
+  private fun ComposeTestRule.delAccountPopupConfirm() = onTag(DeleteAccSectionTestTags.CONFIRM)
+
+  private fun ComposeTestRule.delAccountPopupCancel() = onTag(DeleteAccSectionTestTags.CANCEL)
 
   /// Other helpers
 
@@ -202,18 +230,18 @@ class MainTabComposableTest : FirestoreTests() {
 
     // Local state wrapper so changes propagate to UI as in your other screens
     val accountState = mutableAccount(user)
-      var friendsClicked = false
-      var notifClicked = false
-      var logoutClicked = false
+    var friendsClicked = false
+    var notifClicked = false
+    var logoutClicked = false
 
     compose.setContent {
       AppTheme {
         MainTab(
             viewModel = profileVM,
             account = accountState.value,
-            onFriendsClick = {friendsClicked = true},
-            onNotificationClick = {notifClicked = true},
-            onSignOut = {logoutClicked = true})
+            onFriendsClick = { friendsClicked = true },
+            onNotificationClick = { notifClicked = true },
+            onSignOut = { logoutClicked = true })
       }
     }
 
@@ -228,15 +256,14 @@ class MainTabComposableTest : FirestoreTests() {
       compose.usernameField().assertTextEquals("testUser")
       compose.handleField().assertTextEquals("@tester")
       compose.descriptionField().assertTextEquals("")
-        compose.waitForIdle()
-
+      compose.waitForIdle()
     }
 
     // ---------------------------------------------------------------------
     checkpoint("avatar_shows_chooser_and_handles_cancel") {
       scrollToTag(PublicInfoTestTags.AVATAR_CONTAINER)
       compose.avatarContainer().performClick()
-        compose.avatarEditIcon().assertExists()
+      compose.avatarEditIcon().assertExists()
 
       compose.avatarChooserDialog().assertExists()
 
@@ -245,21 +272,18 @@ class MainTabComposableTest : FirestoreTests() {
       compose.avatarChooserRemove().assertExists().performClick()
       compose.avatarChooserCancel().assertExists().performClick()
       compose.avatarChooserDialog().assertDoesNotExist()
-        compose.waitForIdle()
-
+      compose.waitForIdle()
     }
 
-      checkpoint("button_callbacks_are_handled")
-      {
-          compose.actionFriends().assertExists().performClick()
-          assert(friendsClicked)
-          compose.actionNotifications().assertExists().performClick()
-          assert(notifClicked)
-          compose.actionLogout().assertExists().performClick()
-          assert(logoutClicked)
-          compose.waitForIdle()
-
-      }
+    checkpoint("button_callbacks_are_handled") {
+      compose.actionFriends().assertExists().performClick()
+      assert(friendsClicked)
+      compose.actionNotifications().assertExists().performClick()
+      assert(notifClicked)
+      compose.actionLogout().assertExists().performClick()
+      assert(logoutClicked)
+      compose.waitForIdle()
+    }
 
     // ---------------------------------------------------------------------
     checkpoint("username_blank_shows_error_and_can_be_fixed") {
@@ -272,8 +296,7 @@ class MainTabComposableTest : FirestoreTests() {
       // Fix the username
       inputText(PublicInfoTestTags.INPUT_USERNAME, "NewName")
       compose.usernameError().assertDoesNotExist()
-        compose.waitForIdle()
-
+      compose.waitForIdle()
     }
 
     // ---------------------------------------------------------------------
@@ -296,8 +319,7 @@ class MainTabComposableTest : FirestoreTests() {
 
       inputText(PublicInfoTestTags.INPUT_HANDLE, "tester") // Original handle, should be OK
       compose.handleError().assertDoesNotExist()
-        compose.waitForIdle()
-
+      compose.waitForIdle()
     }
 
     // ---------------------------------------------------------------------
@@ -311,8 +333,7 @@ class MainTabComposableTest : FirestoreTests() {
     checkpoint("Private info section renders") {
       compose.privateInfoRoot().assertExists()
       compose.privateInfoTitle().assertExists()
-        compose.waitForIdle()
-
+      compose.waitForIdle()
     }
 
     // ---------------------------------------------------------------------
@@ -328,8 +349,8 @@ class MainTabComposableTest : FirestoreTests() {
 
       // Toast visible
       compose.emailToast().assertExists()
-        compose.publicInfoToast().assertExists()
-        compose.waitForIdle()
+      compose.publicInfoToast().assertExists()
+      compose.waitForIdle()
     }
 
     // ---------------------------------------------------------------------
@@ -340,7 +361,7 @@ class MainTabComposableTest : FirestoreTests() {
       compose.waitForIdle()
       compose.onRoot().performTouchInput { swipeUp() }
 
-        compose.rolesTitle().assertExists()
+      compose.rolesTitle().assertExists()
       // Toggle on for the first time == no dialog
       compose.roleShopCheckbox().assertExists().performClick()
       compose.roleDialog().assertDoesNotExist()
@@ -360,8 +381,7 @@ class MainTabComposableTest : FirestoreTests() {
 
       compose.roleDialogConfirm().performClick()
       compose.roleDialog().assertDoesNotExist()
-        compose.waitForIdle()
-
+      compose.waitForIdle()
     }
 
     // ---------------------------------------------------------------------
@@ -389,49 +409,46 @@ class MainTabComposableTest : FirestoreTests() {
 
       compose.roleDialogConfirm().performClick()
       compose.roleDialog().assertDoesNotExist()
-        compose.waitForIdle()
-
+      compose.waitForIdle()
     }
 
-      checkpoint("Notifications section exists and works well")
-      {
-          compose.onRoot().performTouchInput {
-              swipeUp()
-          }
+    checkpoint("Notifications section exists and works well") {
+      compose.onRoot().performTouchInput { swipeUp() }
 
-          compose.notifTitle().assertExists()
-          compose.notifRadioEvery().assertExists().performClick()
-          compose.notifRadioEvery()
-              .onChildren()
-              .filterToOne(hasClickAction() or hasSetTextAction())
-              .assertIsSelected()
+      compose.notifTitle().assertExists()
+      compose.notifRadioEvery().assertExists().performClick()
+      compose
+          .notifRadioEvery()
+          .onChildren()
+          .filterToOne(hasClickAction() or hasSetTextAction())
+          .assertIsSelected()
 
-          compose.notifRadioFriends().assertExists().performClick()
-          compose.notifRadioFriends()              .onChildren()
-              .filterToOne(hasClickAction() or hasSetTextAction())
-              .assertIsSelected()
+      compose.notifRadioFriends().assertExists().performClick()
+      compose
+          .notifRadioFriends()
+          .onChildren()
+          .filterToOne(hasClickAction() or hasSetTextAction())
+          .assertIsSelected()
 
-          compose.notifRadioNone().assertExists().performClick()
-          compose.notifRadioNone() .onChildren()
-              .filterToOne(hasClickAction() or hasSetTextAction())
-              .assertIsSelected()
-          compose.waitForIdle()
+      compose.notifRadioNone().assertExists().performClick()
+      compose
+          .notifRadioNone()
+          .onChildren()
+          .filterToOne(hasClickAction() or hasSetTextAction())
+          .assertIsSelected()
+      compose.waitForIdle()
+    }
 
-      }
+    checkpoint("Delete button user flow") {
+      compose.onRoot().performTouchInput { swipeUp() }
 
-      checkpoint("Delete button user flow")
-      {
-          compose.onRoot().performTouchInput {
-              swipeUp()
-          }
-
-          compose.delAccountBtn().assertExists().performClick()
-          compose.delAccountPopup().assertExists()
-          compose.delAccountPopupCancel().assertExists().performClick()
-          compose.delAccountPopup().assertDoesNotExist()
-          compose.delAccountBtn().performClick()
-          compose.delAccountPopupConfirm().assertExists().performClick()
-          compose.waitForIdle()
-      }
+      compose.delAccountBtn().assertExists().performClick()
+      compose.delAccountPopup().assertExists()
+      compose.delAccountPopupCancel().assertExists().performClick()
+      compose.delAccountPopup().assertDoesNotExist()
+      compose.delAccountBtn().performClick()
+      compose.delAccountPopupConfirm().assertExists().performClick()
+      compose.waitForIdle()
+    }
   }
 }

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/MainTabComposableTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/MainTabComposableTest.kt
@@ -12,7 +12,6 @@ import com.github.meeplemeet.model.account.ProfileScreenViewModel
 import com.github.meeplemeet.ui.account.DeleteAccSectionTestTags
 import com.github.meeplemeet.ui.account.MainTab
 import com.github.meeplemeet.ui.account.NotificationsSectionTestTags
-import com.github.meeplemeet.ui.account.PrivateInfo
 import com.github.meeplemeet.ui.account.PrivateInfoTestTags
 import com.github.meeplemeet.ui.account.PublicInfoTestTags
 import com.github.meeplemeet.ui.theme.AppTheme
@@ -173,8 +172,11 @@ class MainTabComposableTest : FirestoreTests() {
   // =======================
   private fun ComposeTestRule.emailNotVerifiedLabel() =
       onTag(PrivateInfoTestTags.EMAIL_NOT_VERIFIED_LABEL)
-    private fun ComposeTestRule.emailErrorLabel() = onTag(PrivateInfoTestTags.EMAIL_ERROR_LABEL)
+
+  private fun ComposeTestRule.emailErrorLabel() = onTag(PrivateInfoTestTags.EMAIL_ERROR_LABEL)
+
   private fun ComposeTestRule.emailSendButton() = onTag(PrivateInfoTestTags.EMAIL_SEND_BUTTON)
+
   private fun ComposeTestRule.emailToast() = onTag(PrivateInfoTestTags.EMAIL_TOAST)
 
   // =======================
@@ -233,7 +235,7 @@ class MainTabComposableTest : FirestoreTests() {
     var friendsClicked = false
     var notifClicked = false
     var logoutClicked = false
-      var delClicked = false
+    var delClicked = false
 
     compose.setContent {
       AppTheme {
@@ -343,11 +345,11 @@ class MainTabComposableTest : FirestoreTests() {
       scrollToTag(PrivateInfoTestTags.EMAIL_SECTION)
 
       compose.emailNotVerifiedLabel().assertExists()
-        inputText(PrivateInfoTestTags.EMAIL_INPUT, "badlyformattedmail")
-        compose.emailErrorLabel().assertExists().assertTextEquals("Invalid Email")
+      inputText(PrivateInfoTestTags.EMAIL_INPUT, "badlyformattedmail")
+      compose.emailErrorLabel().assertExists().assertTextEquals("Invalid Email")
 
-        inputText(PrivateInfoTestTags.EMAIL_INPUT, "newmail@example.com")
-        compose.emailSendButton().performClick()
+      inputText(PrivateInfoTestTags.EMAIL_INPUT, "newmail@example.com")
+      compose.emailSendButton().performClick()
 
       compose.emailToast().assertExists()
       compose.publicInfoToast().assertExists()
@@ -449,7 +451,7 @@ class MainTabComposableTest : FirestoreTests() {
       compose.delAccountPopup().assertDoesNotExist()
       compose.delAccountBtn().performClick()
       compose.delAccountPopupConfirm().assertExists().performClick()
-        assert(delClicked)
+      assert(delClicked)
       compose.waitForIdle()
     }
   }

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/NavigationTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/NavigationTest.kt
@@ -226,8 +226,8 @@ class AuthenticatedNavigationTest : FirestoreTests() {
 
           onNodeWithTag(NavigationTestTags.PROFILE_TAB).performClick()
           waitForIdle()
-          onNodeWithTag(NavigationTestTags.SCREEN_TITLE)
-              .assertTextContains(MeepleMeetScreen.Profile.title)
+          //          onNodeWithTag(NavigationTestTags.SCREEN_TITLE)
+          //              .assertTextContains(MeepleMeetScreen.Profile.title)
         }
 
         /* ----------------------------------------------------------
@@ -275,9 +275,13 @@ class AuthenticatedNavigationTest : FirestoreTests() {
           onNodeWithTag(NavigationTestTags.DISCOVER_TAB).performClick()
           onNodeWithTag(NavigationTestTags.PROFILE_TAB).performClick()
           waitForIdle()
+
           // pressing back should **not** cycle through the tabs
-          onNodeWithTag(NavigationTestTags.SCREEN_TITLE)
-              .assertTextContains(MeepleMeetScreen.Profile.title)
+          val nodes = onAllNodesWithTag(NavigationTestTags.SCREEN_TITLE)
+
+          if (nodes.fetchSemanticsNodes().isNotEmpty()) {
+            nodes.onFirst().assertTextContains(MeepleMeetScreen.Profile.title)
+          }
         }
         checkpoint("bottomBarRemainsVisibleAndHighlightsCurrentTab") {
           val tabs =
@@ -290,7 +294,8 @@ class AuthenticatedNavigationTest : FirestoreTests() {
             onNodeWithTag(tab).performClick()
             waitForIdle()
             onNodeWithTag(NavigationTestTags.BOTTOM_NAVIGATION_MENU).assertExists()
-            onNodeWithTag(NavigationTestTags.SCREEN_TITLE).assertTextContains(title)
+            if (tab != NavigationTestTags.PROFILE_TAB)
+                onNodeWithTag(NavigationTestTags.SCREEN_TITLE).assertTextContains(title)
           }
         }
 
@@ -327,7 +332,8 @@ class AuthenticatedNavigationTest : FirestoreTests() {
           tabs.forEach { (tag, title) ->
             onNodeWithTag(tag).performClick()
             waitForIdle()
-            onNodeWithTag(NavigationTestTags.SCREEN_TITLE).assertTextContains(title)
+            if (tag != NavigationTestTags.PROFILE_TAB)
+                onNodeWithTag(NavigationTestTags.SCREEN_TITLE).assertTextContains(title)
           }
         }
 
@@ -425,8 +431,8 @@ class AuthenticatedNavigationTest : FirestoreTests() {
         checkpoint("profileScreenSignOutButton") {
           onNodeWithTag(NavigationTestTags.PROFILE_TAB).performClick()
           waitForIdle()
-          onNodeWithTag(NavigationTestTags.SCREEN_TITLE)
-              .assertTextContains(MeepleMeetScreen.Profile.title)
+          //          onNodeWithTag(NavigationTestTags.SCREEN_TITLE)
+          //              .assertTextContains(MeepleMeetScreen.Profile.title)
           onNodeWithTag("Logout Button").assertExists()
         }
 

--- a/app/src/main/java/com/github/meeplemeet/MainActivity.kt
+++ b/app/src/main/java/com/github/meeplemeet/MainActivity.kt
@@ -26,6 +26,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navigation
 import com.github.meeplemeet.model.MainActivityViewModel
 import com.github.meeplemeet.model.account.AccountRepository
 import com.github.meeplemeet.model.account.HandlesRepository
@@ -403,7 +404,8 @@ fun MeepleMeetApp(
             onSignOut = {
               navigationActions.navigateTo(MeepleMeetScreen.SignIn)
               signedOut = true
-            })
+            },
+            onDelAcc = { navigationActions.navigateTo(MeepleMeetScreen.SignIn) })
       } ?: navigationActions.navigateTo(MeepleMeetScreen.SignIn)
     }
 

--- a/app/src/main/java/com/github/meeplemeet/MainActivity.kt
+++ b/app/src/main/java/com/github/meeplemeet/MainActivity.kt
@@ -404,7 +404,9 @@ fun MeepleMeetApp(
               navigationActions.navigateTo(MeepleMeetScreen.SignIn)
               signedOut = true
             },
-            onDelete = { FirebaseProvider.auth.signOut() })
+            onDelete = {
+              FirebaseProvider.auth.signOut()
+            }) // Sign out the user before deleting his account, avoiding an infinite loading screen
       } ?: navigationActions.navigateTo(MeepleMeetScreen.SignIn)
     }
 

--- a/app/src/main/java/com/github/meeplemeet/MainActivity.kt
+++ b/app/src/main/java/com/github/meeplemeet/MainActivity.kt
@@ -26,7 +26,6 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import androidx.navigation.navigation
 import com.github.meeplemeet.model.MainActivityViewModel
 import com.github.meeplemeet.model.account.AccountRepository
 import com.github.meeplemeet.model.account.HandlesRepository
@@ -401,11 +400,11 @@ fun MeepleMeetApp(
         ProfileScreen(
             navigation = navigationActions,
             account = account!!,
-            onSignOut = {
+            onSignOutOrDel = {
               navigationActions.navigateTo(MeepleMeetScreen.SignIn)
               signedOut = true
             },
-            onDelAcc = { navigationActions.navigateTo(MeepleMeetScreen.SignIn) })
+            onDelete = { FirebaseProvider.auth.signOut() })
       } ?: navigationActions.navigateTo(MeepleMeetScreen.SignIn)
     }
 

--- a/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -261,7 +262,7 @@ object MainTabUi {
  * @param onFriendsClick callback to navigate to the friend's tab
  * @param onNotificationClick callback to navigate to the notification's tab
  * @param onSignOutOrDel callback upon signing out
- * @param onDelAcc callback upon account deletion
+ * @param onDelete callback upon account deletion
  */
 @Composable
 fun MainTab(
@@ -420,22 +421,41 @@ fun PublicInfoActions(
                   }
 
               // Notifications Button
-              Button(
-                  modifier =
-                      Modifier.size(MainTabUi.ACTION_BUTTON_SIZE)
-                          .testTag(PublicInfoTestTags.ACTION_NOTIFICATIONS),
-                  onClick = { onNotificationClick(account) },
-                  shape = RoundedCornerShape(Dimensions.CornerRadius.extraLarge),
-                  contentPadding = PaddingValues(0.dp),
-                  colors =
-                      ButtonDefaults.buttonColors(
-                          containerColor = AppColors.secondary, contentColor = AppColors.textIcons),
-                  elevation = ButtonDefaults.buttonElevation(Dimensions.Elevation.high)) {
-                    Icon(
-                        Icons.Outlined.NotificationsNone,
-                        contentDescription = MainTabUi.PublicInfo.NOTIF_BTN_DESC,
-                        modifier = Modifier.size(Dimensions.IconSize.extraLarge))
-                  }
+              Box(modifier = Modifier.size(MainTabUi.ACTION_BUTTON_SIZE)) {
+                Button(
+                    modifier =
+                        Modifier.matchParentSize().testTag(PublicInfoTestTags.ACTION_NOTIFICATIONS),
+                    onClick = { onNotificationClick(account) },
+                    shape = RoundedCornerShape(Dimensions.CornerRadius.extraLarge),
+                    contentPadding = PaddingValues(0.dp),
+                    colors =
+                        ButtonDefaults.buttonColors(
+                            containerColor = AppColors.secondary,
+                            contentColor = AppColors.textIcons),
+                    elevation = ButtonDefaults.buttonElevation(Dimensions.Elevation.high)) {
+                      Icon(
+                          Icons.Outlined.NotificationsNone,
+                          contentDescription = MainTabUi.PublicInfo.NOTIF_BTN_DESC,
+                          modifier = Modifier.size(Dimensions.IconSize.extraLarge))
+                    }
+
+                val notificationCount = account.notifications.size
+                if (notificationCount > 0) {
+                  Box(
+                      modifier =
+                          Modifier.size(24.dp)
+                              .align(Alignment.TopEnd)
+                              .offset(4.dp, (-4).dp)
+                              .background(AppColors.negative, CircleShape),
+                      contentAlignment = Alignment.Center) {
+                        Text(
+                            text =
+                                if (notificationCount > 9) "9+" else notificationCount.toString(),
+                            color = AppColors.primary,
+                            fontSize = Dimensions.TextSize.tiny)
+                      }
+                }
+              }
             }
 
         // Logout Button

--- a/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
@@ -184,6 +184,9 @@ object MainTabUi {
   val LOGOUT_BUTTON_W = 140.dp
   val LOGOUT_BUTTON_H = 46.dp
   val AVATAR_SIZE = 130.dp
+    val OFFSET_X = 4.dp
+    val OFFSET_Y = (-4).dp
+    val MAX_NOTIF_COUNT = 9
 
   object Misc {
     const val DELETE_ACCOUNT = "Delete Account"
@@ -443,14 +446,14 @@ fun PublicInfoActions(
                 if (notificationCount > 0) {
                   Box(
                       modifier =
-                          Modifier.size(24.dp)
+                          Modifier.size(Dimensions.IconSize.large)
                               .align(Alignment.TopEnd)
-                              .offset(4.dp, (-4).dp)
+                              .offset(MainTabUi.OFFSET_X, MainTabUi.OFFSET_Y)
                               .background(AppColors.negative, CircleShape),
                       contentAlignment = Alignment.Center) {
                         Text(
                             text =
-                                if (notificationCount > 9) "9+" else notificationCount.toString(),
+                                if (notificationCount > MainTabUi.MAX_NOTIF_COUNT) "9+" else notificationCount.toString(),
                             color = AppColors.primary,
                             fontSize = Dimensions.TextSize.tiny)
                       }
@@ -1057,12 +1060,12 @@ fun RolesSection(account: Account, viewModel: ProfileScreenViewModel) {
         onConfirm = {
           when (pendingAction) {
             RoleAction.ShopOff -> {
-              // Todo: Delete user's shops from the platform
+              viewModel.deleteAccountShops(account)
               isShopChecked = false
               viewModel.setAccountRole(account, isShopOwner = false, isSpaceRenter = isSpaceRented)
             }
             RoleAction.SpaceOff -> {
-              // Todo: Delete user's spaces from the platform
+              viewModel.deleteAccountSpaceRenters(account)
               isSpaceRented = false
               viewModel.setAccountRole(account, isShopOwner = isShopChecked, isSpaceRenter = false)
             }

--- a/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
@@ -530,50 +530,48 @@ fun PublicInfoInputs(account: Account, viewModel: ProfileScreenViewModel) {
         var showErrors by remember { mutableStateOf(false) }
         val errorHandle = showErrors && errorMsg.isNotBlank() && handle != account.handle
 
-
-          FocusableInputField(
-              value = handle,
-              modifier =
-                  Modifier.testTag(PublicInfoTestTags.INPUT_HANDLE)
-                      .padding(bottom = Dimensions.Padding.medium),
-              onValueChange = {
-                  handle = it
-                  if (it.isNotBlank()) {
-                      showErrors = true
-                      viewModel.checkHandleAvailable(it)
-                  } else {
-                      showErrors = false
-                  }
-              },
-              label = { Text(text = MainTabUi.PublicInfo.HANDLE_INPUT_FIELD) },
-              leadingIcon = {
-                  Text(
-                      text = MainTabUi.PublicInfo.HANDLE_PREFIX,
-                      style = MaterialTheme.typography.bodyLarge,
-                      color = AppColors.textIcons,
-                      modifier = Modifier.padding(start = Dimensions.Padding.medium)
-                  )
-              },
-              singleLine = true,
-              isError = errorHandle,
-              onFocusChanged = { focused ->
-                  if (!focused && !errorHandle) viewModel.setAccountHandle(
-                      account,
-                      newHandle = handle
-                  )
-              })
-
-          if (errorHandle) {
+        FocusableInputField(
+            value = handle,
+            modifier =
+                Modifier.testTag(PublicInfoTestTags.INPUT_HANDLE)
+                    .padding(bottom = Dimensions.Padding.medium),
+            onValueChange = {
+              handle = it
+              if (it.isNotBlank()) {
+                showErrors = true
+                viewModel.checkHandleAvailable(it)
+              } else {
+                showErrors = false
+              }
+            },
+            label = { Text(text = MainTabUi.PublicInfo.HANDLE_INPUT_FIELD) },
+            leadingIcon = {
               Text(
-                  text = errorMsg,
-                  color = AppColors.negative,
-                  style = MaterialTheme.typography.bodySmall,
-                  textAlign = TextAlign.Center,
-                  modifier =
-                      Modifier.padding(top = Dimensions.Padding.small, start = Dimensions.Padding.large, end = Dimensions.Padding.large, bottom = Dimensions.Padding.small)
-                          .testTag(PublicInfoTestTags.ERROR_HANDLE)
-              )
-      }
+                  text = MainTabUi.PublicInfo.HANDLE_PREFIX,
+                  style = MaterialTheme.typography.bodyLarge,
+                  color = AppColors.textIcons,
+                  modifier = Modifier.padding(start = Dimensions.Padding.medium))
+            },
+            singleLine = true,
+            isError = errorHandle,
+            onFocusChanged = { focused ->
+              if (!focused && !errorHandle) viewModel.setAccountHandle(account, newHandle = handle)
+            })
+
+        if (errorHandle) {
+          Text(
+              text = errorMsg,
+              color = AppColors.negative,
+              style = MaterialTheme.typography.bodySmall,
+              textAlign = TextAlign.Center,
+              modifier =
+                  Modifier.padding(
+                          top = Dimensions.Padding.small,
+                          start = Dimensions.Padding.large,
+                          end = Dimensions.Padding.large,
+                          bottom = Dimensions.Padding.small)
+                      .testTag(PublicInfoTestTags.ERROR_HANDLE))
+        }
 
         // DESCRIPTION
         FocusableInputField(

--- a/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
@@ -62,7 +62,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.rememberAsyncImagePainter

--- a/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
@@ -1,0 +1,714 @@
+package com.github.meeplemeet.ui.account
+
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Group
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Send
+import androidx.compose.material.icons.outlined.NotificationsNone
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.lifecycle.viewmodel.compose.viewModel
+import coil.compose.rememberAsyncImagePainter
+import com.github.meeplemeet.model.account.Account
+import com.github.meeplemeet.model.account.CreateAccountViewModel
+import com.github.meeplemeet.model.auth.AuthenticationViewModel
+import com.github.meeplemeet.model.images.ImageFileUtils
+import com.github.meeplemeet.ui.FocusableInputField
+import com.github.meeplemeet.ui.theme.AppColors
+import com.github.meeplemeet.ui.theme.Dimensions
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+@Composable
+fun MainTab(
+    authViewModel: AuthenticationViewModel = viewModel(),
+    createAccountViewModel: CreateAccountViewModel = viewModel(),
+    account: Account,
+    onFriendsClick: (account: Account) -> Unit,
+    onNotificationClick: (account: Account) -> Unit,
+    onSignOut: () -> Unit
+) {
+  Column(
+      modifier =
+          Modifier.fillMaxSize()
+              .padding(ProfileScreenUi.xxLargePadding)
+              .verticalScroll(rememberScrollState()),
+      verticalArrangement = Arrangement.spacedBy(ProfileScreenUi.extraLargeSpacing),
+      horizontalAlignment = Alignment.CenterHorizontally) {
+        PublicInfo(
+            account = account,
+            authViewModel = authViewModel,
+            createAccountViewModel = createAccountViewModel,
+            onFriendsClick = onFriendsClick,
+            onNotificationClick = onNotificationClick,
+            onSignOut = onSignOut)
+
+        PrivateInfo(
+            account = account,
+            authViewModel = authViewModel,
+            createAccountViewModel = createAccountViewModel)
+      }
+}
+
+@Composable
+fun PublicInfo(
+    account: Account,
+    authViewModel: AuthenticationViewModel,
+    createAccountViewModel: CreateAccountViewModel,
+    onFriendsClick: (account: Account) -> Unit,
+    onNotificationClick: (account: Account) -> Unit,
+    onSignOut: () -> Unit
+) {
+  Box(
+      modifier =
+          Modifier.fillMaxWidth().clip(RoundedCornerShape(20.dp)).background(AppColors.secondary)) {
+        Column(
+            modifier = Modifier.padding(Dimensions.Padding.large),
+            verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.large),
+            horizontalAlignment = Alignment.CenterHorizontally) {
+              Row(
+                  modifier = Modifier.fillMaxWidth().padding(start = Dimensions.Padding.xLarge),
+                  verticalAlignment = Alignment.CenterVertically) {
+
+                    // 🔹 SECTION 1: Avatar
+                    DisplayAvatar(createAccountViewModel, account)
+
+                    Spacer(modifier = Modifier.weight(1f))
+
+                    // 🔹 SECTION 2: Action buttons
+                    PublicInfoActions(
+                        account = account,
+                        authViewModel = authViewModel,
+                        onFriendsClick = onFriendsClick,
+                        onNotificationClick = onNotificationClick,
+                        onSignOut = onSignOut)
+                  }
+
+              // 🔹 SECTION 3: Input fields
+              PublicInfoInputs(account = account, createAccountViewModel = createAccountViewModel)
+            }
+      }
+}
+
+@Composable
+fun PublicInfoActions(
+    account: Account,
+    authViewModel: AuthenticationViewModel,
+    onFriendsClick: (Account) -> Unit,
+    onNotificationClick: (Account) -> Unit,
+    onSignOut: () -> Unit
+) {
+  Column(
+      horizontalAlignment = Alignment.CenterHorizontally,
+      verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically) {
+              Button(
+                  modifier = Modifier.size(56.dp),
+                  onClick = { onFriendsClick(account) },
+                  shape = RoundedCornerShape(18.dp),
+                  contentPadding = PaddingValues(0.dp),
+                  colors =
+                      ButtonDefaults.buttonColors(
+                          containerColor = AppColors.secondary, contentColor = AppColors.textIcons),
+                  elevation = ButtonDefaults.buttonElevation(4.dp)) {
+                    Icon(
+                        Icons.Default.Group,
+                        contentDescription = "Friends",
+                        modifier = Modifier.size(28.dp))
+                  }
+
+              Button(
+                  modifier = Modifier.size(56.dp),
+                  onClick = { onNotificationClick(account) },
+                  shape = RoundedCornerShape(18.dp),
+                  contentPadding = PaddingValues(0.dp),
+                  colors =
+                      ButtonDefaults.buttonColors(
+                          containerColor = AppColors.secondary, contentColor = AppColors.textIcons),
+                  elevation = ButtonDefaults.buttonElevation(4.dp)) {
+                    Icon(
+                        Icons.Outlined.NotificationsNone,
+                        contentDescription = "Notifications",
+                        modifier = Modifier.size(28.dp))
+                  }
+            }
+
+        Button(
+            onClick = {
+              onSignOut()
+              authViewModel.signOut()
+            },
+            modifier = Modifier.width(140.dp).height(46.dp),
+            shape = RoundedCornerShape(14.dp),
+            elevation = ButtonDefaults.buttonElevation(4.dp)) {
+              Text("Logout")
+            }
+      }
+}
+
+@Composable
+fun PublicInfoInputs(account: Account, createAccountViewModel: CreateAccountViewModel) {
+  var name by remember { mutableStateOf(account.name) }
+  var desc by remember { mutableStateOf(account.description ?: "") }
+
+  // NAME VALIDATION
+  val nameError = name.isBlank()
+
+  FocusableInputField(
+      label = { Text("Username") },
+      value = name,
+      onValueChange = { name = it },
+      isError = nameError,
+      onFocusChanged = { focused ->
+        if (!focused && !nameError) {
+          createAccountViewModel.setAccountName(account, name)
+        }
+      })
+  if (nameError) {
+    Text(
+        text = "Username cannot be blank.",
+        color = AppColors.negative,
+        style = MaterialTheme.typography.bodySmall,
+        modifier = Modifier.padding(start = 16.dp, top = 4.dp))
+  }
+
+  // HANDLE VALIDATION
+  val errorMsg by createAccountViewModel.errorMessage.collectAsState()
+  var handle by remember { mutableStateOf(account.handle) }
+  var showErrors by remember { mutableStateOf(false) }
+  val errorHandle = showErrors && errorMsg.isNotBlank() && handle != account.handle
+
+  FocusableInputField(
+      value = handle,
+      onValueChange = {
+        handle = it
+        if (it.isNotBlank()) {
+          showErrors = true
+          createAccountViewModel.checkHandleAvailable(it)
+        } else {
+          showErrors = false
+        }
+      },
+      label = { Text("Handle") },
+      leadingIcon = {
+        Text(
+            "@",
+            style = MaterialTheme.typography.bodyLarge,
+            color = AppColors.textIcons,
+            modifier = Modifier.padding(start = 8.dp))
+      },
+      singleLine = true,
+      isError = errorHandle,
+      onFocusChanged = {focused ->
+          if (!focused && !errorHandle)
+              createAccountViewModel.setAccountHandle(account, handle)
+      })
+
+  if (errorHandle) {
+    Text(
+        text = errorMsg,
+        color = AppColors.negative,
+        style = MaterialTheme.typography.bodySmall,
+        modifier = Modifier.padding(start = 16.dp, top = 4.dp))
+  }
+
+  // DESCRIPTION
+  FocusableInputField(
+      label = { Text("Description") },
+      value = desc,
+      onValueChange = { desc = it },
+      singleLine = false,
+      onFocusChanged = { focused ->
+        if (!focused) createAccountViewModel.setAccountDescription(account, desc)
+      })
+
+  Spacer(modifier = Modifier.height(Dimensions.Spacing.medium))
+}
+
+@Composable
+fun DisplayAvatar(createAccountViewModel: CreateAccountViewModel, account: Account) {
+  val context = LocalContext.current
+  val scope = rememberCoroutineScope()
+  var showChooser by remember { mutableStateOf(false) }
+  var isSending by remember { mutableStateOf(false) }
+  var showPermissionDenied by remember { mutableStateOf(false) }
+
+  // --- Upload function ---
+  val setPhoto: suspend (String) -> Unit = { path ->
+    isSending = true
+    try {
+      createAccountViewModel.setAccountPhotoUrl(account, newPhotoUrl = path)
+    } finally {
+      isSending = false
+    }
+  }
+
+  // --- Camera launcher ---
+  val cameraLauncher =
+      rememberLauncherForActivityResult(ActivityResultContracts.TakePicturePreview()) { bitmap ->
+        if (bitmap != null) {
+          scope.launch {
+            val path = ImageFileUtils.saveBitmapToCache(context, bitmap)
+            setPhoto(path)
+          }
+        }
+      }
+
+  // --- Camera permission ---
+  val cameraPermissionLauncher =
+      rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+        if (granted) {
+          cameraLauncher.launch(null)
+        } else {
+          showPermissionDenied = true
+        }
+      }
+
+  // --- Gallery launcher ---
+  val galleryLauncher =
+      rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
+        if (uri != null) {
+          scope.launch {
+            val path = ImageFileUtils.cacheUriToFile(context, uri)
+            setPhoto(path)
+          }
+        }
+      }
+
+  // --- Avatar display ---
+  Box(
+      modifier = Modifier.size(130.dp).clickable { showChooser = true },
+      contentAlignment = Alignment.TopEnd) {
+        if (account.photoUrl.isNullOrBlank()) {
+          Box(
+              modifier =
+                  Modifier.size(130.dp).clip(CircleShape).background(AppColors.textIconsFade),
+              contentAlignment = Alignment.Center) {
+                Icon(
+                    Icons.Default.Person,
+                    contentDescription = "Placeholder Image",
+                    tint = Color.White.copy(alpha = 0.7f),
+                    modifier = Modifier.size(60.dp))
+              }
+        } else {
+          Image(
+              painter = rememberAsyncImagePainter(account.photoUrl),
+              contentDescription = "Profile Image",
+              contentScale = ContentScale.Crop,
+              modifier = Modifier.size(130.dp).clip(CircleShape))
+        }
+
+        Icon(
+            imageVector = Icons.Default.Edit,
+            contentDescription = "Edit image",
+            tint = Color.White,
+            modifier =
+                Modifier.size(28.dp)
+                    .background(Color.Black.copy(alpha = 0.4f), CircleShape)
+                    .padding(4.dp))
+      }
+
+  // --- Chooser dialog ---
+  if (showChooser) {
+    AvatarChooserDialog(
+        onDismiss = { showChooser = false },
+        onCamera = {
+          showChooser = false
+          cameraPermissionLauncher.launch(android.Manifest.permission.CAMERA)
+        },
+        onGallery = {
+          showChooser = false
+          galleryLauncher.launch("image/*")
+        },
+        onRemove = {
+          if (!account.photoUrl.isNullOrBlank()) {
+            showChooser = false
+            scope.launch { setPhoto("") }
+          } else null
+        })
+  }
+
+  // --- Permission denied ---
+  if (showPermissionDenied) {
+    AlertDialog(
+        onDismissRequest = { showPermissionDenied = false },
+        title = { Text(text = "Permission denied") },
+        text = { Text(text = "Camera access is required to take a profile picture.") },
+        confirmButton = {
+          TextButton(onClick = { showPermissionDenied = false }) { Text(text = "OK") }
+        })
+  }
+}
+
+@Composable
+fun AvatarChooserDialog(
+    onDismiss: () -> Unit,
+    onCamera: () -> Unit,
+    onGallery: () -> Unit,
+    onRemove: (() -> Unit)? = null
+) {
+  Dialog(onDismissRequest = onDismiss) {
+    Box(
+        modifier =
+            Modifier.clip(RoundedCornerShape(16.dp)).background(AppColors.primary).padding(20.dp)) {
+          Column(
+              verticalArrangement = Arrangement.spacedBy(12.dp),
+              modifier = Modifier.fillMaxWidth()) {
+                Text(text = "Change profile picture", style = MaterialTheme.typography.titleMedium)
+                Text(text = "Choose a source", style = MaterialTheme.typography.bodyMedium)
+
+                Button(onClick = onCamera, modifier = Modifier.fillMaxWidth()) {
+                  Text(text = "Camera")
+                }
+                Button(onClick = onGallery, modifier = Modifier.fillMaxWidth()) {
+                  Text(text = "Gallery")
+                }
+                if (onRemove != null) {
+                  Button(
+                      onClick = onRemove,
+                      modifier = Modifier.fillMaxWidth(),
+                      colors =
+                          ButtonDefaults.buttonColors(
+                              containerColor = AppColors.negative,
+                              contentColor = AppColors.textIcons)) {
+                        Text(text = "Remove Photo")
+                      }
+                }
+                TextButton(onClick = onDismiss, modifier = Modifier.fillMaxWidth()) {
+                  Text(text = "Cancel")
+                }
+              }
+        }
+  }
+}
+
+@Composable
+fun PrivateInfo(
+    account: Account,
+    authViewModel: AuthenticationViewModel,
+    createAccountViewModel: CreateAccountViewModel
+) {
+  val uiState by authViewModel.uiState.collectAsState()
+
+  var email by remember { mutableStateOf(account.email) }
+  val isVerified = uiState.isEmailVerified
+
+  Box(
+      modifier =
+          Modifier.fillMaxWidth().clip(RoundedCornerShape(20.dp)).background(AppColors.secondary)) {
+        Column(
+            modifier = Modifier.padding(Dimensions.Padding.xxxLarge),
+            verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.large),
+            horizontalAlignment = Alignment.CenterHorizontally) {
+
+              // TITLE
+              Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                Text(
+                    "Private Info",
+                    style = MaterialTheme.typography.headlineSmall,
+                )
+              }
+
+              // EMAIL SECTION
+              EmailSection(
+                  email = email,
+                  isVerified = isVerified,
+                  onEmailChange = { newEmail -> email = newEmail },
+                  onFocusChanged = { focused ->
+                    if (!focused) {
+                      createAccountViewModel.setAccountEmail(account, email)
+                    }
+                  },
+                  onSendVerification = {
+                    authViewModel.sendVerificationEmail()
+                    authViewModel.refreshEmailVerificationStatus()
+                  })
+
+              // ROLES SECTION
+              RolesSection(account = account, createAccountViewModel = createAccountViewModel)
+              Spacer(modifier = Modifier.height(Dimensions.Spacing.medium))
+            }
+      }
+}
+
+@Composable
+fun EmailSection(
+    email: String,
+    isVerified: Boolean,
+    onEmailChange: (String) -> Unit,
+    onFocusChanged: (Boolean) -> Unit,
+    onSendVerification: () -> Unit
+) {
+  var toast by remember { mutableStateOf<ToastData?>(null) }
+
+  Box(
+      modifier =
+          Modifier.fillMaxWidth()
+              .clip(RoundedCornerShape(20.dp))
+              .background(AppColors.secondary)
+              .padding(14.dp)) {
+        Column() {
+          Row(
+              modifier = Modifier.fillMaxWidth(),
+              horizontalArrangement = Arrangement.SpaceBetween,
+              verticalAlignment = Alignment.CenterVertically) {
+                FocusableInputField(
+                    label = { Text("Email") },
+                    value = email,
+                    onValueChange = onEmailChange,
+                    trailingIcon = {
+                      if (!isVerified) {
+                        IconButton(
+                            modifier = Modifier.padding(top = 4.dp),
+                            onClick = {
+                              onSendVerification()
+                              toast = ToastData("Sent")
+                            }) {
+                              Icon(
+                                  imageVector = Icons.Default.Send,
+                                  contentDescription = "Send verification email",
+                                  tint = AppColors.textIcons)
+                            }
+                      }
+                    },
+                    onFocusChanged = onFocusChanged,
+                    modifier = Modifier.weight(1f))
+              }
+
+          Row() {
+            if (isVerified) {
+              Text("Email Verified", color = AppColors.affirmative)
+            } else {
+              Text("Email Not Verified", color = AppColors.negative)
+            }
+
+            ToastHost(toast = toast, onToastFinished = { toast = null })
+          }
+        }
+      }
+}
+
+data class ToastData(
+    val message: String,
+    val id: Long = System.currentTimeMillis() // unique per show
+)
+
+@Composable
+fun ToastHost(toast: ToastData?, duration: Long = 1500L, onToastFinished: () -> Unit) {
+  Box(modifier = Modifier.fillMaxSize()) {
+    toast?.let { data ->
+      var visible by remember(data.id) { mutableStateOf(true) }
+
+      LaunchedEffect(data.id) {
+        visible = true
+        delay(duration)
+        visible = false
+        onToastFinished()
+      }
+
+      AnimatedVisibility(
+          visible = visible,
+          enter = fadeIn() + scaleIn(),
+          exit = fadeOut() + scaleOut(),
+          modifier = Modifier.align(Alignment.BottomEnd)) {
+            Box(
+                modifier =
+                    Modifier.background(
+                            color = AppColors.textIconsFade, shape = RoundedCornerShape(20.dp))
+                        .padding(horizontal = 16.dp, vertical = 0.dp)) {
+                  Text(text = data.message, color = Color.White, fontSize = 14.sp)
+                }
+          }
+    }
+  }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RolesSection(account: Account, createAccountViewModel: CreateAccountViewModel) {
+
+  var isShopChecked by remember { mutableStateOf(account.shopOwner) }
+  var isSpaceRented by remember { mutableStateOf(account.spaceRenter) }
+
+  var showDialog by remember { mutableStateOf(false) }
+  var pendingAction by remember { mutableStateOf<RoleAction?>(null) }
+
+  Box(
+      modifier = Modifier.fillMaxWidth().background(AppColors.secondary).padding(14.dp),
+      contentAlignment = Alignment.CenterStart) {
+        Text(
+            "I also want to:",
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(top = 4.dp))
+      }
+
+  RoleCheckBox(
+      isChecked = isShopChecked,
+      onCheckedChange = { checked ->
+        if (!checked) {
+          pendingAction = RoleAction.ShopOff
+          showDialog = true
+        } else {
+          isShopChecked = true
+          createAccountViewModel.setAccountRole(
+              account, isShopOwner = true, isSpaceRenter = isSpaceRented)
+        }
+      },
+      label = "Sell Items",
+      description = "List your shop and games you sell",
+      testTag = CreateAccountTestTags.CHECKBOX_OWNER)
+
+  RoleCheckBox(
+      isChecked = isSpaceRented,
+      onCheckedChange = { checked ->
+        if (!checked) {
+          pendingAction = RoleAction.SpaceOff
+          showDialog = true
+        } else {
+          isSpaceRented = true
+          createAccountViewModel.setAccountRole(
+              account, isShopOwner = isShopChecked, isSpaceRenter = true)
+        }
+      },
+      label = "Rent out spaces",
+      description = "Offer your play spaces for other players to book.",
+      testTag = CreateAccountTestTags.CHECKBOX_RENTER)
+
+  // CONFIRMATION DIALOG
+  if (showDialog && pendingAction != null) {
+    RemoveCatalogDialog(
+        visible = true,
+        action = pendingAction!!, // It's fine to use !! here as we check for null above
+        onConfirm = {
+          when (pendingAction) {
+            RoleAction.ShopOff -> {
+                // Todo: Delete user's shops from the platform
+              isShopChecked = false
+              createAccountViewModel.setAccountRole(
+                  account, isShopOwner = false, isSpaceRenter = isSpaceRented)
+            }
+            RoleAction.SpaceOff -> {
+                // Todo: Delete user's spaces from the platform
+              isSpaceRented = false
+              createAccountViewModel.setAccountRole(
+                  account, isShopOwner = isShopChecked, isSpaceRenter = false)
+            }
+            else -> {}
+          }
+          showDialog = false
+          pendingAction = null
+        },
+        onCancel = {
+          showDialog = false
+          pendingAction = null
+        })
+  }
+}
+
+private enum class RoleAction {
+  ShopOff,
+  SpaceOff
+}
+
+@Composable
+private fun RemoveCatalogDialog(
+    visible: Boolean,
+    action: RoleAction,
+    onConfirm: () -> Unit,
+    onCancel: () -> Unit
+) {
+  val informativeText =
+      when (action) {
+        RoleAction.ShopOff ->
+            "Are you sure you want to stop selling items? Your shops will be removed from the platform.\nThis action is irreversible."
+        RoleAction.SpaceOff ->
+            "Are you sure you want to stop renting out spaces? Your listings will be removed from the platform.\nThis action is irreversible."
+      }
+  if (visible) {
+    AlertDialog(
+        containerColor = AppColors.primary,
+        onDismissRequest = onCancel,
+        title = null,
+        text = { Text(text = informativeText, style = MaterialTheme.typography.bodyLarge) },
+        confirmButton = {
+          TextButton(
+              onClick = onConfirm,
+              colors =
+                  ButtonColors(
+                      containerColor = AppColors.divider,
+                      contentColor = AppColors.textIcons,
+                      disabledContainerColor = AppColors.divider,
+                      disabledContentColor = AppColors.textIcons)) {
+                Text("Confirm")
+              }
+        },
+        dismissButton = {
+          TextButton(
+              onClick = onCancel,
+              colors =
+                  ButtonColors(
+                      containerColor = AppColors.affirmative,
+                      disabledContainerColor = AppColors.affirmative,
+                      contentColor = AppColors.textIcons,
+                      disabledContentColor = AppColors.textIcons)) {
+                Text("Cancel")
+              }
+        },
+        shape = RoundedCornerShape(16.dp))
+  }
+}

--- a/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
@@ -260,7 +260,7 @@ object MainTabUi {
  * @param account current user of the app
  * @param onFriendsClick callback to navigate to the friend's tab
  * @param onNotificationClick callback to navigate to the notification's tab
- * @param onSignOut callback upon signing out
+ * @param onSignOutOrDel callback upon signing out
  * @param onDelAcc callback upon account deletion
  */
 @Composable
@@ -269,8 +269,8 @@ fun MainTab(
     account: Account,
     onFriendsClick: (account: Account) -> Unit,
     onNotificationClick: (account: Account) -> Unit,
-    onSignOut: () -> Unit,
-    onDelAcc: () -> Unit
+    onSignOutOrDel: () -> Unit,
+    onDelete: () -> Unit
 ) {
 
   val focusManager = LocalFocusManager.current
@@ -290,7 +290,7 @@ fun MainTab(
             viewModel = viewModel,
             onFriendsClick = onFriendsClick,
             onNotificationClick = onNotificationClick,
-            onSignOut = onSignOut)
+            onSignOut = onSignOutOrDel)
 
         PrivateInfo(account = account, viewModel = viewModel)
 
@@ -315,8 +315,9 @@ fun MainTab(
             onCancel = { showDelDialog = false },
             onConfirm = {
               showDelDialog = false
-              onDelAcc()
+              onSignOutOrDel()
               viewModel.deleteAccount(account)
+              onDelete()
               Log.d("Account after deletion", account.uid)
             })
       }

--- a/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
@@ -1,5 +1,6 @@
 package com.github.meeplemeet.ui.account
 
+import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
@@ -55,19 +56,16 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.rememberAsyncImagePainter
 import com.github.meeplemeet.model.account.Account
-import com.github.meeplemeet.model.account.CreateAccountViewModel
 import com.github.meeplemeet.model.account.ProfileScreenViewModel
 import com.github.meeplemeet.model.images.ImageFileUtils
 import com.github.meeplemeet.ui.FocusableInputField
@@ -166,27 +164,110 @@ object PrivateInfoTestTags {
 }
 
 object NotificationsSectionTestTags {
-    const val NOTIFICATION_SECTION_TITLE = "notification_section_title"
-    const val RADIO_EVERYONE = "radio_everyone"
-    const val RADIO_FRIENDS = "radio_friends"
-    const val RADIO_NONE = "radio_none"
+  const val NOTIFICATION_SECTION_TITLE = "notification_section_title"
+  const val RADIO_EVERYONE = "radio_everyone"
+  const val RADIO_FRIENDS = "radio_friends"
+  const val RADIO_NONE = "radio_none"
 }
 
 object DeleteAccSectionTestTags {
-    const val BUTTON = "delete_acc_button"
-    const val POPUP = "delete_acc_popup"
-    const val CONFIRM = "delete_acc_popup_confirm"
-    const val CANCEL = "delete_acc_popup_cancel"
+  const val BUTTON = "delete_acc_button"
+  const val POPUP = "delete_acc_popup"
+  const val CONFIRM = "delete_acc_popup_confirm"
+  const val CANCEL = "delete_acc_popup_cancel"
 }
 
+object MainTabUi {
+  val ACTION_BUTTON_SIZE = 56.dp
+  val LOGOUT_BUTTON_W = 140.dp
+  val LOGOUT_BUTTON_H = 46.dp
+  val AVATAR_SIZE = 130.dp
 
+  object Misc {
+    const val DELETE_ACCOUNT = "Delete Account"
+    const val DIALOG_TITLE = "Delete your account"
+    const val DIALOG_DESC =
+        "Do you really want to delete your account? All data related to your account will be erased"
+    const val DIALOG_CONFIRM = "Confirm"
+    const val DIALOG_CANCEL = "Cancel"
+  }
+
+  object PublicInfo {
+    const val NOTIF_BTN_DESC = "Notifications"
+    const val FRIENDS_BTN_DESC = "Friends"
+    const val LOGOUT_BTN = "Logout"
+    const val NAME_INPUT_FIELD = "Username"
+    const val HANDLE_INPUT_FIELD = "Handle"
+    const val DESC_INPUT_FIELD = "Description"
+    const val NAME_INPUT_FIELD_ERR = "Username cannot be blank."
+    const val HANDLE_PREFIX = "@"
+
+    const val AVATAR_HOLDER_DESC = "Placeholder Image"
+    const val AVATAR_IMAGE_DESC = "User's Image"
+    const val AVATAR_EDIT_DESC = "Edit image"
+
+    const val NO_PERMS_TITLE = "Permission denied"
+    const val NO_PERMS_TEXT = "Camera access is required to take a profile picture"
+    const val NO_PERMS_OK = "OK"
+
+    const val AVATAR_DIALOG_TITLE = "Change Profile Picture"
+    const val AVATAR_DIALOG_PROMPT = "Choose a source"
+
+    const val AVATAR_CAMERA_OPT = "Camera"
+    const val AVATAR_GALLERY_OPT = "Gallery"
+    const val AVATAR_REMOVE_OPT = "Remove Photo"
+    const val AVATAR_CANCEL_OPT = "Cancel"
+  }
+
+  object PrivateInfo {
+    const val TITLE = "Private Info"
+    const val EMAIL_INPUT_FIELD = "Email"
+
+    const val TOAST_MSG = "Sent"
+    const val SEND_ICON_DESC = "Send verification meail"
+    const val VERIFIED_MSG = "Email Verified"
+    const val UNVERIFIED_MSG = "Email not Verified"
+    const val ROLES_TITLE = "I also want to"
+    const val SELL_ITEMS_LABEL = "Sell Items"
+    const val SELL_ITEMS_DESC = "List your shop and games you sell"
+
+    const val RENT_SPACES_LABEL = "Rent out Spaces"
+    const val RENT_SPACES_DESC = "Offer your spaces for other players to book."
+    const val DIALOG_CONFIRM = "Confirm"
+    const val DIALOG_CANCEL = "Cancel"
+
+    const val ROLE_ACTION_SHOP =
+        "Are you sure you want to stop selling items? Your shops will be removed from the platform.\nThis action is irreversible."
+    const val ROLE_ACTION_SPACE =
+        "Are you sure you want to stop renting out spaces? Your spaces will be removed from the platform.\nThis action is irreversible."
+  }
+
+  object NotificationsSection {
+    const val TITLE = "Notification Settings"
+    const val OPT_EVERY = "Accept notifications from everyone."
+    const val OPT_FRIENDS = "Accept notifications from friends only."
+    const val OPT_NONE = "Accept notifications from no one."
+  }
+}
+
+/**
+ * Main tab of the profile screen. Displays all the account information that is
+ * important and manageable by the user
+ * @param viewModel the viewmodel used for this screen
+ * @param account current user of the app
+ * @param onFriendsClick callback to navigate to the friend's tab
+ * @param onNotificationClick callback to navigate to the notification's tab
+ * @param onSignOut callback upon signing out
+ * @param onDelAcc callback upon account deletion
+ */
 @Composable
 fun MainTab(
     viewModel: ProfileScreenViewModel = viewModel(),
     account: Account,
     onFriendsClick: (account: Account) -> Unit,
     onNotificationClick: (account: Account) -> Unit,
-    onSignOut: () -> Unit
+    onSignOut: () -> Unit,
+    onDelAcc: () -> Unit
 ) {
 
   val focusManager = LocalFocusManager.current
@@ -214,8 +295,8 @@ fun MainTab(
 
         Button(
             onClick = { showDelDialog = true },
-            shape = RoundedCornerShape(8.dp),
-            elevation = ButtonDefaults.buttonElevation(2.dp),
+            shape = RoundedCornerShape(Dimensions.CornerRadius.medium),
+            elevation = ButtonDefaults.buttonElevation(Dimensions.Elevation.medium),
             modifier = Modifier.testTag(DeleteAccSectionTestTags.BUTTON),
             colors =
                 ButtonColors(
@@ -223,7 +304,7 @@ fun MainTab(
                     disabledContainerColor = AppColors.negative,
                     contentColor = AppColors.textIcons,
                     disabledContentColor = AppColors.textIcons)) {
-              Text("Delete Account")
+              Text(text = MainTabUi.Misc.DELETE_ACCOUNT)
             }
 
         DeleteAccountDialog(
@@ -231,15 +312,25 @@ fun MainTab(
             onCancel = { showDelDialog = false },
             onConfirm = {
               showDelDialog = false
+              onDelAcc()
               viewModel.deleteAccount(account)
+              Log.d("Account after deletion", account.uid)
             })
       }
 }
 
-//////////////////////////////////////////////////////////////////////////////////////
-// PUBLIC INFO SECTION
 /////////////////////////////////////////////////////////////////////////////////////
+// PUBLIC INFO SECTION
+//////////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * Public info section composable. One of 3 sections of the MainTab screen
+ * @param account Current user
+ * @param viewModel viewModel used
+ * @param onFriendsClick callback to navigate to the friend's tab
+ * @param onNotificationClick callback to navigate to the notifications's tab
+ * @param onSignOut callback to sign out
+ */
 @Composable
 fun PublicInfo(
     account: Account,
@@ -251,7 +342,7 @@ fun PublicInfo(
   Box(
       modifier =
           Modifier.fillMaxWidth()
-              .clip(RoundedCornerShape(20.dp))
+              .clip(RoundedCornerShape(Dimensions.CornerRadius.extraLarge))
               .background(AppColors.secondary)
               .testTag(PublicInfoTestTags.PUBLIC_INFO)) {
         Column(
@@ -282,6 +373,14 @@ fun PublicInfo(
       }
 }
 
+/**
+ * Composable representing all 3 buttons in the public info section
+ * @param account Current user
+ * @param viewModel viewmodel used by this screen
+ * @param onFriendsClick callback to navigate to the friend's tab
+ * @param onNotificationClick callback to navigate to the notifications's tab
+ * @param onSignOut callback to sign out
+ */
 @Composable
 fun PublicInfoActions(
     account: Account,
@@ -292,40 +391,44 @@ fun PublicInfoActions(
 ) {
   Column(
       horizontalAlignment = Alignment.CenterHorizontally,
-      verticalArrangement = Arrangement.spacedBy(12.dp)) {
+      verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.large)) {
         Row(
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            horizontalArrangement = Arrangement.spacedBy(Dimensions.Spacing.large),
             verticalAlignment = Alignment.CenterVertically) {
               // Friends Button
               Button(
-                  modifier = Modifier.size(56.dp).testTag(PublicInfoTestTags.ACTION_FRIENDS),
+                  modifier =
+                      Modifier.size(MainTabUi.ACTION_BUTTON_SIZE)
+                          .testTag(PublicInfoTestTags.ACTION_FRIENDS),
                   onClick = { onFriendsClick(account) },
-                  shape = RoundedCornerShape(18.dp),
+                  shape = RoundedCornerShape(Dimensions.CornerRadius.extraLarge),
                   contentPadding = PaddingValues(0.dp),
                   colors =
                       ButtonDefaults.buttonColors(
                           containerColor = AppColors.secondary, contentColor = AppColors.textIcons),
-                  elevation = ButtonDefaults.buttonElevation(4.dp)) {
+                  elevation = ButtonDefaults.buttonElevation(Dimensions.Elevation.high)) {
                     Icon(
                         Icons.Default.Group,
-                        contentDescription = "Friends",
-                        modifier = Modifier.size(28.dp))
+                        contentDescription = MainTabUi.PublicInfo.FRIENDS_BTN_DESC,
+                        modifier = Modifier.size(Dimensions.IconSize.extraLarge))
                   }
 
               // Notifications Button
               Button(
-                  modifier = Modifier.size(56.dp).testTag(PublicInfoTestTags.ACTION_NOTIFICATIONS),
+                  modifier =
+                      Modifier.size(MainTabUi.ACTION_BUTTON_SIZE)
+                          .testTag(PublicInfoTestTags.ACTION_NOTIFICATIONS),
                   onClick = { onNotificationClick(account) },
-                  shape = RoundedCornerShape(18.dp),
+                  shape = RoundedCornerShape(Dimensions.CornerRadius.extraLarge),
                   contentPadding = PaddingValues(0.dp),
                   colors =
                       ButtonDefaults.buttonColors(
                           containerColor = AppColors.secondary, contentColor = AppColors.textIcons),
-                  elevation = ButtonDefaults.buttonElevation(4.dp)) {
+                  elevation = ButtonDefaults.buttonElevation(Dimensions.Elevation.high)) {
                     Icon(
                         Icons.Outlined.NotificationsNone,
-                        contentDescription = "Notifications",
-                        modifier = Modifier.size(28.dp))
+                        contentDescription = MainTabUi.PublicInfo.NOTIF_BTN_DESC,
+                        modifier = Modifier.size(Dimensions.IconSize.extraLarge))
                   }
             }
 
@@ -336,20 +439,28 @@ fun PublicInfoActions(
               viewModel.signOut()
             },
             modifier =
-                Modifier.width(140.dp).height(46.dp).testTag(PublicInfoTestTags.ACTION_LOGOUT),
+                Modifier.width(MainTabUi.LOGOUT_BUTTON_W)
+                    .height(MainTabUi.LOGOUT_BUTTON_H)
+                    .testTag(PublicInfoTestTags.ACTION_LOGOUT),
             colors =
                 ButtonDefaults.buttonColors(
                     containerColor = AppColors.textIconsFade,
                     disabledContainerColor = AppColors.textIconsFade,
                     contentColor = AppColors.primary,
                     disabledContentColor = AppColors.primary),
-            shape = RoundedCornerShape(14.dp),
-            elevation = ButtonDefaults.buttonElevation(4.dp)) {
-              Text("Logout")
+            shape = RoundedCornerShape(Dimensions.CornerRadius.large),
+            elevation = ButtonDefaults.buttonElevation(Dimensions.Elevation.high)) {
+              Text(text = MainTabUi.PublicInfo.LOGOUT_BTN)
             }
       }
 }
 
+
+/**
+ * Handles the input fields in that first section
+ * @param account Current user
+ * @param viewModel viewmodel used by this screen
+ */
 @Composable
 fun PublicInfoInputs(account: Account, viewModel: ProfileScreenViewModel) {
   var name by remember { mutableStateOf(account.name) }
@@ -359,7 +470,7 @@ fun PublicInfoInputs(account: Account, viewModel: ProfileScreenViewModel) {
   val nameError = name.isBlank()
 
   FocusableInputField(
-      label = { Text("Username") },
+      label = { Text(text = MainTabUi.PublicInfo.NAME_INPUT_FIELD) },
       modifier = Modifier.testTag(PublicInfoTestTags.INPUT_USERNAME),
       value = name,
       onValueChange = { name = it },
@@ -371,11 +482,12 @@ fun PublicInfoInputs(account: Account, viewModel: ProfileScreenViewModel) {
       })
   if (nameError) {
     Text(
-        text = "Username cannot be blank.",
+        text = MainTabUi.PublicInfo.NAME_INPUT_FIELD_ERR,
         color = AppColors.negative,
         style = MaterialTheme.typography.bodySmall,
         modifier =
-            Modifier.padding(start = 16.dp, top = 4.dp).testTag(PublicInfoTestTags.ERROR_USERNAME))
+            Modifier.padding(start = Dimensions.Padding.extraLarge, top = Dimensions.Padding.small)
+                .testTag(PublicInfoTestTags.ERROR_USERNAME))
   }
 
   // HANDLE VALIDATION
@@ -396,18 +508,18 @@ fun PublicInfoInputs(account: Account, viewModel: ProfileScreenViewModel) {
           showErrors = false
         }
       },
-      label = { Text("Handle") },
+      label = { Text(text = MainTabUi.PublicInfo.HANDLE_INPUT_FIELD) },
       leadingIcon = {
         Text(
-            "@",
+            text = MainTabUi.PublicInfo.HANDLE_PREFIX,
             style = MaterialTheme.typography.bodyLarge,
             color = AppColors.textIcons,
-            modifier = Modifier.padding(start = 8.dp))
+            modifier = Modifier.padding(start = Dimensions.Padding.medium))
       },
       singleLine = true,
       isError = errorHandle,
       onFocusChanged = { focused ->
-        if (!focused && !errorHandle) viewModel.setAccountHandle(account, handle)
+        if (!focused && !errorHandle) viewModel.setAccountHandle(account, newHandle = handle)
       })
 
   if (errorHandle) {
@@ -416,21 +528,29 @@ fun PublicInfoInputs(account: Account, viewModel: ProfileScreenViewModel) {
         color = AppColors.negative,
         style = MaterialTheme.typography.bodySmall,
         modifier =
-            Modifier.padding(start = 16.dp, top = 4.dp).testTag(PublicInfoTestTags.ERROR_HANDLE))
+            Modifier.padding(start = Dimensions.Padding.extraLarge, top = Dimensions.Padding.small)
+                .testTag(PublicInfoTestTags.ERROR_HANDLE))
   }
 
   // DESCRIPTION
   FocusableInputField(
-      label = { Text("Description") },
+      label = { Text(MainTabUi.PublicInfo.DESC_INPUT_FIELD) },
       modifier = Modifier.testTag(PublicInfoTestTags.INPUT_DESCRIPTION),
       value = desc,
       onValueChange = { desc = it },
       singleLine = false,
-      onFocusChanged = { focused -> if (!focused) viewModel.setAccountDescription(account, desc) })
+      onFocusChanged = { focused ->
+        if (!focused) viewModel.setAccountDescription(account, newDescription = desc)
+      })
 
   Spacer(modifier = Modifier.height(Dimensions.Spacing.medium))
 }
 
+/**
+ * Handles the avatar section of the user
+ * @param viewModel viewmodel used by this screen
+ * @param account Current user
+ */
 @Composable
 fun DisplayAvatar(viewModel: ProfileScreenViewModel, account: Account) {
   val context = LocalContext.current
@@ -485,41 +605,43 @@ fun DisplayAvatar(viewModel: ProfileScreenViewModel, account: Account) {
   // --- Avatar display ---
   Box(
       modifier =
-          Modifier.size(130.dp)
+          Modifier.size(MainTabUi.AVATAR_SIZE)
               .clickable { showChooser = true }
               .testTag(PublicInfoTestTags.AVATAR_CONTAINER),
       contentAlignment = Alignment.TopEnd) {
         if (account.photoUrl.isNullOrBlank()) {
           Box(
               modifier =
-                  Modifier.size(130.dp)
+                  Modifier.size(MainTabUi.AVATAR_SIZE)
                       .clip(CircleShape)
                       .background(AppColors.textIconsFade)
                       .testTag(PublicInfoTestTags.AVATAR_PLACEHOLDER),
               contentAlignment = Alignment.Center) {
                 Icon(
-                    Icons.Default.Person,
-                    contentDescription = "Placeholder Image",
-                    tint = Color.White.copy(alpha = 0.7f),
-                    modifier = Modifier.size(60.dp))
+                    imageVector = Icons.Default.Person,
+                    contentDescription = MainTabUi.PublicInfo.AVATAR_HOLDER_DESC,
+                    tint = AppColors.divider,
+                    modifier = Modifier.size(Dimensions.IconSize.giant))
               }
         } else {
           Image(
               painter = rememberAsyncImagePainter(account.photoUrl),
-              contentDescription = "Profile Image",
+              contentDescription = MainTabUi.PublicInfo.AVATAR_IMAGE_DESC,
               contentScale = ContentScale.Crop,
               modifier =
-                  Modifier.size(130.dp).clip(CircleShape).testTag(PublicInfoTestTags.AVATAR_IMAGE))
+                  Modifier.size(MainTabUi.AVATAR_SIZE)
+                      .clip(CircleShape)
+                      .testTag(PublicInfoTestTags.AVATAR_IMAGE))
         }
 
         Icon(
             imageVector = Icons.Default.Edit,
-            contentDescription = "Edit image",
-            tint = Color.White,
+            contentDescription = MainTabUi.PublicInfo.AVATAR_EDIT_DESC,
+            tint = AppColors.primary,
             modifier =
-                Modifier.size(28.dp)
-                    .background(Color.Black.copy(alpha = 0.4f), CircleShape)
-                    .padding(4.dp)
+                Modifier.size(Dimensions.IconSize.extraLarge)
+                    .background(AppColors.textIconsFade, CircleShape)
+                    .padding(Dimensions.Padding.small)
                     .testTag(PublicInfoTestTags.AVATAR_EDIT_ICON))
       }
 
@@ -549,18 +671,25 @@ fun DisplayAvatar(viewModel: ProfileScreenViewModel, account: Account) {
         containerColor = AppColors.primary,
         modifier = Modifier.testTag(PublicInfoTestTags.CAMERA_PERMISSION_DIALOG),
         onDismissRequest = { showPermissionDenied = false },
-        title = { Text(text = "Permission denied") },
-        text = { Text(text = "Camera access is required to take a profile picture.") },
+        title = { Text(text = MainTabUi.PublicInfo.NO_PERMS_TITLE) },
+        text = { Text(text = MainTabUi.PublicInfo.NO_PERMS_TEXT) },
         confirmButton = {
           TextButton(
               onClick = { showPermissionDenied = false },
               modifier = Modifier.testTag(PublicInfoTestTags.CAMERA_PERMISSION_OK)) {
-                Text(text = "OK")
+                Text(text = MainTabUi.PublicInfo.NO_PERMS_OK)
               }
         })
   }
 }
 
+/**
+ * Dialog upon editing the avatar
+ * @param onDismiss callback upon dismissing
+ * @param onCamera callback upon selecting camera
+ * @param onGallery callback upon selecting gallery
+ * @param onRemove callback upon removing user's profile picture
+ */
 @Composable
 fun AvatarChooserDialog(
     onDismiss: () -> Unit,
@@ -571,28 +700,32 @@ fun AvatarChooserDialog(
   Dialog(onDismissRequest = onDismiss) {
     Box(
         modifier =
-            Modifier.clip(RoundedCornerShape(16.dp))
+            Modifier.clip(RoundedCornerShape(Dimensions.CornerRadius.extraLarge))
                 .background(AppColors.primary)
-                .padding(20.dp)
+                .padding(Dimensions.Padding.xLarge)
                 .testTag(PublicInfoTestTags.AVATAR_CHOOSER_DIALOG)) {
           Column(
-              verticalArrangement = Arrangement.spacedBy(12.dp),
+              verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.large),
               modifier = Modifier.fillMaxWidth()) {
-                Text(text = "Change profile picture", style = MaterialTheme.typography.titleMedium)
-                Text(text = "Choose a source", style = MaterialTheme.typography.bodyMedium)
+                Text(
+                    text = MainTabUi.PublicInfo.AVATAR_DIALOG_TITLE,
+                    style = MaterialTheme.typography.titleMedium)
+                Text(
+                    text = MainTabUi.PublicInfo.AVATAR_DIALOG_PROMPT,
+                    style = MaterialTheme.typography.bodyMedium)
 
                 Button(
                     onClick = onCamera,
                     modifier =
                         Modifier.fillMaxWidth().testTag(PublicInfoTestTags.AVATAR_CHOOSER_CAMERA)) {
-                      Text(text = "Camera")
+                      Text(text = MainTabUi.PublicInfo.AVATAR_CAMERA_OPT)
                     }
                 Button(
                     onClick = onGallery,
                     modifier =
                         Modifier.fillMaxWidth()
                             .testTag(PublicInfoTestTags.AVATAR_CHOOSER_GALLERY)) {
-                      Text(text = "Gallery")
+                      Text(text = MainTabUi.PublicInfo.AVATAR_GALLERY_OPT)
                     }
                 if (onRemove != null) {
                   Button(
@@ -603,14 +736,14 @@ fun AvatarChooserDialog(
                           ButtonDefaults.buttonColors(
                               containerColor = AppColors.negative,
                               contentColor = AppColors.textIcons)) {
-                        Text(text = "Remove Photo")
+                        Text(text = MainTabUi.PublicInfo.AVATAR_REMOVE_OPT)
                       }
                 }
                 TextButton(
                     onClick = onDismiss,
                     modifier =
                         Modifier.fillMaxWidth().testTag(PublicInfoTestTags.AVATAR_CHOOSER_CANCEL)) {
-                      Text(text = "Cancel")
+                      Text(text = MainTabUi.PublicInfo.AVATAR_CANCEL_OPT)
                     }
               }
         }
@@ -621,6 +754,11 @@ fun AvatarChooserDialog(
 // PRIVATE INFO SECTION
 /////////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * Second section of the MainTab's screen. This one handles information only the user has access to
+ * @param account Current user
+ * @param viewModel viewmodel used by this screen
+ */
 @Composable
 fun PrivateInfo(account: Account, viewModel: ProfileScreenViewModel) {
 
@@ -632,7 +770,7 @@ fun PrivateInfo(account: Account, viewModel: ProfileScreenViewModel) {
   Box(
       modifier =
           Modifier.fillMaxWidth()
-              .clip(RoundedCornerShape(20.dp))
+              .clip(RoundedCornerShape(Dimensions.CornerRadius.extraLarge))
               .background(AppColors.secondary)
               .testTag(PrivateInfoTestTags.PRIVATE_INFO)) {
         Column(
@@ -643,7 +781,7 @@ fun PrivateInfo(account: Account, viewModel: ProfileScreenViewModel) {
               // TITLE
               Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
                 Text(
-                    text = "Private Info",
+                    text = MainTabUi.PrivateInfo.TITLE,
                     modifier = Modifier.testTag(PrivateInfoTestTags.PRIVATE_INFO_TITLE),
                     style = MaterialTheme.typography.headlineSmall,
                 )
@@ -665,12 +803,20 @@ fun PrivateInfo(account: Account, viewModel: ProfileScreenViewModel) {
                   })
 
               // ROLES SECTION
-              RolesSection(account = account, createAccountViewModel = viewModel)
+              RolesSection(account = account, viewModel = viewModel)
               Spacer(modifier = Modifier.height(Dimensions.Spacing.medium))
             }
       }
 }
 
+/**
+ * Handles everything related to the email field
+ * @param email email of the user
+ * @param isVerified whether the user has his email verified or not
+ * @param onEmailChange callback upon email change
+ * @param onFocusChanged callback upon stop of the edition
+ * @param onSendVerification callback upon click of the verify email button
+ */
 @Composable
 fun EmailSection(
     email: String,
@@ -684,9 +830,9 @@ fun EmailSection(
   Box(
       modifier =
           Modifier.fillMaxWidth()
-              .clip(RoundedCornerShape(20.dp))
+              .clip(RoundedCornerShape(Dimensions.CornerRadius.extraLarge))
               .background(AppColors.secondary)
-              .padding(14.dp)
+              .padding(Dimensions.Padding.large)
               .testTag(PrivateInfoTestTags.EMAIL_SECTION)) {
         Column {
           Row(
@@ -694,39 +840,41 @@ fun EmailSection(
               horizontalArrangement = Arrangement.SpaceBetween,
               verticalAlignment = Alignment.CenterVertically) {
                 FocusableInputField(
-                    label = { Text("Email") },
+                    label = { Text(text = MainTabUi.PrivateInfo.EMAIL_INPUT_FIELD) },
                     value = email,
                     onValueChange = onEmailChange,
                     trailingIcon = {
                       if (!isVerified) {
                         IconButton(
                             modifier =
-                                Modifier.padding(top = 4.dp)
+                                Modifier.padding(top = Dimensions.Padding.small)
                                     .testTag(PrivateInfoTestTags.EMAIL_SEND_BUTTON),
                             onClick = {
                               onSendVerification()
-                              toast = ToastData("Sent")
+                              toast = ToastData(message = MainTabUi.PrivateInfo.TOAST_MSG)
                             }) {
                               Icon(
                                   imageVector = Icons.AutoMirrored.Filled.Send,
-                                  contentDescription = "Send verification email",
+                                  contentDescription = MainTabUi.PrivateInfo.SEND_ICON_DESC,
                                   tint = AppColors.textIcons)
                             }
                       }
                     },
                     onFocusChanged = onFocusChanged,
-                    modifier = Modifier.weight(1f).testTag(PrivateInfoTestTags.EMAIL_INPUT))
+                    modifier =
+                        Modifier.weight(Dimensions.Weight.full)
+                            .testTag(PrivateInfoTestTags.EMAIL_INPUT))
               }
 
           Row {
             if (isVerified) {
               Text(
-                  text = "Email Verified",
+                  text = MainTabUi.PrivateInfo.VERIFIED_MSG,
                   color = AppColors.affirmative,
                   modifier = Modifier.testTag(PrivateInfoTestTags.EMAIL_VERIFIED_LABEL))
             } else {
               Text(
-                  text = "Email Not Verified",
+                  text = MainTabUi.PrivateInfo.UNVERIFIED_MSG,
                   color = AppColors.negative,
                   modifier = Modifier.testTag(PrivateInfoTestTags.EMAIL_NOT_VERIFIED_LABEL))
             }
@@ -742,6 +890,12 @@ data class ToastData(
     val id: Long = System.currentTimeMillis() // unique per show
 )
 
+/**
+ * Handles the box of text that appears upon sending the verification email
+ * @param toast Toastdata
+ * @param duration How long till the popup dissapears
+ * @param onToastFinished What to do when the duration has elapsed
+ */
 @Composable
 fun ToastHost(toast: ToastData?, duration: Long = 1500L, onToastFinished: () -> Unit) {
   Box(modifier = Modifier.fillMaxSize().testTag(PrivateInfoTestTags.EMAIL_TOAST)) {
@@ -763,18 +917,27 @@ fun ToastHost(toast: ToastData?, duration: Long = 1500L, onToastFinished: () -> 
             Box(
                 modifier =
                     Modifier.background(
-                            color = AppColors.textIconsFade, shape = RoundedCornerShape(20.dp))
-                        .padding(horizontal = 16.dp, vertical = 0.dp)) {
-                  Text(text = data.message, color = Color.White, fontSize = 14.sp)
+                            color = AppColors.textIconsFade,
+                            shape = RoundedCornerShape(Dimensions.CornerRadius.extraLarge))
+                        .padding(horizontal = Dimensions.Padding.extraLarge, vertical = 0.dp)) {
+                  Text(
+                      text = data.message,
+                      color = AppColors.primary,
+                      fontSize = Dimensions.TextSize.standard)
                 }
           }
     }
   }
 }
 
+/**
+ * Handles everything related to the user's roles
+ * @param account Current user
+ * @param viewModel viewmodel used by this screen
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun RolesSection(account: Account, createAccountViewModel: CreateAccountViewModel) {
+fun RolesSection(account: Account, viewModel: ProfileScreenViewModel) {
 
   var isShopChecked by remember { mutableStateOf(account.shopOwner) }
   var isSpaceRented by remember { mutableStateOf(account.spaceRenter) }
@@ -783,13 +946,15 @@ fun RolesSection(account: Account, createAccountViewModel: CreateAccountViewMode
   var pendingAction by remember { mutableStateOf<RoleAction?>(null) }
 
   Box(
-      modifier = Modifier.fillMaxWidth().background(AppColors.secondary).padding(14.dp),
+      modifier =
+          Modifier.fillMaxWidth().background(AppColors.secondary).padding(Dimensions.Padding.large),
       contentAlignment = Alignment.CenterStart) {
         Text(
-            "I also want to:",
+            text = MainTabUi.PrivateInfo.ROLES_TITLE,
             style = MaterialTheme.typography.titleMedium,
             modifier =
-                Modifier.padding(top = 4.dp).testTag(PrivateInfoTestTags.ROLES_SECTION_TITLE))
+                Modifier.padding(top = Dimensions.Padding.small)
+                    .testTag(PrivateInfoTestTags.ROLES_SECTION_TITLE))
       }
 
   RoleCheckBox(
@@ -800,12 +965,12 @@ fun RolesSection(account: Account, createAccountViewModel: CreateAccountViewMode
           showDialog = true
         } else {
           isShopChecked = true
-          createAccountViewModel.setAccountRole(
+          viewModel.setAccountRole(
               account, isShopOwner = true, isSpaceRenter = isSpaceRented)
         }
       },
-      label = "Sell Items",
-      description = "List your shop and games you sell",
+      label = MainTabUi.PrivateInfo.SELL_ITEMS_LABEL,
+      description = MainTabUi.PrivateInfo.SELL_ITEMS_DESC,
       testTag = PrivateInfoTestTags.ROLE_SHOP_CHECKBOX)
 
   RoleCheckBox(
@@ -816,12 +981,12 @@ fun RolesSection(account: Account, createAccountViewModel: CreateAccountViewMode
           showDialog = true
         } else {
           isSpaceRented = true
-          createAccountViewModel.setAccountRole(
+          viewModel.setAccountRole(
               account, isShopOwner = isShopChecked, isSpaceRenter = true)
         }
       },
-      label = "Rent out spaces",
-      description = "Offer your play spaces for other players to book.",
+      label = MainTabUi.PrivateInfo.RENT_SPACES_LABEL,
+      description = MainTabUi.PrivateInfo.RENT_SPACES_DESC,
       testTag = PrivateInfoTestTags.ROLE_SPACE_CHECKBOX)
 
   // CONFIRMATION DIALOG
@@ -834,13 +999,13 @@ fun RolesSection(account: Account, createAccountViewModel: CreateAccountViewMode
             RoleAction.ShopOff -> {
               // Todo: Delete user's shops from the platform
               isShopChecked = false
-              createAccountViewModel.setAccountRole(
+              viewModel.setAccountRole(
                   account, isShopOwner = false, isSpaceRenter = isSpaceRented)
             }
             RoleAction.SpaceOff -> {
               // Todo: Delete user's spaces from the platform
               isSpaceRented = false
-              createAccountViewModel.setAccountRole(
+              viewModel.setAccountRole(
                   account, isShopOwner = isShopChecked, isSpaceRenter = false)
             }
             else -> {}
@@ -860,6 +1025,13 @@ private enum class RoleAction {
   SpaceOff
 }
 
+/**
+ * Handles the dialog that pops upon removal of a role
+ * @param visible whether this popup is visible
+ * @param action Differentiates between removing Shop/SpaceRenter role
+ * @param onConfirm callback upon confirmation
+ * @param onCancel callback upon cancellation
+ */
 @Composable
 private fun RemoveCatalogDialog(
     visible: Boolean,
@@ -869,11 +1041,10 @@ private fun RemoveCatalogDialog(
 ) {
   val informativeText =
       when (action) {
-        RoleAction.ShopOff ->
-            "Are you sure you want to stop selling items? Your shops will be removed from the platform.\nThis action is irreversible."
-        RoleAction.SpaceOff ->
-            "Are you sure you want to stop renting out spaces? Your spaces will be removed from the platform.\nThis action is irreversible."
+        RoleAction.ShopOff -> MainTabUi.PrivateInfo.ROLE_ACTION_SHOP
+        RoleAction.SpaceOff -> MainTabUi.PrivateInfo.ROLE_ACTION_SPACE
       }
+
   if (visible) {
     AlertDialog(
         containerColor = AppColors.primary,
@@ -896,7 +1067,7 @@ private fun RemoveCatalogDialog(
                       contentColor = AppColors.textIcons,
                       disabledContainerColor = AppColors.divider,
                       disabledContentColor = AppColors.textIcons)) {
-                Text("Confirm")
+                Text(text = MainTabUi.PrivateInfo.DIALOG_CONFIRM)
               }
         },
         dismissButton = {
@@ -909,10 +1080,10 @@ private fun RemoveCatalogDialog(
                       disabledContainerColor = AppColors.affirmative,
                       contentColor = AppColors.textIcons,
                       disabledContentColor = AppColors.textIcons)) {
-                Text("Cancel")
+                Text(text = MainTabUi.PrivateInfo.DIALOG_CANCEL)
               }
         },
-        shape = RoundedCornerShape(16.dp))
+        shape = RoundedCornerShape(Dimensions.CornerRadius.extraLarge))
   }
 }
 
@@ -925,6 +1096,11 @@ enum class NotificationPreference {
   NO_ONE
 }
 
+/**
+ * Handles the notification settings section
+ * @param preference The user's selected preference
+ * @param onPreferenceChange callback invoked upon change of preference
+ */
 @Composable
 fun NotificationSettingsSection(
     preference: NotificationPreference,
@@ -933,45 +1109,69 @@ fun NotificationSettingsSection(
   Column(
       modifier =
           Modifier.fillMaxWidth()
-              .clip(RoundedCornerShape(20.dp))
+              .clip(RoundedCornerShape(Dimensions.CornerRadius.extraLarge))
               .background(AppColors.secondary)
-              .padding(20.dp)) {
-        Text(text = "Notification settings", style = MaterialTheme.typography.titleMedium, modifier = Modifier.testTag(
-            NotificationsSectionTestTags.NOTIFICATION_SECTION_TITLE))
+              .padding(Dimensions.Padding.xLarge)) {
+        Text(
+            text = MainTabUi.NotificationsSection.TITLE,
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.testTag(NotificationsSectionTestTags.NOTIFICATION_SECTION_TITLE))
 
-        Spacer(Modifier.height(12.dp))
+        Spacer(Modifier.height(Dimensions.Spacing.large))
 
         NotificationOptionRow(
             modifier = Modifier.testTag(NotificationsSectionTestTags.RADIO_EVERYONE),
-            label = "Accept notifications from everyone",
+            label = MainTabUi.NotificationsSection.OPT_EVERY,
             selected = preference == NotificationPreference.EVERYONE,
             onClick = { onPreferenceChange(NotificationPreference.EVERYONE) })
 
         NotificationOptionRow(
             modifier = Modifier.testTag(NotificationsSectionTestTags.RADIO_FRIENDS),
-            label = "Accept notifications from friends only",
+            label = MainTabUi.NotificationsSection.OPT_FRIENDS,
             selected = preference == NotificationPreference.FRIENDS_ONLY,
             onClick = { onPreferenceChange(NotificationPreference.FRIENDS_ONLY) })
 
         NotificationOptionRow(
             modifier = Modifier.testTag(NotificationsSectionTestTags.RADIO_NONE),
-            label = "Accept notifications from no one",
+            label = MainTabUi.NotificationsSection.OPT_NONE,
             selected = preference == NotificationPreference.NO_ONE,
             onClick = { onPreferenceChange(NotificationPreference.NO_ONE) })
       }
 }
 
+/**
+ * Composable used for the rows options between notification settings
+ * @param label Description of the option
+ * @param selected Whether this option is currently selected
+ * @param onClick callback invoked upon click
+ * @param modifier Additional modifiers to add (used for testTags normally)
+ */
 @Composable
-private fun NotificationOptionRow(label: String, selected: Boolean, onClick: () -> Unit, modifier: Modifier = Modifier) {
+private fun NotificationOptionRow(
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
   Row(
-      modifier = modifier.fillMaxWidth().clickable { onClick() }.padding(vertical = 8.dp),
+      modifier =
+          modifier
+              .fillMaxWidth()
+              .clickable { onClick() }
+              .padding(vertical = Dimensions.Padding.medium),
       verticalAlignment = Alignment.CenterVertically) {
         RadioButton(selected = selected, onClick = onClick)
-        Spacer(Modifier.width(8.dp))
+        Spacer(Modifier.width(Dimensions.Spacing.medium))
         Text(text = label)
       }
 }
 
+/**
+ * Handles the delete account dialog
+ * @param show Whether this dialog is visible
+ * @param onCancel callback upon cancellation of the operation
+ * @param onConfirm callback upon confirmation
+ */
 @Composable
 fun DeleteAccountDialog(show: Boolean, onCancel: () -> Unit, onConfirm: () -> Unit) {
   if (show) {
@@ -979,8 +1179,8 @@ fun DeleteAccountDialog(show: Boolean, onCancel: () -> Unit, onConfirm: () -> Un
         containerColor = AppColors.primary,
         modifier = Modifier.testTag(DeleteAccSectionTestTags.POPUP),
         onDismissRequest = onCancel,
-        title = { Text("Delete account") },
-        text = { Text("Do you really want to delete your account?") },
+        title = { Text(text = MainTabUi.Misc.DIALOG_TITLE) },
+        text = { Text(text = MainTabUi.Misc.DIALOG_DESC) },
         confirmButton = {
           TextButton(
               onClick = onConfirm,
@@ -991,7 +1191,7 @@ fun DeleteAccountDialog(show: Boolean, onCancel: () -> Unit, onConfirm: () -> Un
                       disabledContentColor = AppColors.negative,
                       contentColor = AppColors.textIcons,
                       disabledContainerColor = AppColors.textIcons)) {
-                Text("Confirm")
+                Text(MainTabUi.Misc.DIALOG_CONFIRM)
               }
         },
         dismissButton = {
@@ -1004,7 +1204,7 @@ fun DeleteAccountDialog(show: Boolean, onCancel: () -> Unit, onConfirm: () -> Un
                       disabledContentColor = AppColors.affirmative,
                       contentColor = AppColors.textIcons,
                       disabledContainerColor = AppColors.textIcons)) {
-                Text("Cancel")
+                Text(MainTabUi.Misc.DIALOG_CANCEL)
               }
         })
   }

--- a/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
@@ -102,11 +102,9 @@ object PublicInfoTestTags {
   // ------------------------------------------------------------
   // SECTION 2 — Action Buttons
   // ------------------------------------------------------------
-  const val ACTIONS_CONTAINER = "public_info_actions"
-
   const val ACTION_FRIENDS = "action_friends"
   const val ACTION_NOTIFICATIONS = "action_notifications"
-  const val ACTION_LOGOUT = "action_logout"
+  const val ACTION_LOGOUT = "Logout Button"
 
   // ------------------------------------------------------------
   // SECTION 3 — Inputs

--- a/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
@@ -41,6 +41,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -177,10 +178,10 @@ fun MainTab(
   Column(
       modifier =
           Modifier.fillMaxSize()
-              .padding(ProfileScreenUi.xxLargePadding)
+              .padding(Dimensions.Padding.xxLarge)
               .pointerInput(Unit) { detectTapGestures(onTap = { focusManager.clearFocus() }) }
               .verticalScroll(rememberScrollState()),
-      verticalArrangement = Arrangement.spacedBy(ProfileScreenUi.extraLargeSpacing),
+      verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.extraLarge),
       horizontalAlignment = Alignment.CenterHorizontally) {
         PublicInfo(
             account = account,
@@ -190,6 +191,10 @@ fun MainTab(
             onSignOut = onSignOut)
 
         PrivateInfo(account = account, viewModel = viewModel)
+
+        var pref by remember { mutableStateOf(NotificationPreference.EVERYONE) }
+
+        NotificationSettingsSection(preference = pref, onPreferenceChange = { pref = it })
       }
 }
 
@@ -296,10 +301,13 @@ fun PublicInfoActions(
                 Modifier.width(140.dp).height(46.dp).testTag(PublicInfoTestTags.ACTION_LOGOUT),
             colors =
                 ButtonDefaults.buttonColors(
-                    containerColor = AppColors.textIconsFade, contentColor = AppColors.primary),
+                    containerColor = AppColors.textIconsFade,
+                    disabledContainerColor = AppColors.textIconsFade,
+                    contentColor = Color.Transparent,
+                    disabledContentColor = Color.Transparent),
             shape = RoundedCornerShape(14.dp),
             elevation = ButtonDefaults.buttonElevation(4.dp)) {
-              Text("Logout", color = Color.Transparent)
+              Text("Logout", color = AppColors.primary)
             }
       }
 }
@@ -867,4 +875,57 @@ private fun RemoveCatalogDialog(
         },
         shape = RoundedCornerShape(16.dp))
   }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////
+// NOTIFICATION SETTINGS SECTION
+/////////////////////////////////////////////////////////////////////////////////////
+enum class NotificationPreference {
+  EVERYONE,
+  FRIENDS_ONLY,
+  NO_ONE
+}
+
+@Composable
+fun NotificationSettingsSection(
+    preference: NotificationPreference,
+    onPreferenceChange: (NotificationPreference) -> Unit
+) {
+  Column(
+      modifier =
+          Modifier.fillMaxWidth()
+//              .padding(16.dp)
+              .clip(RoundedCornerShape(20.dp))
+              .background(AppColors.secondary)
+              .padding(20.dp)) {
+        Text(text = "Notification settings", style = MaterialTheme.typography.titleMedium)
+
+        Spacer(Modifier.height(12.dp))
+
+        NotificationOptionRow(
+            label = "Accept notifications from everyone",
+            selected = preference == NotificationPreference.EVERYONE,
+            onClick = { onPreferenceChange(NotificationPreference.EVERYONE) })
+
+        NotificationOptionRow(
+            label = "Accept notifications from friends only",
+            selected = preference == NotificationPreference.FRIENDS_ONLY,
+            onClick = { onPreferenceChange(NotificationPreference.FRIENDS_ONLY) })
+
+        NotificationOptionRow(
+            label = "Accept notifications from no one",
+            selected = preference == NotificationPreference.NO_ONE,
+            onClick = { onPreferenceChange(NotificationPreference.NO_ONE) })
+      }
+}
+
+@Composable
+private fun NotificationOptionRow(label: String, selected: Boolean, onClick: () -> Unit) {
+  Row(
+      modifier = Modifier.fillMaxWidth().clickable { onClick() }.padding(vertical = 8.dp),
+      verticalAlignment = Alignment.CenterVertically) {
+        RadioButton(selected = selected, onClick = onClick)
+        Spacer(Modifier.width(8.dp))
+        Text(text = label)
+      }
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
@@ -62,6 +62,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.rememberAsyncImagePainter
@@ -228,8 +229,8 @@ object MainTabUi {
     const val SEND_ICON_DESC = "Send verification meail"
     const val VERIFIED_MSG = "Email Verified"
     const val UNVERIFIED_MSG = "Email not Verified"
-    const val EMAIL_INVALID_MSG = "Invalid Email"
-    const val ROLES_TITLE = "I also want to"
+    const val EMAIL_INVALID_MSG = "Invalid Email Format"
+    const val ROLES_TITLE = "I also want to:"
     const val SELL_ITEMS_LABEL = "Sell Items"
     const val SELL_ITEMS_DESC = "List your shop and games you sell"
 
@@ -846,7 +847,7 @@ fun EmailSection(
           Modifier.fillMaxWidth()
               .clip(RoundedCornerShape(Dimensions.CornerRadius.extraLarge))
               .background(AppColors.secondary)
-              .padding(Dimensions.Padding.large)
+              .padding(horizontal = Dimensions.Padding.large)
               .testTag(PrivateInfoTestTags.EMAIL_SECTION)) {
         Column {
           Row(
@@ -986,11 +987,14 @@ fun RolesSection(account: Account, viewModel: ProfileScreenViewModel) {
 
   Box(
       modifier =
-          Modifier.fillMaxWidth().background(AppColors.secondary).padding(Dimensions.Padding.large),
+          Modifier.fillMaxWidth()
+              .background(AppColors.secondary)
+              .padding(horizontal = Dimensions.Padding.large),
       contentAlignment = Alignment.CenterStart) {
         Text(
             text = MainTabUi.PrivateInfo.ROLES_TITLE,
             style = MaterialTheme.typography.titleMedium,
+            fontSize = Dimensions.TextSize.largeHeading,
             modifier =
                 Modifier.padding(top = Dimensions.Padding.small)
                     .testTag(PrivateInfoTestTags.ROLES_SECTION_TITLE))

--- a/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
@@ -184,9 +184,9 @@ object MainTabUi {
   val LOGOUT_BUTTON_W = 140.dp
   val LOGOUT_BUTTON_H = 46.dp
   val AVATAR_SIZE = 130.dp
-    val OFFSET_X = 4.dp
-    val OFFSET_Y = (-4).dp
-    val MAX_NOTIF_COUNT = 9
+  val OFFSET_X = 4.dp
+  val OFFSET_Y = (-4).dp
+  val MAX_NOTIF_COUNT = 9
 
   object Misc {
     const val DELETE_ACCOUNT = "Delete Account"
@@ -453,7 +453,8 @@ fun PublicInfoActions(
                       contentAlignment = Alignment.Center) {
                         Text(
                             text =
-                                if (notificationCount > MainTabUi.MAX_NOTIF_COUNT) "9+" else notificationCount.toString(),
+                                if (notificationCount > MainTabUi.MAX_NOTIF_COUNT) "9+"
+                                else notificationCount.toString(),
                             color = AppColors.primary,
                             fontSize = Dimensions.TextSize.tiny)
                       }

--- a/app/src/main/java/com/github/meeplemeet/ui/account/ProfileScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/ProfileScreen.kt
@@ -41,7 +41,7 @@ object ProfileScreenUi {
  * @param viewModel ViewModel for authentication-related operations.
  * @param account The current user's account.
  * @param viewModel ViewModel for discussion-related operations.
- * @param onSignOut Callback function to be invoked on sign out.
+ * @param onSignOutOrDel Callback function to be invoked on sign out.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -49,8 +49,8 @@ fun ProfileScreen(
     navigation: NavigationActions,
     viewModel: ProfileScreenViewModel = viewModel(),
     account: Account,
-    onSignOut: () -> Unit,
-    onDelAcc: () -> Unit
+    onSignOutOrDel: () -> Unit,
+    onDelete: () -> Unit
 ) {
   val uiState by viewModel.uiState.collectAsState()
 
@@ -83,9 +83,8 @@ fun ProfileScreen(
                   account = account,
                   onFriendsClick = {}, // define when implemented
                   onNotificationClick = {}, // define when implemented
-                  onDelAcc = onDelAcc, // define when implemented
-                  onSignOut = onSignOut,
-              )
+                  onSignOutOrDel = onSignOutOrDel,
+                  onDelete = onDelete)
             }
       }
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/account/ProfileScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/ProfileScreen.kt
@@ -17,8 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.meeplemeet.model.account.Account
-import com.github.meeplemeet.model.account.CreateAccountViewModel
-import com.github.meeplemeet.model.auth.AuthenticationViewModel
+import com.github.meeplemeet.model.account.ProfileScreenViewModel
 import com.github.meeplemeet.ui.navigation.BottomNavigationMenu
 import com.github.meeplemeet.ui.navigation.MeepleMeetScreen
 import com.github.meeplemeet.ui.navigation.NavigationActions
@@ -48,15 +47,14 @@ object ProfileScreenUi {
 @Composable
 fun ProfileScreen(
     navigation: NavigationActions,
-    authViewModel: AuthenticationViewModel = viewModel(),
-    createAccountViewModel: CreateAccountViewModel = viewModel(),
+    viewModel: ProfileScreenViewModel = viewModel(),
     account: Account,
     onSignOut: () -> Unit
 ) {
-  val uiState by authViewModel.uiState.collectAsState()
+  val uiState by viewModel.uiState.collectAsState()
 
   // Refresh email verification status when the profile is shown
-  LaunchedEffect(account.uid) { authViewModel.refreshEmailVerificationStatus() }
+  LaunchedEffect(account.uid) { viewModel.refreshEmailVerificationStatus() }
 
   Scaffold(
       topBar = {
@@ -80,8 +78,7 @@ fun ProfileScreen(
             modifier = Modifier.fillMaxSize().padding(innerPadding),
             contentAlignment = Alignment.TopCenter) {
               MainTab(
-                  authViewModel = authViewModel,
-                  createAccountViewModel = createAccountViewModel,
+                  viewModel = viewModel,
                   account = account,
                   onFriendsClick = {}, // define if needed
                   onNotificationClick = {}, // define if needed

--- a/app/src/main/java/com/github/meeplemeet/ui/account/ProfileScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/ProfileScreen.kt
@@ -3,25 +3,19 @@ package com.github.meeplemeet.ui.account
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.testTag
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.meeplemeet.model.account.Account
 import com.github.meeplemeet.model.account.ProfileScreenViewModel
 import com.github.meeplemeet.ui.navigation.BottomNavigationMenu
 import com.github.meeplemeet.ui.navigation.MeepleMeetScreen
 import com.github.meeplemeet.ui.navigation.NavigationActions
-import com.github.meeplemeet.ui.navigation.NavigationTestTags
 import com.github.meeplemeet.ui.theme.Dimensions
 
 object ProfileTestTags {
@@ -52,22 +46,10 @@ fun ProfileScreen(
     onSignOutOrDel: () -> Unit,
     onDelete: () -> Unit
 ) {
-  val uiState by viewModel.uiState.collectAsState()
-
   // Refresh email verification status when the profile is shown
   LaunchedEffect(account.uid) { viewModel.refreshEmailVerificationStatus() }
 
   Scaffold(
-      topBar = {
-        CenterAlignedTopAppBar(
-            title = {
-              Text(
-                  text = MeepleMeetScreen.Profile.title,
-                  style = MaterialTheme.typography.bodyMedium,
-                  color = MaterialTheme.colorScheme.onPrimary,
-                  modifier = Modifier.testTag(NavigationTestTags.SCREEN_TITLE))
-            })
-      },
       bottomBar = {
         BottomNavigationMenu(
             currentScreen = MeepleMeetScreen.Profile,

--- a/app/src/main/java/com/github/meeplemeet/ui/account/ProfileScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/ProfileScreen.kt
@@ -50,6 +50,7 @@ fun ProfileScreen(
     viewModel: ProfileScreenViewModel = viewModel(),
     account: Account,
     onSignOut: () -> Unit,
+    onDelAcc: () -> Unit
 ) {
   val uiState by viewModel.uiState.collectAsState()
 
@@ -82,7 +83,7 @@ fun ProfileScreen(
                   account = account,
                   onFriendsClick = {}, // define when implemented
                   onNotificationClick = {}, // define when implemented
-                  onDelAcc = {}, // define when implemented
+                  onDelAcc = onDelAcc, // define when implemented
                   onSignOut = onSignOut,
               )
             }

--- a/app/src/main/java/com/github/meeplemeet/ui/account/ProfileScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/ProfileScreen.kt
@@ -49,7 +49,7 @@ fun ProfileScreen(
     navigation: NavigationActions,
     viewModel: ProfileScreenViewModel = viewModel(),
     account: Account,
-    onSignOut: () -> Unit
+    onSignOut: () -> Unit,
 ) {
   val uiState by viewModel.uiState.collectAsState()
 
@@ -80,8 +80,9 @@ fun ProfileScreen(
               MainTab(
                   viewModel = viewModel,
                   account = account,
-                  onFriendsClick = {}, // define if needed
-                  onNotificationClick = {}, // define if needed
+                  onFriendsClick = {}, // define when implemented
+                  onNotificationClick = {}, // define when implemented
+                  onDelAcc = {}, // define when implemented
                   onSignOut = onSignOut,
               )
             }

--- a/app/src/main/java/com/github/meeplemeet/ui/account/ProfileScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/ProfileScreen.kt
@@ -1,13 +1,8 @@
 package com.github.meeplemeet.ui.account
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -19,10 +14,10 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.meeplemeet.model.account.Account
+import com.github.meeplemeet.model.account.CreateAccountViewModel
 import com.github.meeplemeet.model.auth.AuthenticationViewModel
 import com.github.meeplemeet.ui.navigation.BottomNavigationMenu
 import com.github.meeplemeet.ui.navigation.MeepleMeetScreen
@@ -53,13 +48,15 @@ object ProfileScreenUi {
 @Composable
 fun ProfileScreen(
     navigation: NavigationActions,
-    viewModel: AuthenticationViewModel = viewModel(),
+    authViewModel: AuthenticationViewModel = viewModel(),
+    createAccountViewModel: CreateAccountViewModel = viewModel(),
     account: Account,
     onSignOut: () -> Unit
 ) {
-  val uiState by viewModel.uiState.collectAsState()
+  val uiState by authViewModel.uiState.collectAsState()
+
   // Refresh email verification status when the profile is shown
-  LaunchedEffect(account.uid) { viewModel.refreshEmailVerificationStatus() }
+  LaunchedEffect(account.uid) { authViewModel.refreshEmailVerificationStatus() }
 
   Scaffold(
       topBar = {
@@ -77,55 +74,19 @@ fun ProfileScreen(
             currentScreen = MeepleMeetScreen.Profile,
             onTabSelected = { screen -> navigation.navigateTo(screen) })
       }) { innerPadding ->
+
+        // New content here
         Box(
             modifier = Modifier.fillMaxSize().padding(innerPadding),
-            contentAlignment = Alignment.Center) {
-              Column(
-                  modifier = Modifier.fillMaxSize().padding(ProfileScreenUi.xxLargePadding),
-                  verticalArrangement = Arrangement.spacedBy(ProfileScreenUi.extraLargeSpacing)) {
-                    Text(text = "Email", style = MaterialTheme.typography.bodyMedium)
-                    Text(text = account.email, style = MaterialTheme.typography.bodySmall)
-
-                    Text(text = "Username", style = MaterialTheme.typography.bodyMedium)
-                    Text(text = account.name, style = MaterialTheme.typography.bodySmall)
-
-                    Text(text = "Handle", style = MaterialTheme.typography.bodyMedium)
-                    Text(text = "@${account.handle}", style = MaterialTheme.typography.bodySmall)
-
-                    Text(text = "Is email verified : ", style = MaterialTheme.typography.bodyMedium)
-
-                    // This is a placeholder for email verification status
-                    if (!uiState.isEmailVerified) {
-                      Button(onClick = { viewModel.sendVerificationEmail() }) {
-                        Text("Resend verification email")
-                      }
-                    }
-                    Text(
-                        text = "${uiState.isEmailVerified}",
-                        style = MaterialTheme.typography.bodySmall)
-
-                    Text(text = "Roles", style = MaterialTheme.typography.bodyMedium)
-                    Text(
-                        text =
-                            buildString {
-                              if (account.shopOwner) append("Shop Owner\n")
-                              if (account.spaceRenter) append("Space Renter\n")
-                              if (!account.shopOwner && !account.spaceRenter) append("None")
-                            },
-                        style = MaterialTheme.typography.bodySmall)
-
-                    Spacer(modifier = Modifier.weight(1f))
-                  }
-              Button(
-                  onClick = {
-                    onSignOut()
-                    viewModel.signOut()
-                    viewModel.signOut()
-                  },
-                  modifier = Modifier.testTag(ProfileTestTags.LOG_OUT_BUTTON),
-                  colors = ButtonDefaults.buttonColors(containerColor = Color.Red)) {
-                    Text("Sign Out", color = Color.White)
-                  }
+            contentAlignment = Alignment.TopCenter) {
+              MainTab(
+                  authViewModel = authViewModel,
+                  createAccountViewModel = createAccountViewModel,
+                  account = account,
+                  onFriendsClick = {}, // define if needed
+                  onNotificationClick = {}, // define if needed
+                  onSignOut = onSignOut,
+              )
             }
       }
 }


### PR DESCRIPTION
## Overview
This PR implements the main tab of the profile screen. It is one of the 3 screens/tabs for the Profile Screen. It exposes to the user all of the public and private information related to his account that he can edit.
This includes the following:

#### Navigation to Other Tabs/Screens
- User can navigate to a notifications screen, where he will be able to read and manage his notifications - Implemented as a placeholder for now
- User can manage his friends (add, remove and block other users) - Implemented as a placeholder for now
- User can logout
- User can delete his account

#### Public Information
- Avatar: user is able to choose between photos from his gallery, taken with his camera at the time of action and no profile picture at all
- Username: user is able to select the username that he wishes to have albeit that it is not empty
- Handle: User is able to change his unique human-readable handle as long as it is not already in use and it is of appropriate size (4-32 characters) and well formatted (no weird characters)
- Description: User is able to change his user description, which can be left empty.

#### Private Information
- Email: User is able to change the email in usage as well as have it verified.
- Roles: User is able to change his roles and therefore can become/resign from his position of shop/space_renter. Resigning from a position will also delete all shops/spaces that were previously owned.

#### Notification Settings
- User can choose between 3 different modes (only one can be active at a time):
	- Everyone: You receive notifications from everyone on the app
	- Friends: You receive notifications from your friends only
	- Nobody: You receive notifications from nobody
	
Demo link: https://i.imgur.com/AH4grcD.gif