### PR TITLE
feat(ui): add friends' screen

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/ui/FriendsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/FriendsScreenTest.kt
@@ -1,0 +1,665 @@
+// This file was done first by hand, corrected and improved using ChatGPT-5
+// and finally completed by copilot
+package com.github.meeplemeet.ui
+
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import com.github.meeplemeet.model.account.Account
+import com.github.meeplemeet.model.account.ProfileScreenViewModel
+import com.github.meeplemeet.model.account.RelationshipStatus
+import com.github.meeplemeet.ui.account.FriendsManagementScreen
+import com.github.meeplemeet.ui.account.FriendsManagementTestTags
+import com.github.meeplemeet.ui.theme.AppTheme
+import com.github.meeplemeet.ui.theme.ThemeMode
+import com.github.meeplemeet.utils.Checkpoint
+import com.github.meeplemeet.utils.FirestoreTests
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class FriendsScreenTest : FirestoreTests() {
+
+  @get:Rule val compose = createComposeRule()
+  @get:Rule val ck = Checkpoint.Rule()
+
+  private fun checkpoint(name: String, block: () -> Unit) = ck.ck(name, block)
+
+  private lateinit var viewModel: ProfileScreenViewModel
+
+  private lateinit var currentUser: Account
+  private lateinit var friend1: Account
+  private lateinit var friend2: Account
+  private lateinit var friend3: Account
+  private lateinit var friend4: Account
+  private lateinit var friend5: Account
+  private lateinit var friend6: Account
+  private lateinit var friend7: Account
+  private lateinit var friend8: Account
+
+  private lateinit var stranger: Account
+  private lateinit var blockedUser: Account
+
+  @Before
+  fun setup() {
+    viewModel = ProfileScreenViewModel(accountRepository, handlesRepository)
+
+    runBlocking {
+      val suffix = System.currentTimeMillis()
+
+      currentUser =
+          accountRepository.createAccount(
+              userHandle = "meeple_host_$suffix",
+              name = "Game Master",
+              email = "host_$suffix@meeple.test",
+              photoUrl = null)
+
+      friend1 =
+          accountRepository.createAccount(
+              userHandle = "meeple_catan_$suffix",
+              name = "Catan Carl",
+              email = "catan_$suffix@meeple.test",
+              photoUrl = null)
+
+      friend2 =
+          accountRepository.createAccount(
+              userHandle = "meeple_ticket_$suffix",
+              name = "Ticket Tina",
+              email = "ticket_$suffix@meeple.test",
+              photoUrl = null)
+
+      friend3 =
+          accountRepository.createAccount(
+              userHandle = "meeple_pandemic_$suffix",
+              name = "Pandemic Pam",
+              email = "pandemic_$suffix@meeple.test",
+              photoUrl = null)
+
+      friend4 =
+          accountRepository.createAccount(
+              userHandle = "extra_azul_$suffix",
+              name = "Azul Alex",
+              email = "azul_$suffix@meeple.test",
+              photoUrl = null)
+
+      friend5 =
+          accountRepository.createAccount(
+              userHandle = "extra_wingspan_$suffix",
+              name = "Wingspan Wendy",
+              email = "wingspan_$suffix@meeple.test",
+              photoUrl = null)
+
+      friend6 =
+          accountRepository.createAccount(
+              userHandle = "extra_gloomhaven_$suffix",
+              name = "Gloomhaven Greg",
+              email = "gloomhaven_$suffix@meeple.test",
+              photoUrl = null)
+
+      friend7 =
+          accountRepository.createAccount(
+              userHandle = "extra_carcassonne_$suffix",
+              name = "Carcassonne Chloe",
+              email = "carcassonne_$suffix@meeple.test",
+              photoUrl = null)
+
+      friend8 =
+          accountRepository.createAccount(
+              userHandle = "extra_dixit_$suffix",
+              name = "Dixit Dan",
+              email = "dixit_$suffix@meeple.test",
+              photoUrl = null)
+
+      // Stranger that we block via search
+      stranger =
+          accountRepository.createAccount(
+              userHandle = "meeple_spy_$suffix",
+              name = "Spyfall Sam",
+              email = "spy_$suffix@meeple.test",
+              photoUrl = null)
+
+      // Already-blocked user
+      blockedUser =
+          accountRepository.createAccount(
+              userHandle = "meeple_blocked_$suffix",
+              name = "Blocked Codenames",
+              email = "blocked_$suffix@meeple.test",
+              photoUrl = null)
+
+      // Register handles so searchByHandle() can find them
+      handlesRepository.createAccountHandle(currentUser.uid, currentUser.handle)
+      handlesRepository.createAccountHandle(friend1.uid, friend1.handle)
+      handlesRepository.createAccountHandle(friend2.uid, friend2.handle)
+      handlesRepository.createAccountHandle(friend3.uid, friend3.handle)
+      handlesRepository.createAccountHandle(friend4.uid, friend4.handle)
+      handlesRepository.createAccountHandle(friend5.uid, friend5.handle)
+      handlesRepository.createAccountHandle(friend6.uid, friend6.handle)
+      handlesRepository.createAccountHandle(friend7.uid, friend7.handle)
+      handlesRepository.createAccountHandle(friend8.uid, friend8.handle)
+      handlesRepository.createAccountHandle(stranger.uid, stranger.handle)
+      handlesRepository.createAccountHandle(blockedUser.uid, blockedUser.handle)
+
+      // Make friend1..friend8 friends of currentUser
+      suspend fun befriend(other: Account) {
+        accountRepository.sendFriendRequest(currentUser.uid, other.uid)
+        accountRepository.acceptFriendRequest(other.uid, currentUser.uid)
+      }
+
+      befriend(friend1)
+      befriend(friend2)
+      befriend(friend3)
+      befriend(friend4)
+      befriend(friend5)
+      befriend(friend6)
+      befriend(friend7)
+      befriend(friend8)
+
+      // Block one user
+      accountRepository.blockUser(currentUser.uid, blockedUser.uid)
+
+      // Refresh all accounts from Firestore to get relationships maps populated
+      currentUser = accountRepository.getAccount(currentUser.uid)
+      friend1 = accountRepository.getAccount(friend1.uid)
+      friend2 = accountRepository.getAccount(friend2.uid)
+      friend3 = accountRepository.getAccount(friend3.uid)
+      friend4 = accountRepository.getAccount(friend4.uid)
+      friend5 = accountRepository.getAccount(friend5.uid)
+      friend6 = accountRepository.getAccount(friend6.uid)
+      friend7 = accountRepository.getAccount(friend7.uid)
+      friend8 = accountRepository.getAccount(friend8.uid)
+      stranger = accountRepository.getAccount(stranger.uid)
+      blockedUser = accountRepository.getAccount(blockedUser.uid)
+    }
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // TEST 1 – Smoke test: top bar, search bar, friends list & scrollbar
+  // ────────────────────────────────────────────────────────────────────────────
+
+  @OptIn(ExperimentalTestApi::class)
+  @Test
+  fun friendsScreen_smoke_showsTopBarSearchAndFriendList() {
+    compose.setContent {
+      AppTheme(themeMode = ThemeMode.DARK) {
+        FriendsManagementScreen(
+            account = currentUser,
+            viewModel = viewModel,
+            onBack = {},
+        )
+      }
+    }
+
+    // Let the first composition settle
+    compose.waitForIdle()
+
+    // Sanity: screen root is there
+    compose.waitUntilAtLeastOneExists(
+        hasTestTag(FriendsManagementTestTags.SCREEN_ROOT),
+        timeoutMillis = 5_000,
+    )
+
+    /* 1  Top bar presence ---------------------------------------------------- */
+    checkpoint("Top bar is visible with back button") {
+      compose
+          .onNodeWithTag(FriendsManagementTestTags.TOP_BAR, useUnmergedTree = true)
+          .assertExists()
+          .assertIsDisplayed()
+
+      compose
+          .onNodeWithTag(FriendsManagementTestTags.TOP_BAR_BACK, useUnmergedTree = true)
+          .assertExists()
+          .assertIsDisplayed()
+          .assertHasClickAction()
+    }
+
+    /* 2  Friends section title and list -------------------------------------- */
+    checkpoint("Friends section title and list are visible") {
+      // Wait until at least one friend row exists -> means friends have been loaded
+      compose.waitUntil(timeoutMillis = 5_000) {
+        compose
+            .onAllNodesWithTag(
+                FriendsManagementTestTags.FRIEND_ITEM_PREFIX + friend1.uid,
+                useUnmergedTree = true,
+            )
+            .fetchSemanticsNodes()
+            .isNotEmpty()
+      }
+
+      // Section title should now be visible
+      compose
+          .onNodeWithTag(
+              FriendsManagementTestTags.SECTION_TITLE_FRIENDS,
+              useUnmergedTree = true,
+          )
+          .assertExists()
+          .assertIsDisplayed()
+
+      // And the list container itself should exist & be visible
+      compose
+          .onNodeWithTag(
+              FriendsManagementTestTags.FRIEND_LIST,
+              useUnmergedTree = true,
+          )
+          .assertExists()
+          .assertIsDisplayed()
+    }
+
+    /* 3  Friend rows, avatars and actions ------------------------------------ */
+    checkpoint("Friend rows, avatars and actions are present for each friend") {
+      // Wait until at least one friend row exists -> means friends have been loaded
+      compose.waitUntil(timeoutMillis = 5_000) {
+        compose
+            .onAllNodes(
+                SemanticsMatcher("friend row") { node ->
+                  val tag = node.config.getOrNull(SemanticsProperties.TestTag)
+                  tag?.startsWith(FriendsManagementTestTags.FRIEND_ITEM_PREFIX) == true
+                },
+                useUnmergedTree = true,
+            )
+            .fetchSemanticsNodes()
+            .isNotEmpty()
+      }
+
+      // Collect visible friend rows
+      val friendRows =
+          compose
+              .onAllNodes(
+                  SemanticsMatcher("friend row") { node ->
+                    val tag = node.config.getOrNull(SemanticsProperties.TestTag)
+                    tag?.startsWith(FriendsManagementTestTags.FRIEND_ITEM_PREFIX) == true
+                  },
+                  useUnmergedTree = true,
+              )
+              .fetchSemanticsNodes()
+
+      assert(friendRows.isNotEmpty()) { "Expected at least one friend row in the list." }
+
+      // Collect visible avatars, block buttons and action buttons
+      val avatars =
+          compose
+              .onAllNodes(
+                  SemanticsMatcher("friend avatar") { node ->
+                    val tag = node.config.getOrNull(SemanticsProperties.TestTag)
+                    tag?.startsWith(FriendsManagementTestTags.AVATAR_PREFIX) == true
+                  },
+                  useUnmergedTree = true,
+              )
+              .fetchSemanticsNodes()
+
+      val blockButtons =
+          compose
+              .onAllNodes(
+                  SemanticsMatcher("friend block button") { node ->
+                    val tag = node.config.getOrNull(SemanticsProperties.TestTag)
+                    tag?.startsWith(FriendsManagementTestTags.FRIEND_BLOCK_BUTTON_PREFIX) == true
+                  },
+                  useUnmergedTree = true,
+              )
+              .fetchSemanticsNodes()
+
+      val actionButtons =
+          compose
+              .onAllNodes(
+                  SemanticsMatcher("friend action button") { node ->
+                    val tag = node.config.getOrNull(SemanticsProperties.TestTag)
+                    tag?.startsWith(FriendsManagementTestTags.FRIEND_ACTION_BUTTON_PREFIX) == true
+                  },
+                  useUnmergedTree = true,
+              )
+              .fetchSemanticsNodes()
+
+      assert(avatars.size >= friendRows.size) {
+        "Expected at least one avatar per friend row; rows=${friendRows.size}, avatars=${avatars.size}"
+      }
+      assert(blockButtons.size >= friendRows.size) {
+        "Expected at least one block button per friend row; rows=${friendRows.size}, blocks=${blockButtons.size}"
+      }
+      assert(actionButtons.size >= friendRows.size) {
+        "Expected at least one action button per friend row; rows=${friendRows.size}, actions=${actionButtons.size}"
+      }
+    }
+
+    /* 4  Scrollbar ----------------------------------------------------------- */
+    checkpoint("Custom scrollbar track and thumb are visible with enough friends") {
+      compose.waitUntil(timeoutMillis = 3_000) {
+        compose
+            .onAllNodesWithTag(
+                FriendsManagementTestTags.SCROLLBAR_TRACK,
+                useUnmergedTree = true,
+            )
+            .fetchSemanticsNodes()
+            .isNotEmpty()
+      }
+
+      compose
+          .onNodeWithTag(
+              FriendsManagementTestTags.SCROLLBAR_TRACK,
+              useUnmergedTree = true,
+          )
+          .assertExists()
+          .assertIsDisplayed()
+
+      compose
+          .onNodeWithTag(
+              FriendsManagementTestTags.SCROLLBAR_THUMB,
+              useUnmergedTree = true,
+          )
+          .assertExists()
+          .assertIsDisplayed()
+    }
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // TEST 2 – Search mode: dropdown results, clear button, toggle sections
+  // ────────────────────────────────────────────────────────────────────────────
+
+  @OptIn(ExperimentalTestApi::class)
+  @Test
+  fun friendsScreen_search_showsDropdownAndHidesFriendsSection() {
+    compose.setContent {
+      AppTheme(themeMode = ThemeMode.DARK) {
+        FriendsManagementScreen(
+            account = currentUser,
+            viewModel = viewModel,
+            onBack = {},
+        )
+      }
+    }
+
+    compose.waitUntilAtLeastOneExists(
+        hasTestTag(FriendsManagementTestTags.SEARCH_TEXT_FIELD), timeoutMillis = 5_000)
+
+    val searchField =
+        compose.onNodeWithTag(FriendsManagementTestTags.SEARCH_TEXT_FIELD, useUnmergedTree = true)
+
+    /* 1  Type query -> clear icon + dropdown appear ------------------------- */
+    checkpoint("Typing search query shows clear icon and search dropdown") {
+      searchField.performClick()
+      // prefix shared by all non-current handles
+      searchField.performTextInput("meeple_")
+
+      // Clear icon should now be visible
+      compose.waitUntilAtLeastOneExists(
+          hasTestTag(FriendsManagementTestTags.SEARCH_CLEAR), timeoutMillis = 5_000)
+
+      compose
+          .onNodeWithTag(FriendsManagementTestTags.SEARCH_CLEAR, useUnmergedTree = true)
+          .assertExists()
+          .assertIsDisplayed()
+          .assertHasClickAction()
+
+      // Wait for suggestions to flow through and dropdown to be rendered
+      compose.waitUntilAtLeastOneExists(
+          hasTestTag(FriendsManagementTestTags.SEARCH_RESULTS_DROPDOWN), timeoutMillis = 5_000)
+
+      compose
+          .onNodeWithTag(FriendsManagementTestTags.SEARCH_RESULTS_DROPDOWN, useUnmergedTree = true)
+          .assertExists()
+          .assertIsDisplayed()
+    }
+
+    /* 2  Friends section hidden while searching ----------------------------- */
+    checkpoint("Friends list is hidden while search results are visible") {
+      compose
+          .onAllNodesWithTag(FriendsManagementTestTags.FRIEND_LIST, useUnmergedTree = true)
+          .assertCountEquals(0)
+    }
+
+    /* 3  Search result rows and their actions exist ------------------------- */
+    checkpoint("Search results show multiple accounts with avatars and actions") {
+      // currentUser is filtered out, others with prefix "meeple_" should appear
+      val expectedResultUids =
+          listOf(friend1.uid, friend2.uid, friend3.uid, stranger.uid, blockedUser.uid)
+
+      expectedResultUids.forEach { uid ->
+        compose
+            .onNodeWithTag(
+                FriendsManagementTestTags.SEARCH_RESULT_ITEM_PREFIX + uid, useUnmergedTree = true)
+            .assertExists()
+
+        compose
+            .onNodeWithTag(FriendsManagementTestTags.AVATAR_PREFIX + uid, useUnmergedTree = true)
+            .assertExists()
+
+        compose
+            .onNodeWithTag(
+                FriendsManagementTestTags.SEARCH_RESULT_BLOCK_BUTTON_PREFIX + uid,
+                useUnmergedTree = true)
+            .assertExists()
+            .assertHasClickAction()
+
+        compose
+            .onNodeWithTag(
+                FriendsManagementTestTags.SEARCH_RESULT_ACTION_BUTTON_PREFIX + uid,
+                useUnmergedTree = true)
+            .assertExists()
+            .assertHasClickAction()
+      }
+    }
+
+    /* 4  Clear query -> back to friends list -------------------------------- */
+    checkpoint("Clearing search restores friends section and hides dropdown") {
+      compose
+          .onNodeWithTag(FriendsManagementTestTags.SEARCH_CLEAR, useUnmergedTree = true)
+          .performClick()
+
+      compose.waitUntilAtLeastOneExists(
+          hasTestTag(FriendsManagementTestTags.FRIEND_LIST), timeoutMillis = 5_000)
+
+      compose
+          .onNodeWithTag(FriendsManagementTestTags.FRIEND_LIST, useUnmergedTree = true)
+          .assertExists()
+          .assertIsDisplayed()
+
+      compose
+          .onAllNodesWithTag(
+              FriendsManagementTestTags.SEARCH_RESULTS_DROPDOWN, useUnmergedTree = true)
+          .assertCountEquals(0)
+    }
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // TEST 3 – Remove friend from list updates Firestore relationships
+  // ────────────────────────────────────────────────────────────────────────────
+
+  @OptIn(ExperimentalTestApi::class)
+  @Test
+  fun friendsScreen_removeFriend_updatesRepository() {
+    compose.setContent {
+      AppTheme(themeMode = ThemeMode.DARK) {
+        FriendsManagementScreen(
+            account = currentUser,
+            viewModel = viewModel,
+            onBack = {},
+        )
+      }
+    }
+
+    compose.waitUntilAtLeastOneExists(
+        hasTestTag(FriendsManagementTestTags.FRIEND_LIST), timeoutMillis = 5_000)
+
+    checkpoint("Precondition: friend1 is a FRIEND in repository") {
+      val accounts = runBlocking {
+        accountRepository.getAccounts(listOf(currentUser.uid, friend1.uid))
+      }
+      val updatedCurrent = accounts[0]
+      val updatedFriend = accounts[1]
+
+      assert(updatedCurrent.relationships[friend1.uid] == RelationshipStatus.FRIEND) {
+        "Expected currentUser to have FRIEND relationship with friend1 (Catan Carl)"
+      }
+      assert(updatedFriend.relationships[currentUser.uid] == RelationshipStatus.FRIEND) {
+        "Expected friend1 (Catan Carl) to have FRIEND relationship with currentUser"
+      }
+    }
+
+    /* 1  Click remove-friend icon ------------------------------------------- */
+    checkpoint("Remove-friend button for friend1 can be clicked") {
+      compose
+          .onNodeWithTag(
+              FriendsManagementTestTags.FRIEND_ACTION_BUTTON_PREFIX + friend1.uid,
+              useUnmergedTree = true)
+          .assertExists()
+          .assertHasClickAction()
+          .performClick()
+    }
+
+    /* 2  Repository relationship removed on both sides ---------------------- */
+    checkpoint("Clicking remove-friend removes relationship in Firestore") {
+      // Give the ViewModel coroutine a moment to complete
+      runBlocking { delay(200) }
+
+      val accounts = runBlocking {
+        accountRepository.getAccounts(listOf(currentUser.uid, friend1.uid))
+      }
+      val updatedCurrent = accounts[0]
+      val updatedFriend = accounts[1]
+
+      assert(updatedCurrent.relationships[friend1.uid] == null) {
+        "Expected currentUser.relationships[friend1] to be null after removal, was " +
+            updatedCurrent.relationships[friend1.uid]
+      }
+      assert(updatedFriend.relationships[currentUser.uid] == null) {
+        "Expected friend1.relationships[currentUser] to be null after removal, was " +
+            updatedFriend.relationships[currentUser.uid]
+      }
+    }
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // TEST 4 – Block from search results updates Firestore relationships
+  // ────────────────────────────────────────────────────────────────────────────
+
+  @OptIn(ExperimentalTestApi::class)
+  @Test
+  fun friendsScreen_blockFromSearch_updatesRepository() {
+    compose.setContent {
+      AppTheme(themeMode = ThemeMode.DARK) {
+        FriendsManagementScreen(
+            account =
+                currentUser.copy( // ensure we start without relationship to stranger
+                    relationships = currentUser.relationships.filterKeys { it != stranger.uid }),
+            viewModel = viewModel,
+            onBack = {},
+        )
+      }
+    }
+
+    compose.waitUntilAtLeastOneExists(
+        hasTestTag(FriendsManagementTestTags.SEARCH_TEXT_FIELD), timeoutMillis = 5_000)
+
+    val searchField =
+        compose.onNodeWithTag(FriendsManagementTestTags.SEARCH_TEXT_FIELD, useUnmergedTree = true)
+
+    /* 1  Type query to bring up stranger row -------------------------------- */
+    checkpoint("Search dropdown shows stranger row") {
+      searchField.performClick()
+      searchField.performTextInput("meeple_spy_")
+
+      compose.waitUntilAtLeastOneExists(
+          hasTestTag(FriendsManagementTestTags.SEARCH_RESULTS_DROPDOWN), timeoutMillis = 5_000)
+
+      compose
+          .onNodeWithTag(
+              FriendsManagementTestTags.SEARCH_RESULT_ITEM_PREFIX + stranger.uid,
+              useUnmergedTree = true)
+          .assertExists()
+          .assertIsDisplayed()
+    }
+
+    /* 2  Click block icon in stranger search row ---------------------------- */
+    checkpoint("Block button on stranger row can be clicked") {
+      compose
+          .onNodeWithTag(
+              FriendsManagementTestTags.SEARCH_RESULT_BLOCK_BUTTON_PREFIX + stranger.uid,
+              useUnmergedTree = true)
+          .assertExists()
+          .assertHasClickAction()
+          .performClick()
+    }
+
+    /* 3  Repository now has BLOCKED relationship ---------------------------- */
+    checkpoint("Clicking block sets BLOCKED relationship in Firestore") {
+      runBlocking { delay(200) }
+
+      val updatedCurrent = runBlocking { accountRepository.getAccount(currentUser.uid) }
+
+      assert(updatedCurrent.relationships[stranger.uid] == RelationshipStatus.BLOCKED) {
+        "Expected currentUser to BLOCK stranger (Spyfall Sam) after clicking block, " +
+            "but got ${updatedCurrent.relationships[stranger.uid]}"
+      }
+    }
+  }
+
+  @OptIn(ExperimentalTestApi::class)
+  @Test
+  fun friendsScreen_unblockFromSearch_updatesRepository() {
+    // currentUser already has blockedUser as BLOCKED in setup()
+    compose.setContent {
+      AppTheme(themeMode = ThemeMode.DARK) {
+        FriendsManagementScreen(
+            account = currentUser,
+            viewModel = viewModel,
+            onBack = {},
+        )
+      }
+    }
+
+    compose.waitUntilAtLeastOneExists(
+        hasTestTag(FriendsManagementTestTags.SEARCH_TEXT_FIELD), timeoutMillis = 5_000)
+
+    val searchField =
+        compose.onNodeWithTag(FriendsManagementTestTags.SEARCH_TEXT_FIELD, useUnmergedTree = true)
+
+    // 1. Show blocked user in search results
+    checkpoint("Search dropdown shows blocked user row") {
+      searchField.performClick()
+      searchField.performTextInput("meeple_blocked_")
+
+      compose.waitUntilAtLeastOneExists(
+          hasTestTag(FriendsManagementTestTags.SEARCH_RESULTS_DROPDOWN), timeoutMillis = 5_000)
+
+      compose
+          .onNodeWithTag(
+              FriendsManagementTestTags.SEARCH_RESULT_ITEM_PREFIX + blockedUser.uid,
+              useUnmergedTree = true)
+          .assertExists()
+          .assertIsDisplayed()
+    }
+
+    // 2. Tap block/unblock icon
+    checkpoint("Block button on blocked user row can be clicked to unblock") {
+      compose
+          .onNodeWithTag(
+              FriendsManagementTestTags.SEARCH_RESULT_BLOCK_BUTTON_PREFIX + blockedUser.uid,
+              useUnmergedTree = true)
+          .assertExists()
+          .assertHasClickAction()
+          .performClick()
+    }
+
+    // 3. Repository is now neutral
+    checkpoint("Clicking block on a BLOCKED user unblocks in Firestore") {
+      runBlocking { delay(200) }
+
+      val updatedCurrent = runBlocking { accountRepository.getAccount(currentUser.uid) }
+
+      assert(updatedCurrent.relationships[blockedUser.uid] == null) {
+        "Expected currentUser to UNBLOCK blockedUser (Blocked Codenames), but relationship is " +
+            updatedCurrent.relationships[blockedUser.uid]
+      }
+    }
+  }
+}

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/FriendsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/FriendsScreenTest.kt
@@ -15,13 +15,11 @@ import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
-import androidx.navigation.compose.rememberNavController
 import com.github.meeplemeet.model.account.Account
 import com.github.meeplemeet.model.account.FriendsScreenViewModel
 import com.github.meeplemeet.model.account.RelationshipStatus
 import com.github.meeplemeet.ui.account.FriendsManagementTestTags
 import com.github.meeplemeet.ui.account.FriendsScreen
-import com.github.meeplemeet.ui.navigation.NavigationActions
 import com.github.meeplemeet.ui.theme.AppTheme
 import com.github.meeplemeet.ui.theme.ThemeMode
 import com.github.meeplemeet.utils.Checkpoint
@@ -195,10 +193,7 @@ class FriendsScreenTest : FirestoreTests() {
   fun friendsScreen_smoke_showsTopBarSearchAndFriendList() {
     compose.setContent {
       AppTheme(themeMode = ThemeMode.DARK) {
-        val navController = rememberNavController()
-        val navigationActions = NavigationActions(navController)
         FriendsScreen(
-            navigation = navigationActions,
             account = currentUser,
             viewModel = viewModel,
             onBack = {},
@@ -369,10 +364,7 @@ class FriendsScreenTest : FirestoreTests() {
   fun friendsScreen_search_showsDropdownAndHidesFriendsSection() {
     compose.setContent {
       AppTheme(themeMode = ThemeMode.DARK) {
-        val navController = rememberNavController()
-        val navigationActions = NavigationActions(navController)
         FriendsScreen(
-            navigation = navigationActions,
             account = currentUser,
             viewModel = viewModel,
             onBack = {},
@@ -486,10 +478,7 @@ class FriendsScreenTest : FirestoreTests() {
   fun friendsScreen_removeFriend_updatesRepository() {
     compose.setContent {
       AppTheme(themeMode = ThemeMode.DARK) {
-        val navController = rememberNavController()
-        val navigationActions = NavigationActions(navController)
         FriendsScreen(
-            navigation = navigationActions,
             account = currentUser,
             viewModel = viewModel,
             onBack = {},
@@ -557,10 +546,7 @@ class FriendsScreenTest : FirestoreTests() {
   fun friendsScreen_blockFromSearch_updatesRepository() {
     compose.setContent {
       AppTheme(themeMode = ThemeMode.DARK) {
-        val navController = rememberNavController()
-        val navigationActions = NavigationActions(navController)
         FriendsScreen(
-            navigation = navigationActions,
             account =
                 currentUser.copy( // ensure we start without relationship to stranger
                     relationships = currentUser.relationships.filterKeys { it != stranger.uid }),
@@ -622,10 +608,7 @@ class FriendsScreenTest : FirestoreTests() {
     // currentUser already has blockedUser as BLOCKED in setup()
     compose.setContent {
       AppTheme(themeMode = ThemeMode.DARK) {
-        val navController = rememberNavController()
-        val navigationActions = NavigationActions(navController)
         FriendsScreen(
-            navigation = navigationActions,
             account = currentUser,
             viewModel = viewModel,
             onBack = {},

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/FriendsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/FriendsScreenTest.kt
@@ -18,8 +18,8 @@ import androidx.compose.ui.test.performTextInput
 import com.github.meeplemeet.model.account.Account
 import com.github.meeplemeet.model.account.ProfileScreenViewModel
 import com.github.meeplemeet.model.account.RelationshipStatus
-import com.github.meeplemeet.ui.account.FriendsManagementScreen
 import com.github.meeplemeet.ui.account.FriendsManagementTestTags
+import com.github.meeplemeet.ui.account.FriendsScreen
 import com.github.meeplemeet.ui.theme.AppTheme
 import com.github.meeplemeet.ui.theme.ThemeMode
 import com.github.meeplemeet.utils.Checkpoint
@@ -193,7 +193,7 @@ class FriendsScreenTest : FirestoreTests() {
   fun friendsScreen_smoke_showsTopBarSearchAndFriendList() {
     compose.setContent {
       AppTheme(themeMode = ThemeMode.DARK) {
-        FriendsManagementScreen(
+        FriendsScreen(
             account = currentUser,
             viewModel = viewModel,
             onBack = {},
@@ -370,7 +370,7 @@ class FriendsScreenTest : FirestoreTests() {
   fun friendsScreen_search_showsDropdownAndHidesFriendsSection() {
     compose.setContent {
       AppTheme(themeMode = ThemeMode.DARK) {
-        FriendsManagementScreen(
+        FriendsScreen(
             account = currentUser,
             viewModel = viewModel,
             onBack = {},
@@ -479,7 +479,7 @@ class FriendsScreenTest : FirestoreTests() {
   fun friendsScreen_removeFriend_updatesRepository() {
     compose.setContent {
       AppTheme(themeMode = ThemeMode.DARK) {
-        FriendsManagementScreen(
+        FriendsScreen(
             account = currentUser,
             viewModel = viewModel,
             onBack = {},
@@ -547,7 +547,7 @@ class FriendsScreenTest : FirestoreTests() {
   fun friendsScreen_blockFromSearch_updatesRepository() {
     compose.setContent {
       AppTheme(themeMode = ThemeMode.DARK) {
-        FriendsManagementScreen(
+        FriendsScreen(
             account =
                 currentUser.copy( // ensure we start without relationship to stranger
                     relationships = currentUser.relationships.filterKeys { it != stranger.uid }),
@@ -609,7 +609,7 @@ class FriendsScreenTest : FirestoreTests() {
     // currentUser already has blockedUser as BLOCKED in setup()
     compose.setContent {
       AppTheme(themeMode = ThemeMode.DARK) {
-        FriendsManagementScreen(
+        FriendsScreen(
             account = currentUser,
             viewModel = viewModel,
             onBack = {},

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/FriendsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/FriendsScreenTest.kt
@@ -155,7 +155,7 @@ class FriendsScreenTest : FirestoreTests() {
 
       // Make friend1..friend8 friends of currentUser
       suspend fun befriend(other: Account) {
-        accountRepository.sendFriendRequest(currentUser.uid, other.uid)
+        accountRepository.sendFriendRequest(currentUser, other.uid)
         accountRepository.acceptFriendRequest(other.uid, currentUser.uid)
       }
 

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/FriendsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/FriendsScreenTest.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.navigation.compose.rememberNavController
 import com.github.meeplemeet.model.account.Account
-import com.github.meeplemeet.model.account.ProfileScreenViewModel
+import com.github.meeplemeet.model.account.FriendsScreenViewModel
 import com.github.meeplemeet.model.account.RelationshipStatus
 import com.github.meeplemeet.ui.account.FriendsManagementTestTags
 import com.github.meeplemeet.ui.account.FriendsScreen
@@ -39,7 +39,7 @@ class FriendsScreenTest : FirestoreTests() {
 
   private fun checkpoint(name: String, block: () -> Unit) = ck.ck(name, block)
 
-  private lateinit var viewModel: ProfileScreenViewModel
+  private lateinit var viewModel: FriendsScreenViewModel
 
   private lateinit var currentUser: Account
   private lateinit var friend1: Account
@@ -56,7 +56,7 @@ class FriendsScreenTest : FirestoreTests() {
 
   @Before
   fun setup() {
-    viewModel = ProfileScreenViewModel(accountRepository, handlesRepository)
+    viewModel = FriendsScreenViewModel(accountRepository, handlesRepository)
 
     runBlocking {
       val suffix = System.currentTimeMillis()

--- a/app/src/main/java/com/github/meeplemeet/MainActivity.kt
+++ b/app/src/main/java/com/github/meeplemeet/MainActivity.kt
@@ -47,7 +47,7 @@ import com.github.meeplemeet.model.space_renter.SpaceRenter
 import com.github.meeplemeet.model.space_renter.SpaceRenterRepository
 import com.github.meeplemeet.ui.MapScreen
 import com.github.meeplemeet.ui.account.CreateAccountScreen
-import com.github.meeplemeet.ui.account.FriendsManagementScreen
+import com.github.meeplemeet.ui.account.FriendsScreen
 import com.github.meeplemeet.ui.account.ProfileScreen
 import com.github.meeplemeet.ui.auth.SignInScreen
 import com.github.meeplemeet.ui.auth.SignUpScreen
@@ -475,7 +475,7 @@ fun MeepleMeetApp(
     }
     composable(MeepleMeetScreen.Friends.name) {
       account?.let { currentAccount ->
-        FriendsManagementScreen(
+        FriendsScreen(
             account = currentAccount,
             onBack = { navigationActions.goBack() },
         )

--- a/app/src/main/java/com/github/meeplemeet/MainActivity.kt
+++ b/app/src/main/java/com/github/meeplemeet/MainActivity.kt
@@ -47,6 +47,7 @@ import com.github.meeplemeet.model.space_renter.SpaceRenter
 import com.github.meeplemeet.model.space_renter.SpaceRenterRepository
 import com.github.meeplemeet.ui.MapScreen
 import com.github.meeplemeet.ui.account.CreateAccountScreen
+import com.github.meeplemeet.ui.account.FriendsManagementScreen
 import com.github.meeplemeet.ui.account.ProfileScreen
 import com.github.meeplemeet.ui.auth.SignInScreen
 import com.github.meeplemeet.ui.auth.SignUpScreen
@@ -471,6 +472,14 @@ fun MeepleMeetApp(
       } else {
         LoadingScreen()
       }
+    }
+    composable(MeepleMeetScreen.Friends.name) {
+      account?.let { currentAccount ->
+        FriendsManagementScreen(
+            account = currentAccount,
+            onBack = { navigationActions.goBack() },
+        )
+      } ?: navigationActions.navigateTo(MeepleMeetScreen.SignIn)
     }
   }
 }

--- a/app/src/main/java/com/github/meeplemeet/MainActivity.kt
+++ b/app/src/main/java/com/github/meeplemeet/MainActivity.kt
@@ -476,7 +476,6 @@ fun MeepleMeetApp(
     composable(MeepleMeetScreen.Friends.name) {
       account?.let { currentAccount ->
         FriendsScreen(
-            navigation = navigationActions,
             account = currentAccount,
             onBack = { navigationActions.goBack() },
         )

--- a/app/src/main/java/com/github/meeplemeet/MainActivity.kt
+++ b/app/src/main/java/com/github/meeplemeet/MainActivity.kt
@@ -476,6 +476,7 @@ fun MeepleMeetApp(
     composable(MeepleMeetScreen.Friends.name) {
       account?.let { currentAccount ->
         FriendsScreen(
+            navigation = navigationActions,
             account = currentAccount,
             onBack = { navigationActions.goBack() },
         )

--- a/app/src/main/java/com/github/meeplemeet/model/account/AccountViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/AccountViewModel.kt
@@ -26,7 +26,7 @@ interface AccountViewModel {
    * @throws IllegalArgumentException if the ID is blank
    */
   fun getAccount(id: String) {
-    if (id.isBlank()) throw IllegalArgumentException(BLANK_ACCOUNT_ID_ERROR)
+    require(id.isNotBlank()) { BLANK_ACCOUNT_ID_ERROR }
     scope.launch { RepositoryProvider.accounts.getAccount(id, false) }
   }
 
@@ -62,7 +62,7 @@ interface AccountViewModel {
    * @throws IllegalArgumentException if the ID is blank
    */
   fun getOtherAccount(id: String, onResult: (Account) -> Unit) {
-    if (id.isBlank()) throw IllegalArgumentException(BLANK_ACCOUNT_ID_ERROR)
+    require(id.isNotBlank()) { BLANK_ACCOUNT_ID_ERROR }
     scope.launch { onResult(RepositoryProvider.accounts.getAccount(id, false)) }
   }
 
@@ -74,7 +74,7 @@ interface AccountViewModel {
    * @param onResult Callback that receives the retrieved account
    */
   fun getOtherAccount(id: String, context: Context, onResult: (Account) -> Unit) {
-    if (id.isBlank()) throw IllegalArgumentException(BLANK_ACCOUNT_ID_ERROR)
+    require(id.isNotBlank()) { BLANK_ACCOUNT_ID_ERROR }
     scope.launch {
       val account = RepositoryProvider.accounts.getAccount(id, false)
       onResult(account)

--- a/app/src/main/java/com/github/meeplemeet/model/account/AccountViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/AccountViewModel.kt
@@ -6,6 +6,8 @@ import com.github.meeplemeet.RepositoryProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
+const val BLANK_ACCOUNT_ID_ERROR = "Account id cannot be blank"
+
 /**
  * Interface defining common account management operations for ViewModels.
  *
@@ -24,7 +26,7 @@ interface AccountViewModel {
    * @throws IllegalArgumentException if the ID is blank
    */
   fun getAccount(id: String) {
-    if (id.isBlank()) throw IllegalArgumentException("Account id cannot be blank")
+    if (id.isBlank()) throw IllegalArgumentException(BLANK_ACCOUNT_ID_ERROR)
     scope.launch { RepositoryProvider.accounts.getAccount(id, false) }
   }
 
@@ -60,7 +62,7 @@ interface AccountViewModel {
    * @throws IllegalArgumentException if the ID is blank
    */
   fun getOtherAccount(id: String, onResult: (Account) -> Unit) {
-    if (id.isBlank()) throw IllegalArgumentException("Account id cannot be blank")
+    if (id.isBlank()) throw IllegalArgumentException(BLANK_ACCOUNT_ID_ERROR)
     scope.launch { onResult(RepositoryProvider.accounts.getAccount(id, false)) }
   }
 
@@ -72,7 +74,7 @@ interface AccountViewModel {
    * @param onResult Callback that receives the retrieved account
    */
   fun getOtherAccount(id: String, context: Context, onResult: (Account) -> Unit) {
-    if (id.isBlank()) throw IllegalArgumentException("Account id cannot be blank")
+    if (id.isBlank()) throw IllegalArgumentException(BLANK_ACCOUNT_ID_ERROR)
     scope.launch {
       val account = RepositoryProvider.accounts.getAccount(id, false)
       onResult(account)

--- a/app/src/main/java/com/github/meeplemeet/model/account/AccountViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/AccountViewModel.kt
@@ -1,6 +1,7 @@
 // Docs generated with Claude Code.
 package com.github.meeplemeet.model.account
 
+import android.content.Context
 import com.github.meeplemeet.RepositoryProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -28,6 +29,27 @@ interface AccountViewModel {
   }
 
   /**
+   * Retrieves multiple accounts by their IDs and provides them to a callback.
+   *
+   * Additionally, this method preloads each account's profile picture in the provided context.
+   *
+   * @param uids List of account IDs to retrieve
+   * @param context Context used for loading profile pictures
+   * @param onResult Callback that receives the list of retrieved accounts
+   */
+  fun getAccounts(uids: List<String>, context: Context, onResult: (List<Account>) -> Unit) {
+    scope.launch {
+      val accounts = RepositoryProvider.accounts.getAccounts(uids)
+      onResult(accounts)
+      accounts.forEach { account ->
+        launch {
+          runCatching { RepositoryProvider.images.loadAccountProfilePicture(account.uid, context) }
+        }
+      }
+    }
+  }
+
+  /**
    * Retrieves an account by ID and provides it to a callback.
    *
    * This method is useful when you need to fetch account data without updating the current
@@ -40,6 +62,22 @@ interface AccountViewModel {
   fun getOtherAccount(id: String, onResult: (Account) -> Unit) {
     if (id.isBlank()) throw IllegalArgumentException("Account id cannot be blank")
     scope.launch { onResult(RepositoryProvider.accounts.getAccount(id, false)) }
+  }
+
+  /**
+   * Retrieves an account by ID and provides it to a callback, preloading its profile picture.
+   *
+   * @param id The account ID to retrieve
+   * @param context Context used for loading the profile picture
+   * @param onResult Callback that receives the retrieved account
+   */
+  fun getOtherAccount(id: String, context: Context, onResult: (Account) -> Unit) {
+    if (id.isBlank()) throw IllegalArgumentException("Account id cannot be blank")
+    scope.launch {
+      val account = RepositoryProvider.accounts.getAccount(id, false)
+      onResult(account)
+      runCatching { RepositoryProvider.images.loadAccountProfilePicture(account.uid, context) }
+    }
   }
 
   /**

--- a/app/src/main/java/com/github/meeplemeet/model/account/FriendsScreenViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/FriendsScreenViewModel.kt
@@ -64,7 +64,10 @@ class FriendsScreenViewModel(
         other.relationships[account.uid] != null)
         return
 
-    scope.launch { accountRepository.sendFriendRequest(account, other.uid) }
+    scope.launch {
+      accountRepository.sendFriendRequest(account, other.uid)
+      accountRepository.sendFriendRequestNotification(other.uid, account)
+    }
   }
 
   /**

--- a/app/src/main/java/com/github/meeplemeet/model/account/FriendsScreenViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/FriendsScreenViewModel.kt
@@ -1,0 +1,172 @@
+// This file was done first by hand, corrected and improved using ChatGPT-5
+// and finally completed by copilot
+package com.github.meeplemeet.model.account
+
+import android.content.Context
+import androidx.lifecycle.viewModelScope
+import com.github.meeplemeet.RepositoryProvider
+import com.github.meeplemeet.model.images.ImageRepository
+import kotlinx.coroutines.launch
+
+/**
+ * ViewModel for the Friends screen.
+ *
+ * This ViewModel exposes only the operations needed for:
+ * - Managing friendships (send, remove, cancel, accept)
+ * - Blocking / unblocking users
+ * - Loading account profile pictures
+ *
+ * It inherits from [CreateAccountViewModel] so it can reuse the existing handle-based search
+ * functionality (e.g. [searchByHandle], handleSuggestions).
+ *
+ * @property accountRepository The AccountRepository used for data operations.
+ * @property imageRepository The ImageRepository used for loading avatars.
+ */
+class FriendsScreenViewModel(
+    private val accountRepository: AccountRepository = RepositoryProvider.accounts,
+    handlesRepository: HandlesRepository = RepositoryProvider.handles,
+    private val imageRepository: ImageRepository = RepositoryProvider.images,
+) : CreateAccountViewModel(handlesRepository) {
+
+  /**
+   * Checks if two accounts are the same user or if either has blocked the other.
+   *
+   * This helper method is used to prevent relationship operations between users who should not be
+   * able to interact (same user or blocked relationship).
+   *
+   * @param account The first account to check
+   * @param other The second account to check
+   * @return True if the accounts are the same user, or if either has blocked the other
+   */
+  private fun sameOrBlocked(account: Account, other: Account) =
+      account.uid == other.uid ||
+          account.relationships[other.uid] == RelationshipStatus.BLOCKED ||
+          other.relationships[account.uid] == RelationshipStatus.BLOCKED
+
+  /**
+   * Sends a friend request from the current account to another user.
+   *
+   * This method validates that a friend request can be sent before initiating the operation. It
+   * prevents sending requests in the following cases:
+   * - The accounts are the same user
+   * - Either user has blocked the other
+   * - A relationship already exists between the users (any status: Friend, Sent, Pending, or
+   *   Blocked)
+   *
+   * If validation passes, the request is sent asynchronously via the repository.
+   *
+   * @param account The account sending the friend request
+   * @param other The account receiving the friend request
+   */
+  fun sendFriendRequest(account: Account, other: Account) {
+    if (sameOrBlocked(account, other) ||
+        account.relationships[other.uid] != null ||
+        other.relationships[account.uid] != null)
+        return
+
+    scope.launch { accountRepository.sendFriendRequest(account.uid, other.uid) }
+  }
+
+  /**
+   * Blocks another user, preventing all future interactions.
+   *
+   * This method validates that the block operation is valid before proceeding. It prevents blocking
+   * in the following cases:
+   * - The accounts are the same user
+   * - The other user is already blocked by the current account
+   *
+   * If validation passes, the block is executed asynchronously via the repository.
+   *
+   * @param account The account performing the block action
+   * @param other The account being blocked
+   */
+  fun blockUser(account: Account, other: Account) {
+    if (account.uid == other.uid || account.relationships[other.uid] == RelationshipStatus.BLOCKED)
+        return
+
+    scope.launch { accountRepository.blockUser(account.uid, other.uid) }
+  }
+
+  /**
+   * Cancels or denies a sent friend request from the current account to another user.
+   *
+   * This method validates that the operation is valid before proceeding. It prevents canceling in
+   * the following cases:
+   * - The accounts are the same user
+   * - Either user has blocked the other
+   *
+   * If validation passes, the relationship is reset asynchronously via the repository.
+   *
+   * @param account The account canceling the sent friend request
+   * @param other The account to whom the friend request was sent
+   */
+  fun rejectFriendRequest(account: Account, other: Account) {
+    if (sameOrBlocked(account, other)) return
+
+    scope.launch { accountRepository.resetRelationship(account.uid, other.uid) }
+  }
+
+  /**
+   * Removes an existing friendship between two users.
+   *
+   * This method validates that the operation is valid before proceeding. It prevents removing
+   * friendships in the following cases:
+   * - The accounts are the same user
+   * - Either user has blocked the other
+   *
+   * If validation passes, the relationship is reset asynchronously via the repository.
+   *
+   * @param account The account removing the friendship
+   * @param friend The friend to be removed
+   */
+  fun removeFriend(account: Account, friend: Account) {
+    if (sameOrBlocked(account, friend)) return
+
+    scope.launch { accountRepository.resetRelationship(account.uid, friend.uid) }
+  }
+
+  /**
+   * Unblocks a previously blocked user, removing the block status.
+   *
+   * This method validates that the operation is valid before proceeding. It prevents unblocking in
+   * the following cases:
+   * - The accounts are the same user
+   * - The relationship from the current account to the other user is not Blocked
+   *
+   * If validation passes, the unblock is executed asynchronously via the repository.
+   *
+   * @param account The account unblocking the other user
+   * @param other The account being unblocked
+   */
+  fun unblockUser(account: Account, other: Account) {
+    if (account.uid == other.uid || account.relationships[other.uid] != RelationshipStatus.BLOCKED)
+        return
+
+    scope.launch { accountRepository.unblockUser(account.uid, other.uid) }
+  }
+
+  /**
+   * Loads the account profile picture for the given [accountId].
+   *
+   * Used by the FriendsScreen avatar composable to show a profile image or fall back to initials.
+   *
+   * @param accountId The ID of the account whose picture to load
+   * @param context Android Context required by the ImageRepository
+   * @param onLoaded Callback with the loaded bytes, or null on failure
+   */
+  fun loadAccountProfilePicture(
+      accountId: String,
+      context: Context,
+      onLoaded: (ByteArray?) -> Unit
+  ) {
+    viewModelScope.launch {
+      val bytes =
+          try {
+            imageRepository.loadAccountProfilePicture(accountId, context)
+          } catch (_: Exception) {
+            null
+          }
+      onLoaded(bytes)
+    }
+  }
+}

--- a/app/src/main/java/com/github/meeplemeet/model/account/FriendsScreenViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/FriendsScreenViewModel.kt
@@ -64,7 +64,7 @@ class FriendsScreenViewModel(
         other.relationships[account.uid] != null)
         return
 
-    scope.launch { accountRepository.sendFriendRequest(account.uid, other.uid) }
+    scope.launch { accountRepository.sendFriendRequest(account, other.uid) }
   }
 
   /**

--- a/app/src/main/java/com/github/meeplemeet/model/account/ProfileScreenViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/ProfileScreenViewModel.kt
@@ -314,6 +314,22 @@ class ProfileScreenViewModel(
     }
   }
 
+  fun loadAccountProfilePicture(
+      accountId: String,
+      context: Context,
+      onLoaded: (ByteArray?) -> Unit
+  ) {
+    viewModelScope.launch {
+      val bytes =
+          try {
+            imageRepository.loadAccountProfilePicture(accountId, context)
+          } catch (e: Exception) {
+            null
+          }
+      onLoaded(bytes)
+    }
+  }
+
   /**
    * Signs out the current user.
    *

--- a/app/src/main/java/com/github/meeplemeet/model/account/ProfileScreenViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/ProfileScreenViewModel.kt
@@ -314,22 +314,6 @@ class ProfileScreenViewModel(
     }
   }
 
-  fun loadAccountProfilePicture(
-      accountId: String,
-      context: Context,
-      onLoaded: (ByteArray?) -> Unit
-  ) {
-    viewModelScope.launch {
-      val bytes =
-          try {
-            imageRepository.loadAccountProfilePicture(accountId, context)
-          } catch (e: Exception) {
-            null
-          }
-      onLoaded(bytes)
-    }
-  }
-
   /**
    * Signs out the current user.
    *

--- a/app/src/main/java/com/github/meeplemeet/ui/account/FriendsScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/FriendsScreen.kt
@@ -3,6 +3,7 @@
 package com.github.meeplemeet.ui.account
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -565,6 +566,11 @@ private fun FriendsTabSwitcher(
               Modifier.weight(1f)
                   .fillMaxHeight()
                   .background(bgColor)
+                  .border(
+                      width = 0.dp,
+                      color = MaterialTheme.colorScheme.outline,
+                      shape = RectangleShape,
+                  )
                   .clickable { onTabSelected(tab) }
                   .testTag(tabTag),
           contentAlignment = Alignment.Center,

--- a/app/src/main/java/com/github/meeplemeet/ui/account/FriendsScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/FriendsScreen.kt
@@ -39,7 +39,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -67,6 +66,7 @@ import coil.compose.AsyncImage
 import com.github.meeplemeet.model.account.Account
 import com.github.meeplemeet.model.account.ProfileScreenViewModel
 import com.github.meeplemeet.model.account.RelationshipStatus
+import com.github.meeplemeet.ui.FocusableInputField
 import com.github.meeplemeet.ui.theme.Dimensions
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -363,7 +363,7 @@ fun FriendsSearchBar(
     onClearQuery: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-  TextField(
+  FocusableInputField(
       value = query,
       onValueChange = onQueryChange,
       modifier =

--- a/app/src/main/java/com/github/meeplemeet/ui/account/FriendsScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/FriendsScreen.kt
@@ -1,0 +1,774 @@
+// This file was done first by hand, corrected and improved using ChatGPT-5
+// and finally completed by copilot
+package com.github.meeplemeet.ui.account
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Block
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.PersonAdd
+import androidx.compose.material.icons.filled.PersonRemove
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import coil.compose.AsyncImage
+import com.github.meeplemeet.model.account.Account
+import com.github.meeplemeet.model.account.ProfileScreenViewModel
+import com.github.meeplemeet.model.account.RelationshipStatus
+import com.github.meeplemeet.ui.theme.Dimensions
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  TEST TAGS
+// ─────────────────────────────────────────────────────────────────────────────
+
+object FriendsManagementTestTags {
+  const val SCREEN_ROOT = "FRIENDS_SCREEN_ROOT"
+
+  const val TOP_BAR = "FRIENDS_TOP_BAR"
+  const val TOP_BAR_BACK = "FRIENDS_TOP_BAR_BACK"
+
+  const val SEARCH_TEXT_FIELD = "FRIENDS_SEARCH_TEXT_FIELD"
+  const val SEARCH_CLEAR = "FRIENDS_SEARCH_CLEAR"
+
+  const val SECTION_TITLE_FRIENDS = "FRIENDS_SECTION_TITLE"
+  const val FRIEND_LIST = "FRIENDS_LIST"
+  const val FRIEND_ITEM_PREFIX = "FRIEND_ITEM_"
+  const val FRIEND_BLOCK_BUTTON_PREFIX = "FRIEND_BLOCK_BUTTON_"
+  const val FRIEND_ACTION_BUTTON_PREFIX = "FRIEND_ACTION_BUTTON_"
+
+  const val SEARCH_RESULTS_DROPDOWN = "FRIENDS_SEARCH_DROPDOWN"
+  const val SEARCH_RESULT_ITEM_PREFIX = "FRIENDS_SEARCH_ITEM_"
+  const val SEARCH_RESULT_BLOCK_BUTTON_PREFIX = "FRIENDS_SEARCH_BLOCK_BUTTON_"
+  const val SEARCH_RESULT_ACTION_BUTTON_PREFIX = "FRIENDS_SEARCH_ACTION_BUTTON_"
+
+  const val AVATAR_PREFIX = "FRIENDS_AVATAR_"
+
+  const val SCROLLBAR_TRACK = "FRIENDS_SCROLLBAR_TRACK"
+  const val SCROLLBAR_THUMB = "FRIENDS_SCROLLBAR_THUMB"
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  MAGIC NUMBERS
+// ─────────────────────────────────────────────────────────────────────────────
+
+object FriendsManagementDefaults {
+
+  const val TITLE = "Manage your friends"
+  const val SECTION_TITLE_FRIENDS = "Your friends :"
+  const val SEARCH_PLACEHOLDER = "Search users"
+  const val RESET_QUERY_TEXT = ""
+
+  object Layout {
+    val BetweenSearchAndContent = Dimensions.Spacing.large
+    val ItemVerticalPadding = Dimensions.Padding.small
+    val ItemHorizontalPadding = Dimensions.Padding.extraMedium
+    val ItemInnerHorizontalSpacing = Dimensions.Spacing.medium
+    val ItemAvatarNameSpacing = Dimensions.Spacing.medium
+    val ItemActionsSpacing = Dimensions.Spacing.small
+    val SectionTitleBottomPadding = Dimensions.Padding.small
+
+    val RowMinHeight = 72.dp
+    const val MAX_VISIBLE_FRIEND_ROWS = 6
+    const val MAX_VISIBLE_SEARCH_ROWS = 6
+  }
+
+  object Avatar {
+    val SIZE = Dimensions.AvatarSize.medium
+    const val DEFAULT_TEXT_AVATAR = "?"
+  }
+
+  object Scrollbar {
+    val TrackWidth = 15.dp
+    val TrackPadding = Dimensions.Padding.tiny
+    const val MIN_ITEMS_FOR_SCROLLBAR = 8
+    const val SCROLLBAR_ALPHA = 0.1f
+
+    const val EPS = 0.001f
+    const val MIN_SCROLLBAR_SIZE_PERCENTAGE = 0.15f
+    const val MAX_SCROLLBAR_SIZE_PERCENTAGE = 1f
+    const val MIN_COUNT_FOR_SCROLLBAR = 1
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Enums
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Secondary action types for user rows in the friends management screen. */
+enum class UserRowSecondaryAction {
+  ADD_FRIEND,
+  REMOVE_FRIEND,
+}
+
+/** Contexts in which a user row can be displayed in the friends management screen. */
+enum class UserRowContext {
+  FRIEND_LIST,
+  SEARCH_RESULTS,
+}
+
+/** Data class representing scroll metrics for the custom scrollbar. */
+private data class ScrollMetrics(
+    val progress: Float,
+    val thumbFraction: Float,
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Main screen
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Screen for managing friends: viewing current friends, searching users, adding/removing friends,
+ * blocking/unblocking users.
+ *
+ * @param account The current user's account.
+ * @param viewModel The ViewModel managing the profile screen state and actions.
+ * @param onBack Callback invoked when the back button is pressed.
+ */
+@Composable
+fun FriendsManagementScreen(
+    account: Account,
+    viewModel: ProfileScreenViewModel = viewModel(),
+    onBack: () -> Unit,
+) {
+  val suggestions by viewModel.handleSuggestions.collectAsStateWithLifecycle()
+
+  var searchQuery by rememberSaveable { mutableStateOf("") }
+
+  // Load current friends as Account list
+  val friendIds =
+      remember(account.relationships) {
+        account.relationships.filterValues { it == RelationshipStatus.FRIEND }.keys.toList()
+      }
+
+  var friends by remember { mutableStateOf<List<Account>>(emptyList()) }
+
+  LaunchedEffect(friendIds) {
+    if (friendIds.isEmpty()) {
+      friends = emptyList()
+    } else {
+      viewModel.getAccounts(friendIds) { result -> friends = result }
+    }
+  }
+
+  // Keep search suggestions updated
+  LaunchedEffect(searchQuery) { viewModel.searchByHandle(searchQuery.trim()) }
+
+  Scaffold(
+      topBar = {
+        FriendsTopBar(
+            onBack = onBack,
+        )
+      },
+      containerColor = MaterialTheme.colorScheme.background,
+  ) { innerPadding ->
+    Column(
+        modifier =
+            Modifier.fillMaxSize()
+                .padding(innerPadding)
+                .testTag(FriendsManagementTestTags.SCREEN_ROOT),
+    ) {
+      FriendsSearchBar(
+          query = searchQuery,
+          onQueryChange = { searchQuery = it },
+          onClearQuery = { searchQuery = FriendsManagementDefaults.RESET_QUERY_TEXT },
+          modifier = Modifier.fillMaxWidth(),
+      )
+
+      val isSearching = searchQuery.isNotBlank() && suggestions.isNotEmpty()
+
+      if (isSearching) {
+        FriendsSearchResultsDropdown(
+            currentAccount = account,
+            results = suggestions.filter { it.uid != account.uid },
+            onBlockToggle = { other ->
+              if (account.relationships[other.uid] == RelationshipStatus.BLOCKED) {
+                viewModel.unblockUser(account, other)
+              } else {
+                viewModel.blockUser(account, other)
+              }
+            },
+            onAddFriend = { other -> viewModel.sendFriendRequest(account, other) },
+            onRemoveFriend = { other -> viewModel.removeFriend(account, other) },
+            modifier = Modifier.fillMaxWidth(),
+        )
+      } else {
+        Spacer(Modifier.height(FriendsManagementDefaults.Layout.BetweenSearchAndContent))
+
+        Text(
+            text = FriendsManagementDefaults.SECTION_TITLE_FRIENDS,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            modifier =
+                Modifier.padding(Dimensions.Padding.medium)
+                    .fillMaxWidth()
+                    .testTag(FriendsManagementTestTags.SECTION_TITLE_FRIENDS),
+        )
+
+        Spacer(Modifier.height(FriendsManagementDefaults.Layout.SectionTitleBottomPadding))
+
+        FriendsList(
+            currentAccount = account,
+            friends = friends,
+            modifier = Modifier.fillMaxWidth(),
+            onBlockToggle = { friend ->
+              if (account.relationships[friend.uid] == RelationshipStatus.BLOCKED) {
+                viewModel.unblockUser(account, friend)
+              } else {
+                viewModel.blockUser(account, friend)
+              }
+            },
+            onRemoveFriend = { friend -> viewModel.removeFriend(account, friend) },
+        )
+      }
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Composables
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Top bar for the Friends Management screen with a back button and title.
+ *
+ * @param onBack Callback invoked when the back button is pressed.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun FriendsTopBar(
+    onBack: () -> Unit,
+) {
+  CenterAlignedTopAppBar(
+      modifier = Modifier.testTag(FriendsManagementTestTags.TOP_BAR),
+      colors =
+          TopAppBarDefaults.centerAlignedTopAppBarColors(
+              containerColor = MaterialTheme.colorScheme.background,
+          ),
+      title = {
+        Text(
+            text = FriendsManagementDefaults.TITLE,
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.SemiBold,
+        )
+      },
+      navigationIcon = {
+        IconButton(
+            onClick = onBack,
+            modifier = Modifier.testTag(FriendsManagementTestTags.TOP_BAR_BACK),
+        ) {
+          Icon(
+              imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+              contentDescription = "Back",
+          )
+        }
+      },
+  )
+}
+
+/**
+ * Search bar for searching users to add as friends.
+ *
+ * @param query The current search query.
+ * @param onQueryChange Callback invoked when the search query changes.
+ * @param onClearQuery Callback invoked to clear the search query.
+ * @param modifier Modifier to be applied to the search bar.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FriendsSearchBar(
+    query: String,
+    onQueryChange: (String) -> Unit,
+    onClearQuery: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+  TextField(
+      value = query,
+      onValueChange = onQueryChange,
+      modifier =
+          modifier
+              .height(Dimensions.ContainerSize.timeFieldHeight)
+              .testTag(FriendsManagementTestTags.SEARCH_TEXT_FIELD)
+              .shadow(elevation = Dimensions.Elevation.high, shape = RectangleShape, clip = false)
+              .background(MaterialTheme.colorScheme.surface, MaterialTheme.shapes.medium),
+      placeholder = {
+        Text(
+            FriendsManagementDefaults.SEARCH_PLACEHOLDER,
+            style = MaterialTheme.typography.bodyMedium,
+        )
+      },
+      singleLine = true,
+      leadingIcon = {
+        Icon(
+            imageVector = Icons.Default.Search,
+            contentDescription = "Search",
+        )
+      },
+      trailingIcon = {
+        if (query.isNotEmpty()) {
+          IconButton(
+              onClick = onClearQuery,
+              modifier = Modifier.testTag(FriendsManagementTestTags.SEARCH_CLEAR),
+          ) {
+            Icon(
+                imageVector = Icons.Default.Close,
+                contentDescription = "Clear search",
+            )
+          }
+        }
+      },
+      textStyle = MaterialTheme.typography.bodyMedium,
+      shape = RectangleShape,
+      colors =
+          TextFieldDefaults.colors(
+              focusedContainerColor = MaterialTheme.colorScheme.surface,
+              unfocusedContainerColor = MaterialTheme.colorScheme.surface,
+              disabledContainerColor = MaterialTheme.colorScheme.surface,
+              focusedIndicatorColor = Color.Transparent,
+              unfocusedIndicatorColor = Color.Transparent,
+              disabledIndicatorColor = Color.Transparent,
+          ),
+  )
+}
+
+/**
+ * A row representing a user in the friends management context, with options to block/unblock and
+ * add/remove as a friend.
+ *
+ * @param user The user account to display.
+ * @param isBlocked Whether the user is currently blocked.
+ * @param secondaryAction The secondary action to display (add/remove friend).
+ * @param context The context in which this row is used (friend list or search results).
+ * @param onBlockClick Callback invoked when the block/unblock button is clicked.
+ * @param onSecondaryActionClick Callback invoked when the secondary action button is clicked.
+ */
+@Composable
+fun RelationshipUserRow(
+    user: Account,
+    isBlocked: Boolean,
+    secondaryAction: UserRowSecondaryAction,
+    context: UserRowContext,
+    onBlockClick: () -> Unit,
+    onSecondaryActionClick: () -> Unit,
+) {
+  val itemPrefix =
+      when (context) {
+        UserRowContext.FRIEND_LIST -> FriendsManagementTestTags.FRIEND_ITEM_PREFIX
+        UserRowContext.SEARCH_RESULTS -> FriendsManagementTestTags.SEARCH_RESULT_ITEM_PREFIX
+      }
+
+  val blockButtonPrefix =
+      when (context) {
+        UserRowContext.FRIEND_LIST -> FriendsManagementTestTags.FRIEND_BLOCK_BUTTON_PREFIX
+        UserRowContext.SEARCH_RESULTS -> FriendsManagementTestTags.SEARCH_RESULT_BLOCK_BUTTON_PREFIX
+      }
+
+  val actionButtonPrefix =
+      when (context) {
+        UserRowContext.FRIEND_LIST -> FriendsManagementTestTags.FRIEND_ACTION_BUTTON_PREFIX
+        UserRowContext.SEARCH_RESULTS ->
+            FriendsManagementTestTags.SEARCH_RESULT_ACTION_BUTTON_PREFIX
+      }
+
+  Row(
+      modifier =
+          Modifier.fillMaxWidth()
+              .background(MaterialTheme.colorScheme.surface)
+              .defaultMinSize(minHeight = FriendsManagementDefaults.Layout.RowMinHeight)
+              .testTag("$itemPrefix${user.uid}")
+              .padding(
+                  vertical = FriendsManagementDefaults.Layout.ItemVerticalPadding,
+                  horizontal = FriendsManagementDefaults.Layout.ItemHorizontalPadding,
+              ),
+      verticalAlignment = Alignment.CenterVertically,
+  ) {
+    UserAvatar(
+        account = user,
+        modifier =
+            Modifier.size(FriendsManagementDefaults.Avatar.SIZE)
+                .testTag("${FriendsManagementTestTags.AVATAR_PREFIX}${user.uid}"),
+    )
+
+    Spacer(Modifier.width(FriendsManagementDefaults.Layout.ItemAvatarNameSpacing))
+
+    Column(
+        modifier = Modifier.weight(weight = 1f),
+        verticalArrangement = Arrangement.Center,
+    ) {
+      Text(
+          text = user.name,
+          style = MaterialTheme.typography.bodyMedium,
+          color = MaterialTheme.colorScheme.onBackground,
+          fontWeight = FontWeight.Medium,
+          maxLines = 1,
+          overflow = TextOverflow.Ellipsis,
+      )
+      Text(
+          text = "@${user.handle}",
+          style = MaterialTheme.typography.bodySmall,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+          maxLines = 1,
+          overflow = TextOverflow.Ellipsis,
+      )
+    }
+
+    Spacer(Modifier.width(FriendsManagementDefaults.Layout.ItemInnerHorizontalSpacing))
+
+    Row(
+        horizontalArrangement =
+            Arrangement.spacedBy(
+                FriendsManagementDefaults.Layout.ItemActionsSpacing,
+            ),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+      IconButton(
+          onClick = onBlockClick,
+          modifier = Modifier.testTag("$blockButtonPrefix${user.uid}"),
+      ) {
+        Icon(
+            imageVector = Icons.Default.Block,
+            contentDescription = if (isBlocked) "Unblock" else "Block",
+            tint =
+                if (isBlocked) {
+                  MaterialTheme.colorScheme.error
+                } else {
+                  MaterialTheme.colorScheme.onSurfaceVariant
+                },
+        )
+      }
+
+      val (icon, description, tint) =
+          when (secondaryAction) {
+            UserRowSecondaryAction.ADD_FRIEND ->
+                Triple(
+                    Icons.Default.PersonAdd,
+                    "Add friend",
+                    MaterialTheme.colorScheme.onBackground,
+                )
+            UserRowSecondaryAction.REMOVE_FRIEND ->
+                Triple(
+                    Icons.Default.PersonRemove,
+                    "Remove friend",
+                    MaterialTheme.colorScheme.onBackground,
+                )
+          }
+
+      IconButton(
+          onClick = onSecondaryActionClick,
+          modifier = Modifier.testTag("$actionButtonPrefix${user.uid}"),
+      ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = description,
+            tint = tint,
+        )
+      }
+    }
+  }
+}
+
+/**
+ * Composable to display a user's avatar. If the user has a photo URL, it loads and displays the
+ * image; otherwise, it shows the user's initials in a colored circle.
+ *
+ * @param account The user account whose avatar is to be displayed.
+ * @param modifier Modifier to be applied to the avatar.
+ */
+@Composable
+private fun UserAvatar(
+    account: Account,
+    modifier: Modifier = Modifier,
+) {
+  val placeholderColor = MaterialTheme.colorScheme.primary
+  val initials =
+      remember(account.name) {
+        account.name.trim().takeIf { it.isNotEmpty() }?.first()?.uppercase()
+            ?: FriendsManagementDefaults.Avatar.DEFAULT_TEXT_AVATAR
+      }
+
+  Box(
+      modifier =
+          modifier
+              .clip(CircleShape)
+              .background(placeholderColor)
+              .shadow(Dimensions.Elevation.minimal, CircleShape, clip = true),
+      contentAlignment = Alignment.Center,
+  ) {
+    if (account.photoUrl != null) {
+      AsyncImage(
+          model = account.photoUrl,
+          contentDescription = "Profile picture of ${account.name}",
+          contentScale = ContentScale.Crop,
+          modifier = Modifier.fillMaxSize(),
+      )
+    } else {
+      Text(
+          text = initials,
+          style = MaterialTheme.typography.bodyMedium,
+          color = MaterialTheme.colorScheme.onPrimary,
+          fontWeight = FontWeight.SemiBold,
+      )
+    }
+  }
+}
+
+/**
+ * Composable to display a scrollable list of friends with block and remove actions.
+ *
+ * @param currentAccount The current user's account.
+ * @param friends The list of friend accounts to display.
+ * @param onBlockToggle Callback invoked when a friend is blocked or unblocked.
+ * @param onRemoveFriend Callback invoked when a friend is removed.
+ * @param modifier Modifier to be applied to the friends list.
+ */
+@Composable
+fun FriendsList(
+    currentAccount: Account,
+    friends: List<Account>,
+    onBlockToggle: (Account) -> Unit,
+    onRemoveFriend: (Account) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+
+  val listHeight =
+      remember(friends.size) {
+        val visibleRows =
+            friends.size.coerceAtMost(FriendsManagementDefaults.Layout.MAX_VISIBLE_FRIEND_ROWS)
+        FriendsManagementDefaults.Layout.RowMinHeight * visibleRows
+      }
+
+  Box(
+      modifier =
+          modifier
+              .heightIn(max = listHeight)
+              .fillMaxWidth()
+              .testTag(FriendsManagementTestTags.FRIEND_LIST),
+  ) {
+    val listState = rememberLazyListState()
+
+    LazyColumn(
+        state = listState,
+        modifier = Modifier.fillMaxSize(),
+    ) {
+      itemsIndexed(friends, key = { _, friend -> friend.uid }) { index, friend ->
+        val isBlocked = (currentAccount.relationships[friend.uid] == RelationshipStatus.BLOCKED)
+
+        RelationshipUserRow(
+            user = friend,
+            isBlocked = isBlocked,
+            secondaryAction = UserRowSecondaryAction.REMOVE_FRIEND,
+            context = UserRowContext.FRIEND_LIST,
+            onBlockClick = { onBlockToggle(friend) },
+            onSecondaryActionClick = { onRemoveFriend(friend) },
+        )
+
+        if (index < friends.lastIndex) {
+          HorizontalDivider(
+              color = MaterialTheme.colorScheme.onBackground,
+              thickness = Dimensions.DividerThickness.standard,
+          )
+        }
+      }
+    }
+
+    if (friends.size >= FriendsManagementDefaults.Scrollbar.MIN_ITEMS_FOR_SCROLLBAR) {
+      FriendsScrollBar(
+          listState = listState,
+          itemCount = friends.size,
+          modifier = Modifier.align(Alignment.CenterEnd),
+      )
+    }
+  }
+}
+
+/**
+ * Composable to display a custom scrollbar for a lazy list.
+ *
+ * @param listState The state of the lazy list to track scroll position.
+ * @param itemCount The total number of items in the list.
+ * @param modifier Modifier to be applied to the scrollbar.
+ */
+@Composable
+private fun FriendsScrollBar(
+    listState: LazyListState,
+    itemCount: Int,
+    modifier: Modifier = Modifier,
+) {
+  Box(
+      modifier =
+          modifier
+              .fillMaxHeight()
+              .width(FriendsManagementDefaults.Scrollbar.TrackWidth)
+              .padding(FriendsManagementDefaults.Scrollbar.TrackPadding)
+              .clip(CircleShape)
+              .background(
+                  MaterialTheme.colorScheme.background.copy(
+                      alpha = FriendsManagementDefaults.Scrollbar.SCROLLBAR_ALPHA),
+              )
+              .testTag(FriendsManagementTestTags.SCROLLBAR_TRACK),
+  ) {
+    val metrics by remember {
+      derivedStateOf {
+        val visibleItems =
+            listState.layoutInfo.visibleItemsInfo.size.coerceAtLeast(
+                FriendsManagementDefaults.Scrollbar.MIN_COUNT_FOR_SCROLLBAR)
+        val totalItems =
+            itemCount.coerceAtLeast(FriendsManagementDefaults.Scrollbar.MIN_COUNT_FOR_SCROLLBAR)
+
+        // Scroll progress
+        val lastStartIndex =
+            (totalItems - visibleItems).coerceAtLeast(
+                FriendsManagementDefaults.Scrollbar.MIN_COUNT_FOR_SCROLLBAR)
+        val rawProgress =
+            if (totalItems <= visibleItems) 0f
+            else listState.firstVisibleItemIndex.toFloat() / lastStartIndex.toFloat()
+        val progress = rawProgress.coerceIn(0f, 1f)
+
+        // How much of the list is visible
+        val rawThumbFraction = visibleItems.toFloat() / totalItems.toFloat()
+        val thumbFraction =
+            rawThumbFraction.coerceIn(
+                FriendsManagementDefaults.Scrollbar.MIN_SCROLLBAR_SIZE_PERCENTAGE,
+                FriendsManagementDefaults.Scrollbar.MAX_SCROLLBAR_SIZE_PERCENTAGE)
+
+        ScrollMetrics(progress = progress, thumbFraction = thumbFraction)
+      }
+    }
+
+    val thumbFraction = metrics.thumbFraction
+    val remaining = (1f - thumbFraction)
+
+    val rawTop = remaining * metrics.progress
+    val rawBottom = remaining * (1f - metrics.progress)
+
+    val topWeight = rawTop + FriendsManagementDefaults.Scrollbar.EPS
+    val bottomWeight = rawBottom + FriendsManagementDefaults.Scrollbar.EPS
+    val thumbWeight = thumbFraction + FriendsManagementDefaults.Scrollbar.EPS
+
+    Column(modifier = Modifier.fillMaxSize()) {
+      Spacer(modifier = Modifier.weight(topWeight))
+      Box(
+          modifier =
+              Modifier.fillMaxWidth()
+                  .weight(thumbWeight)
+                  .clip(CircleShape)
+                  .background(MaterialTheme.colorScheme.background)
+                  .testTag(FriendsManagementTestTags.SCROLLBAR_THUMB),
+      )
+      Spacer(modifier = Modifier.weight(bottomWeight))
+    }
+  }
+}
+
+/**
+ * Composable to display a dropdown list of search results for adding friends.
+ *
+ * @param currentAccount The current user's account.
+ * @param results The list of account search results to display.
+ * @param onBlockToggle Callback invoked when a user is blocked or unblocked.
+ * @param onAddFriend Callback invoked when a user is added as a friend.
+ * @param onRemoveFriend Callback invoked when a user is removed as a friend.
+ * @param modifier Modifier to be applied to the search results dropdown.
+ */
+@Composable
+fun FriendsSearchResultsDropdown(
+    currentAccount: Account,
+    results: List<Account>,
+    onBlockToggle: (Account) -> Unit,
+    onAddFriend: (Account) -> Unit,
+    onRemoveFriend: (Account) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+
+  val dropdownMaxHeight =
+      remember(results.size) {
+        val visibleRows =
+            results.size.coerceAtMost(FriendsManagementDefaults.Layout.MAX_VISIBLE_SEARCH_ROWS)
+        FriendsManagementDefaults.Layout.RowMinHeight * visibleRows
+      }
+
+  Surface(
+      modifier =
+          modifier
+              .heightIn(max = dropdownMaxHeight)
+              .testTag(FriendsManagementTestTags.SEARCH_RESULTS_DROPDOWN),
+      tonalElevation = Dimensions.Elevation.low,
+      shadowElevation = Dimensions.Elevation.low,
+      shape = RectangleShape,
+      color = MaterialTheme.colorScheme.surface,
+  ) {
+    LazyColumn(modifier = Modifier.fillMaxWidth()) {
+      items(results, key = { it.uid }) { other ->
+        val relStatus = currentAccount.relationships[other.uid]
+        val isFriend = (relStatus == RelationshipStatus.FRIEND)
+        val isBlocked = (relStatus == RelationshipStatus.BLOCKED)
+
+        val action =
+            if (isFriend) UserRowSecondaryAction.REMOVE_FRIEND
+            else UserRowSecondaryAction.ADD_FRIEND
+
+        RelationshipUserRow(
+            user = other,
+            isBlocked = isBlocked,
+            secondaryAction = action,
+            context = UserRowContext.SEARCH_RESULTS,
+            onBlockClick = { onBlockToggle(other) },
+            onSecondaryActionClick = {
+              if (isFriend) onRemoveFriend(other) else onAddFriend(other)
+            },
+        )
+      }
+    }
+  }
+}

--- a/app/src/main/java/com/github/meeplemeet/ui/account/FriendsScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/FriendsScreen.kt
@@ -111,15 +111,15 @@ object FriendsManagementDefaults {
   const val RESET_QUERY_TEXT = ""
 
   object Layout {
-    val BetweenSearchAndContent = Dimensions.Spacing.large
-    val ItemVerticalPadding = Dimensions.Padding.small
-    val ItemHorizontalPadding = Dimensions.Padding.extraMedium
-    val ItemInnerHorizontalSpacing = Dimensions.Spacing.medium
-    val ItemAvatarNameSpacing = Dimensions.Spacing.medium
-    val ItemActionsSpacing = Dimensions.Spacing.small
-    val SectionTitleBottomPadding = Dimensions.Padding.small
+    val BETWEEN_SEARCH_AND_CONTENT = Dimensions.Spacing.large
+    val ITEM_VERTICAL_PADDING = Dimensions.Padding.small
+    val ITEM_HORIZONTAL_PADDING = Dimensions.Padding.extraMedium
+    val ITEM_INNER_HORIZONTAL_SPACING = Dimensions.Spacing.medium
+    val ITEM_AVATAR_NAME_SPACING = Dimensions.Spacing.medium
+    val ITEM_ACTIONS_SPACING = Dimensions.Spacing.small
+    val SECTION_TITLE_BOTTOM_PADDING = Dimensions.Padding.small
 
-    val RowMinHeight = 72.dp
+    val ROW_MIN_HEIGHT = 72.dp
     const val MAX_VISIBLE_FRIEND_ROWS = 6
     const val MAX_VISIBLE_SEARCH_ROWS = 6
   }
@@ -130,8 +130,8 @@ object FriendsManagementDefaults {
   }
 
   object Scrollbar {
-    val TrackWidth = 15.dp
-    val TrackPadding = Dimensions.Padding.tiny
+    val TRACK_WIDTH = 15.dp
+    val TRACK_PADDING = Dimensions.Padding.tiny
     const val MIN_ITEMS_FOR_SCROLLBAR = 8
     const val SCROLLBAR_ALPHA = 0.1f
 
@@ -244,7 +244,7 @@ fun FriendsManagementScreen(
             modifier = Modifier.fillMaxWidth(),
         )
       } else {
-        Spacer(Modifier.height(FriendsManagementDefaults.Layout.BetweenSearchAndContent))
+        Spacer(Modifier.height(FriendsManagementDefaults.Layout.BETWEEN_SEARCH_AND_CONTENT))
 
         Text(
             text = FriendsManagementDefaults.SECTION_TITLE_FRIENDS,
@@ -256,7 +256,7 @@ fun FriendsManagementScreen(
                     .testTag(FriendsManagementTestTags.SECTION_TITLE_FRIENDS),
         )
 
-        Spacer(Modifier.height(FriendsManagementDefaults.Layout.SectionTitleBottomPadding))
+        Spacer(Modifier.height(FriendsManagementDefaults.Layout.SECTION_TITLE_BOTTOM_PADDING))
 
         FriendsList(
             currentAccount = account,
@@ -425,11 +425,11 @@ fun RelationshipUserRow(
       modifier =
           Modifier.fillMaxWidth()
               .background(MaterialTheme.colorScheme.surface)
-              .defaultMinSize(minHeight = FriendsManagementDefaults.Layout.RowMinHeight)
+              .defaultMinSize(minHeight = FriendsManagementDefaults.Layout.ROW_MIN_HEIGHT)
               .testTag("$itemPrefix${user.uid}")
               .padding(
-                  vertical = FriendsManagementDefaults.Layout.ItemVerticalPadding,
-                  horizontal = FriendsManagementDefaults.Layout.ItemHorizontalPadding,
+                  vertical = FriendsManagementDefaults.Layout.ITEM_VERTICAL_PADDING,
+                  horizontal = FriendsManagementDefaults.Layout.ITEM_HORIZONTAL_PADDING,
               ),
       verticalAlignment = Alignment.CenterVertically,
   ) {
@@ -440,7 +440,7 @@ fun RelationshipUserRow(
                 .testTag("${FriendsManagementTestTags.AVATAR_PREFIX}${user.uid}"),
     )
 
-    Spacer(Modifier.width(FriendsManagementDefaults.Layout.ItemAvatarNameSpacing))
+    Spacer(Modifier.width(FriendsManagementDefaults.Layout.ITEM_AVATAR_NAME_SPACING))
 
     Column(
         modifier = Modifier.weight(weight = 1f),
@@ -463,12 +463,12 @@ fun RelationshipUserRow(
       )
     }
 
-    Spacer(Modifier.width(FriendsManagementDefaults.Layout.ItemInnerHorizontalSpacing))
+    Spacer(Modifier.width(FriendsManagementDefaults.Layout.ITEM_INNER_HORIZONTAL_SPACING))
 
     Row(
         horizontalArrangement =
             Arrangement.spacedBy(
-                FriendsManagementDefaults.Layout.ItemActionsSpacing,
+                FriendsManagementDefaults.Layout.ITEM_ACTIONS_SPACING,
             ),
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -585,7 +585,7 @@ fun FriendsList(
       remember(friends.size) {
         val visibleRows =
             friends.size.coerceAtMost(FriendsManagementDefaults.Layout.MAX_VISIBLE_FRIEND_ROWS)
-        FriendsManagementDefaults.Layout.RowMinHeight * visibleRows
+        FriendsManagementDefaults.Layout.ROW_MIN_HEIGHT * visibleRows
       }
 
   Box(
@@ -649,8 +649,8 @@ private fun FriendsScrollBar(
       modifier =
           modifier
               .fillMaxHeight()
-              .width(FriendsManagementDefaults.Scrollbar.TrackWidth)
-              .padding(FriendsManagementDefaults.Scrollbar.TrackPadding)
+              .width(FriendsManagementDefaults.Scrollbar.TRACK_WIDTH)
+              .padding(FriendsManagementDefaults.Scrollbar.TRACK_PADDING)
               .clip(CircleShape)
               .background(
                   MaterialTheme.colorScheme.background.copy(
@@ -735,7 +735,7 @@ fun FriendsSearchResultsDropdown(
       remember(results.size) {
         val visibleRows =
             results.size.coerceAtMost(FriendsManagementDefaults.Layout.MAX_VISIBLE_SEARCH_ROWS)
-        FriendsManagementDefaults.Layout.RowMinHeight * visibleRows
+        FriendsManagementDefaults.Layout.ROW_MIN_HEIGHT * visibleRows
       }
 
   Surface(

--- a/app/src/main/java/com/github/meeplemeet/ui/account/FriendsScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/FriendsScreen.kt
@@ -73,9 +73,6 @@ import com.github.meeplemeet.model.account.Account
 import com.github.meeplemeet.model.account.FriendsScreenViewModel
 import com.github.meeplemeet.model.account.RelationshipStatus
 import com.github.meeplemeet.ui.FocusableInputField
-import com.github.meeplemeet.ui.navigation.BottomNavigationMenu
-import com.github.meeplemeet.ui.navigation.MeepleMeetScreen
-import com.github.meeplemeet.ui.navigation.NavigationActions
 import com.github.meeplemeet.ui.theme.Dimensions
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -249,14 +246,12 @@ private fun FriendsScreenViewModel.toggleBlock(
 /**
  * Composable function to display the Friends Management Screen.
  *
- * @param navigation Navigation actions for screen transitions.
  * @param viewModel ViewModel for friends-related operations.
  * @param account The current user's account.
  * @param onBack Callback function to be invoked when the back button is pressed.
  */
 @Composable
 fun FriendsScreen(
-    navigation: NavigationActions,
     viewModel: FriendsScreenViewModel = viewModel(),
     account: Account,
     onBack: () -> Unit,
@@ -298,12 +293,6 @@ fun FriendsScreen(
 
   Scaffold(
       topBar = { FriendsTopBar(onBack = onBack) },
-      bottomBar = {
-        BottomNavigationMenu(
-            currentScreen = MeepleMeetScreen.Profile,
-            onTabSelected = { screen -> navigation.navigateTo(screen) },
-        )
-      },
       containerColor = MaterialTheme.colorScheme.background,
   ) { innerPadding ->
     Column(

--- a/app/src/main/java/com/github/meeplemeet/ui/account/FriendsScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/FriendsScreen.kt
@@ -69,7 +69,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.AsyncImage
 import com.github.meeplemeet.model.account.Account
-import com.github.meeplemeet.model.account.ProfileScreenViewModel
+import com.github.meeplemeet.model.account.FriendsScreenViewModel
 import com.github.meeplemeet.model.account.RelationshipStatus
 import com.github.meeplemeet.ui.FocusableInputField
 import com.github.meeplemeet.ui.navigation.BottomNavigationMenu
@@ -212,7 +212,7 @@ private fun Account.idsFor(status: RelationshipStatus): List<String> =
  * @param ids List of account IDs to load.
  * @param onResult Callback function to handle the loaded accounts.
  */
-private fun ProfileScreenViewModel.loadAccountsOrEmpty(
+private fun FriendsScreenViewModel.loadAccountsOrEmpty(
     ids: List<String>,
     onResult: (List<Account>) -> Unit,
 ) {
@@ -229,7 +229,7 @@ private fun ProfileScreenViewModel.loadAccountsOrEmpty(
  * @param current The current user's account.
  * @param other The other user's account to block or unblock.
  */
-private fun ProfileScreenViewModel.toggleBlock(
+private fun FriendsScreenViewModel.toggleBlock(
     current: Account,
     other: Account,
 ) {
@@ -249,14 +249,14 @@ private fun ProfileScreenViewModel.toggleBlock(
  * Composable function to display the Friends Management Screen.
  *
  * @param navigation Navigation actions for screen transitions.
- * @param viewModel ViewModel for profile-related operations.
+ * @param viewModel ViewModel for friends-related operations.
  * @param account The current user's account.
  * @param onBack Callback function to be invoked when the back button is pressed.
  */
 @Composable
 fun FriendsScreen(
     navigation: NavigationActions,
-    viewModel: ProfileScreenViewModel = viewModel(),
+    viewModel: FriendsScreenViewModel = viewModel(),
     account: Account,
     onBack: () -> Unit,
 ) {
@@ -350,7 +350,7 @@ fun FriendsScreen(
  * @param suggestions The list of suggested accounts based on the search query.
  * @param searchQuery The current search query.
  * @param selectedTab The currently selected tab in the friends management screen.
- * @param viewModel ViewModel for profile-related operations.
+ * @param viewModel ViewModel for friends-related operations.
  */
 @Composable
 private fun FriendsManagementContent(
@@ -359,7 +359,7 @@ private fun FriendsManagementContent(
     suggestions: List<Account>,
     searchQuery: String,
     selectedTab: FriendsTab,
-    viewModel: ProfileScreenViewModel,
+    viewModel: FriendsScreenViewModel,
 ) {
   val isSearching = searchQuery.isNotBlank()
 
@@ -741,14 +741,14 @@ private fun UserAvatar(
       }
 
   val context = LocalContext.current
-  val profileViewModel: ProfileScreenViewModel = viewModel()
+  val viewModel: FriendsScreenViewModel = viewModel()
   val scope = rememberCoroutineScope()
 
   var avatarBytes by remember(account.uid) { mutableStateOf<ByteArray?>(null) }
 
   LaunchedEffect(account.uid) {
     scope.launch {
-      profileViewModel.loadAccountProfilePicture(
+      viewModel.loadAccountProfilePicture(
           accountId = account.uid,
           context = context,
       ) { bytes ->

--- a/app/src/main/java/com/github/meeplemeet/ui/account/FriendsScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/FriendsScreen.kt
@@ -158,43 +158,85 @@ object FriendsManagementDefaults {
 //  Enums & helpers
 // ─────────────────────────────────────────────────────────────────────────────
 
+/**
+ * Enum representing the secondary action available for a user row.
+ *
+ * @property ADD_FRIEND Action to send a friend request.
+ * @property REMOVE_FRIEND Action to remove an existing friend.
+ * @property REQUEST_SENT Indicates a friend request has already been sent (view-only state).
+ */
 enum class UserRowSecondaryAction {
   ADD_FRIEND,
   REMOVE_FRIEND,
   REQUEST_SENT,
 }
 
+/**
+ * Enum representing the context in which a user row is displayed.
+ *
+ * @property FRIEND_LIST User row is displayed in the friends list.
+ * @property SEARCH_RESULTS User row is displayed in search results.
+ */
 enum class UserRowContext {
   FRIEND_LIST,
   SEARCH_RESULTS,
 }
 
+/**
+ * Enum representing the available tabs in the friends management screen.
+ *
+ * @property FRIENDS Tab displaying the user's friends.
+ * @property REQUESTS Tab displaying sent friend requests.
+ * @property BLOCKED Tab displaying blocked users.
+ */
 enum class FriendsTab {
   FRIENDS,
   REQUESTS,
   BLOCKED,
 }
 
+/**
+ * Data class to hold scroll-related metrics for the custom scrollbar.
+ *
+ * @property progress The current scroll progress (0.0 to 1.0).
+ * @property thumbFraction The fraction of the scrollbar occupied by the thumb (0.0 to 1.0).
+ */
 private data class ScrollMetrics(
     val progress: Float,
     val thumbFraction: Float,
 )
 
+/**
+ * Data class to hold lists of users in different relationship categories.
+ *
+ * @property friends List of accounts that are friends.
+ * @property sentRequests List of accounts to whom friend requests have been sent.
+ * @property blockedUsers List of accounts that are blocked.
+ */
 private data class FriendsLists(
     val friends: List<Account>,
     val sentRequests: List<Account>,
     val blockedUsers: List<Account>,
 )
 
+/** Extension property to check if a relationship status indicates a friend relationship. */
 private val RelationshipStatus?.isFriend: Boolean
   get() = (this == RelationshipStatus.FRIEND)
 
+/** Extension property to check if a relationship status indicates a blocked relationship. */
 private val RelationshipStatus?.isBlocked: Boolean
   get() = (this == RelationshipStatus.BLOCKED)
 
+/** Extension property to check if a relationship status indicates a sent friend request. */
 private val RelationshipStatus?.isRequestSent: Boolean
   get() = (this == RelationshipStatus.SENT)
 
+/**
+ * Data class to hold UI-related data for a friends tab.
+ *
+ * @property label The display label for the tab.
+ * @property testTag The test tag identifier for the tab.
+ */
 private data class FriendsTabUiData(
     val label: String,
     val testTag: String,

--- a/app/src/main/java/com/github/meeplemeet/ui/navigation/NavigationSystem.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/navigation/NavigationSystem.kt
@@ -149,6 +149,7 @@ enum class MeepleMeetScreen(
   CreateSpaceRenter("Create Space Renter"),
   SpaceDetails("Space Renter Details"),
   EditSpaceRenter("Edit Space Renter"),
+  Friends("Friends"),
 }
 
 /**


### PR DESCRIPTION
**Description**
This PR introduces the friends screen. This screen allows a user to manage their list of friends, search for new users and block others.
It introduces the following features:
* Lists of actual friends, requested one's and blocked users
* Possibility of removing or blocking a friend
* Search for other users by handle
* Add or block other users
* VM for the screen
* Preloading images when fetching accounts

**Visuals**
<video controls playsinline muted
       src="https://github.com/user-attachments/assets/aa278bea-f344-4137-88a1-743d6303a86e">

**References**
* Issues: https://github.com/Meeple-Meet/Meeple-Meet/issues/182

**TODOS**
* Integrate it 100% on the app navigation. For the moment there is no entry point for this screen