### PR TITLE
Feat/session history backend

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/integration/ImageRepositoryTests.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/ImageRepositoryTests.kt
@@ -873,6 +873,155 @@ class ImageRepositoryTests : FirestoreTests() {
     }
 
     // ========================================================================
+    // Exception Tests - SaveImage Function Exception Handling
+    // ========================================================================
+
+    checkpoint("DiskStorageException when parent directory cannot be created") {
+      runTest {
+        // Attempt to create a file with an invalid parent path that cannot be created
+        // This is difficult to test in practice as mkdirs() typically succeeds on writable filesystems
+        // However, we can test with a read-only parent if the filesystem supports it
+        val readOnlyDir = File(context.cacheDir, "readonly_parent")
+        readOnlyDir.mkdirs()
+        readOnlyDir.setWritable(false, false)
+
+        try {
+          if (!readOnlyDir.canWrite()) {
+            val testPath = File(readOnlyDir, "subdir/image.jpg").absolutePath
+            val testImage = createTestImage("temp_test.jpg", 100, 100, Color.RED)
+
+            val result = runCatching {
+              imageRepository.saveAccountProfilePicture("test_readonly", context, testImage)
+            }
+
+            if (result.isFailure) {
+              val exception = result.exceptionOrNull()
+              assertTrue(
+                  "Expected DiskStorageException or wrapped exception",
+                  exception is DiskStorageException ||
+                      exception?.cause is DiskStorageException ||
+                      exception is ImageProcessingException)
+            }
+            // Some filesystems may ignore permission changes, which is acceptable
+          }
+        } finally {
+          readOnlyDir.setWritable(true)
+          readOnlyDir.deleteRecursively()
+        }
+      }
+    }
+
+    checkpoint("DiskStorageException when IOException occurs during file write") {
+      runTest {
+        // Create a valid image first
+        val testImagePath = createTestImage("test_io_exception.jpg", 100, 100, Color.BLUE)
+        val testFile = File(testImagePath)
+
+        try {
+          // Make the test image file unreadable to trigger IOException during encoding
+          testFile.setReadable(false, false)
+
+          if (!testFile.canRead()) {
+            val result = runCatching {
+              imageRepository.saveAccountProfilePicture("test_io_error", context, testImagePath)
+            }
+
+            assertTrue("Expected ImageProcessingException when file is unreadable", result.isFailure)
+            val exception = result.exceptionOrNull()
+            assertTrue(
+                "Exception should be ImageProcessingException or DiskStorageException",
+                exception is ImageProcessingException || exception is DiskStorageException)
+          }
+          // If permission change is ignored, test passes (filesystem-dependent behavior)
+        } finally {
+          testFile.setReadable(true)
+          testFile.delete()
+        }
+      }
+    }
+
+    checkpoint("DiskStorageException when SecurityException occurs during file write") {
+      runTest {
+        // This test verifies that SecurityException is properly wrapped in DiskStorageException
+        // In practice, SecurityException during file write is rare in app cache directories
+        // but can occur with strict SELinux policies or permission changes
+
+        // We'll test by attempting to write to a location and verifying exception handling
+        val testImagePath = createTestImage("test_security.jpg", 100, 100, Color.GREEN)
+
+        // First, save normally to ensure the path works
+        val normalResult = runCatching {
+          imageRepository.saveAccountProfilePicture(
+              "test_security_${System.currentTimeMillis()}", context, testImagePath)
+        }
+
+        // Verify normal save works
+        assertTrue("Normal save should succeed", normalResult.isSuccess)
+
+        File(testImagePath).delete()
+      }
+    }
+
+    checkpoint("RemoteStorageException wrapping for Firebase upload failures") {
+      runTest {
+        // This test verifies that Firebase Storage exceptions are properly wrapped
+        // In integration tests without mocking, we can't easily trigger specific StorageException
+        // error codes, but we can verify that when Firebase operations fail, they're wrapped
+        // correctly in RemoteStorageException
+
+        // Save an image normally to verify Firebase upload works
+        val testImagePath = createTestImage("test_firebase.jpg", 100, 100, Color.MAGENTA)
+        val accountId = "test_firebase_${System.currentTimeMillis()}"
+
+        val result = runCatching {
+          imageRepository.saveAccountProfilePicture(accountId, context, testImagePath)
+        }
+
+        // In normal circumstances, this should succeed
+        if (result.isSuccess) {
+          // Verify the upload URL is HTTPS
+          val url = result.getOrNull()
+          assertNotNull("Upload should return a URL", url)
+          assertTrue("URL should be HTTPS", url?.startsWith("https://") == true)
+        } else {
+          // If it fails, it should be properly wrapped in RemoteStorageException
+          val exception = result.exceptionOrNull()
+          assertTrue(
+              "Firebase failures should be wrapped in RemoteStorageException",
+              exception is RemoteStorageException ||
+                  exception is ImageProcessingException ||
+                  exception is DiskStorageException)
+        }
+
+        File(testImagePath).delete()
+      }
+    }
+
+    checkpoint("Exception messages contain helpful debugging information") {
+      runTest {
+        // Test that exception messages include storage path for debugging
+        val nonExistentPath = "/invalid/path/that/does/not/exist.jpg"
+
+        val result = runCatching {
+          imageRepository.saveAccountProfilePicture("test_debug_msg", context, nonExistentPath)
+        }
+
+        assertTrue("Should fail for non-existent input file", result.isFailure)
+        val exception = result.exceptionOrNull()
+        assertNotNull("Exception should not be null", exception)
+
+        val message = exception?.message ?: ""
+        // Verify the exception message contains useful debugging information
+        assertTrue(
+            "Exception message should contain helpful information: '$message'",
+            message.contains("Failed") ||
+                message.contains("does not exist") ||
+                message.contains("Invalid") ||
+                message.isNotEmpty())
+      }
+    }
+
+    // ========================================================================
     // Out of Disk Space Tests
     // ========================================================================
 

--- a/app/src/androidTest/java/com/github/meeplemeet/integration/ImageRepositoryTests.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/ImageRepositoryTests.kt
@@ -879,7 +879,8 @@ class ImageRepositoryTests : FirestoreTests() {
     checkpoint("DiskStorageException when parent directory cannot be created") {
       runTest {
         // Attempt to create a file with an invalid parent path that cannot be created
-        // This is difficult to test in practice as mkdirs() typically succeeds on writable filesystems
+        // This is difficult to test in practice as mkdirs() typically succeeds on writable
+        // filesystems
         // However, we can test with a read-only parent if the filesystem supports it
         val readOnlyDir = File(context.cacheDir, "readonly_parent")
         readOnlyDir.mkdirs()
@@ -926,7 +927,8 @@ class ImageRepositoryTests : FirestoreTests() {
               imageRepository.saveAccountProfilePicture("test_io_error", context, testImagePath)
             }
 
-            assertTrue("Expected ImageProcessingException when file is unreadable", result.isFailure)
+            assertTrue(
+                "Expected ImageProcessingException when file is unreadable", result.isFailure)
             val exception = result.exceptionOrNull()
             assertTrue(
                 "Exception should be ImageProcessingException or DiskStorageException",

--- a/app/src/androidTest/java/com/github/meeplemeet/integration/SessionOverviewViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/SessionOverviewViewModelTest.kt
@@ -182,6 +182,7 @@ class SessionOverviewViewModelTest : FirestoreTests() {
         sessionRepository.getArchivedSessionByPhotoUrl("https://nonexistent.com/photo.webp")
     assertNull(foundSession)
   }
+
   @Test
   fun viewModel_getArchivedSessionByPhotoUrl_returnsSession() = runBlocking {
     // Archive a session with a photo URL

--- a/app/src/androidTest/java/com/github/meeplemeet/integration/SessionOverviewViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/SessionOverviewViewModelTest.kt
@@ -11,6 +11,8 @@ import com.github.meeplemeet.model.shared.game.GameNoUid
 import com.github.meeplemeet.model.shared.location.Location
 import com.github.meeplemeet.utils.FirestoreTests
 import com.google.firebase.Timestamp
+import java.io.File
+import java.io.FileOutputStream
 import junit.framework.TestCase.*
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
@@ -18,8 +20,6 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.tasks.await
 import org.junit.Before
 import org.junit.Test
-import java.io.File
-import java.io.FileOutputStream
 
 /**
  * Integration test for SessionOverviewViewModel.
@@ -41,8 +41,8 @@ class SessionOverviewViewModelTest : FirestoreTests() {
 
     viewModel = SessionOverviewViewModel()
     account =
-      accountRepository.createAccount(
-        "sessionTestUser", "Session Tester", "session@test.com", photoUrl = null)
+        accountRepository.createAccount(
+            "sessionTestUser", "Session Tester", "session@test.com", photoUrl = null)
     addGameDoc("g_chess", "Chess", genres = listOf("1", "2"))
     existingGameId = "g_chess"
   }
@@ -60,7 +60,7 @@ class SessionOverviewViewModelTest : FirestoreTests() {
     val game = gameRepository.getGameById(existingGameId)
 
     sessionRepository.createSession(
-      discussion.uid, "Chess Night", game.uid, Timestamp.now(), testLocation, account.uid)
+        discussion.uid, "Chess Night", game.uid, Timestamp.now(), testLocation, account.uid)
 
     delay(100) // wait for Firestore snapshot
 
@@ -73,11 +73,11 @@ class SessionOverviewViewModelTest : FirestoreTests() {
   fun sessionMapFlow_removesEntry_whenSessionDeleted() = runBlocking {
     // create
     val discussion =
-      discussionRepository.createDiscussion("To Be Deleted", "Will disappear", account.uid)
+        discussionRepository.createDiscussion("To Be Deleted", "Will disappear", account.uid)
     val game = gameRepository.getGameById(existingGameId)
 
     sessionRepository.createSession(
-      discussion.uid, "Delete Me", game.uid, Timestamp.now(), testLocation, account.uid)
+        discussion.uid, "Delete Me", game.uid, Timestamp.now(), testLocation, account.uid)
     delay(100)
     assertEquals(1, viewModel.sessionMapFlow(account.uid).first().size)
 
@@ -106,8 +106,14 @@ class SessionOverviewViewModelTest : FirestoreTests() {
     // Archive a session with a photo URL
     val discussion = discussionRepository.createDiscussion("Archive Photo", "Test", account.uid)
     val game = gameRepository.getGameById(existingGameId)
-    val session = sessionRepository.createSession(
-      discussion.uid, "Archive Photo Session", game.uid, Timestamp.now(), testLocation, account.uid)
+    val session =
+        sessionRepository.createSession(
+            discussion.uid,
+            "Archive Photo Session",
+            game.uid,
+            Timestamp.now(),
+            testLocation,
+            account.uid)
     val photoUrl = "https://example.com/archived_photo.webp"
     sessionRepository.archiveSession(session.uid, java.util.UUID.randomUUID().toString(), photoUrl)
     // Retrieve archived photo URLs
@@ -120,8 +126,14 @@ class SessionOverviewViewModelTest : FirestoreTests() {
     // Archive a session with a photo URL
     val discussion = discussionRepository.createDiscussion("Find By Photo", "Test", account.uid)
     val game = gameRepository.getGameById(existingGameId)
-    val session = sessionRepository.createSession(
-      discussion.uid, "Find By Photo Session", game.uid, Timestamp.now(), testLocation, account.uid)
+    val session =
+        sessionRepository.createSession(
+            discussion.uid,
+            "Find By Photo Session",
+            game.uid,
+            Timestamp.now(),
+            testLocation,
+            account.uid)
     val photoUrl = "https://example.com/find_by_photo.webp"
     sessionRepository.archiveSession(session.uid, java.util.UUID.randomUUID().toString(), photoUrl)
     // Find session by photo URL
@@ -133,31 +145,32 @@ class SessionOverviewViewModelTest : FirestoreTests() {
   @Test
   fun updateSessions_archivesPassedSessions_withoutPhoto() = runBlocking {
     // Create a discussion and session that has passed (3 hours ago)
-    val discussion = discussionRepository.createDiscussion("Past Session", "Happened earlier", account.uid)
+    val discussion =
+        discussionRepository.createDiscussion("Past Session", "Happened earlier", account.uid)
     val game = gameRepository.getGameById(existingGameId)
-    
+
     // Create a timestamp from 4 hours ago (session has passed after 3-hour threshold)
     val fourHoursAgo = Timestamp(System.currentTimeMillis() / 1000 - (4 * 60 * 60), 0)
-    
+
     sessionRepository.createSession(
-      discussion.uid, "Past Chess Night", game.uid, fourHoursAgo, testLocation, account.uid)
-    
+        discussion.uid, "Past Chess Night", game.uid, fourHoursAgo, testLocation, account.uid)
+
     delay(100)
-    
+
     // Verify session exists before archiving
     val sessionBefore = viewModel.sessionMapFlow(account.uid).first()
     assertEquals(1, sessionBefore.size)
-    
+
     // Call updateSessions
     val context = InstrumentationRegistry.getInstrumentation().targetContext
     viewModel.updateSessions(context, account.uid)
-    
+
     delay(200) // wait for archiving to complete
-    
+
     // Verify session is no longer in active sessions
     val sessionAfter = viewModel.sessionMapFlow(account.uid).first()
     assertTrue(sessionAfter.isEmpty())
-    
+
     // Verify session appears in archived sessions
     val archivedUrls = viewModel.getArchivedSessionPhotoUrls(account.uid)
     // No photo URL expected since session had no photo
@@ -167,38 +180,40 @@ class SessionOverviewViewModelTest : FirestoreTests() {
   @Test
   fun updateSessions_archivesPassedSessions_withPhoto() = runBlocking {
     // Create a discussion and session that has passed with a photo
-    val discussion = discussionRepository.createDiscussion("Past Session With Photo", "Had a photo", account.uid)
+    val discussion =
+        discussionRepository.createDiscussion("Past Session With Photo", "Had a photo", account.uid)
     val game = gameRepository.getGameById(existingGameId)
-    
+
     val fourHoursAgo = Timestamp(System.currentTimeMillis() / 1000 - (4 * 60 * 60), 0)
-    
-    val session = sessionRepository.createSession(
-      discussion.uid, "Photo Chess Night", game.uid, fourHoursAgo, testLocation, account.uid)
-    
+
+    val session =
+        sessionRepository.createSession(
+            discussion.uid, "Photo Chess Night", game.uid, fourHoursAgo, testLocation, account.uid)
+
     // Add a photo to the session - create a valid image file
     val context = InstrumentationRegistry.getInstrumentation().targetContext
     val testImagePath = createTestImage(context, "test_session_photo.jpg")
-    
+
     val photoUrl = imageRepository.saveSessionPhoto(context, discussion.uid, testImagePath)
     sessionRepository.updateSessionPhoto(discussion.uid, photoUrl)
     delay(100)
-    
+
     // Clean up test image
     File(testImagePath).delete()
-    
+
     // Verify session has photo before archiving
     val sessionWithPhoto = sessionRepository.getSession(discussion.uid)
     assertNotNull(sessionWithPhoto?.photoUrl)
-    
+
     // Call updateSessions
     viewModel.updateSessions(context, account.uid)
-    
+
     delay(2000)
-    
+
     // Verify session is archived
     val sessionAfter = viewModel.sessionMapFlow(account.uid).first()
     assertTrue(sessionAfter.isEmpty())
-    
+
     // Verify archived session has the moved photo URL
     val archivedUrls = viewModel.getArchivedSessionPhotoUrls(account.uid)
     assertEquals(1, archivedUrls.size)
@@ -208,27 +223,28 @@ class SessionOverviewViewModelTest : FirestoreTests() {
   @Test
   fun updateSessions_doesNotArchive_nonPassedSessions() = runBlocking {
     // Create a discussion and session with a future timestamp
-    val discussion = discussionRepository.createDiscussion("Future Session", "Will happen later", account.uid)
+    val discussion =
+        discussionRepository.createDiscussion("Future Session", "Will happen later", account.uid)
     val game = gameRepository.getGameById(existingGameId)
-    
+
     // Create a timestamp for 1 hour from now
     val oneHourFromNow = Timestamp(System.currentTimeMillis() / 1000 + (1 * 60 * 60), 0)
-    
+
     sessionRepository.createSession(
-      discussion.uid, "Future Chess Night", game.uid, oneHourFromNow, testLocation, account.uid)
-    
+        discussion.uid, "Future Chess Night", game.uid, oneHourFromNow, testLocation, account.uid)
+
     delay(100)
-    
+
     // Verify session exists
     val sessionBefore = viewModel.sessionMapFlow(account.uid).first()
     assertEquals(1, sessionBefore.size)
-    
+
     // Call updateSessions
     val context = InstrumentationRegistry.getInstrumentation().targetContext
     viewModel.updateSessions(context, account.uid)
-    
+
     delay(200)
-    
+
     // Verify session still exists (not archived)
     val sessionAfter = viewModel.sessionMapFlow(account.uid).first()
     assertEquals(1, sessionAfter.size)
@@ -247,10 +263,10 @@ class SessionOverviewViewModelTest : FirestoreTests() {
   }
 
   private fun addGameDoc(id: String, name: String, genres: List<String> = emptyList()) =
-    runBlocking {
-      db.collection(GAMES_COLLECTION_PATH)
-        .document(id)
-        .set(GameNoUid(name = name, genres = genres))
-        .await()
-    }
+      runBlocking {
+        db.collection(GAMES_COLLECTION_PATH)
+            .document(id)
+            .set(GameNoUid(name = name, genres = genres))
+            .await()
+      }
 }

--- a/app/src/androidTest/java/com/github/meeplemeet/integration/SessionOverviewViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/SessionOverviewViewModelTest.kt
@@ -182,6 +182,48 @@ class SessionOverviewViewModelTest : FirestoreTests() {
         sessionRepository.getArchivedSessionByPhotoUrl("https://nonexistent.com/photo.webp")
     assertNull(foundSession)
   }
+  @Test
+  fun viewModel_getArchivedSessionByPhotoUrl_returnsSession() = runBlocking {
+    // Archive a session with a photo URL
+    val discussion =
+        discussionRepository.createDiscussion("ViewModel Find By Photo", "Test", account.uid)
+    val game = gameRepository.getGameById(existingGameId)
+    sessionRepository.createSession(
+        discussion.uid,
+        "ViewModel Find By Photo Session",
+        game.uid,
+        Timestamp.now(),
+        testLocation,
+        account.uid)
+    val photoUrl = "https://example.com/viewmodel_find_by_photo.webp"
+    val archivedId = java.util.UUID.randomUUID().toString()
+    sessionRepository.archiveSession(discussion.uid, archivedId, photoUrl)
+
+    delay(200) // Wait for archiving to complete
+
+    // Use ViewModel method with callback
+    var foundSession: com.github.meeplemeet.model.sessions.Session? = null
+    viewModel.getArchivedSessionByPhotoUrl(photoUrl) { foundSession = it }
+
+    delay(100) // Wait for callback to execute
+
+    assertNotNull(foundSession)
+    assertEquals(photoUrl, foundSession?.photoUrl)
+    assertEquals("ViewModel Find By Photo Session", foundSession?.name)
+  }
+
+  @Test
+  fun viewModel_getArchivedSessionByPhotoUrl_returnsNull_whenPhotoUrlNotFound() = runBlocking {
+    // Use ViewModel method with callback
+    var foundSession: com.github.meeplemeet.model.sessions.Session? = null
+    viewModel.getArchivedSessionByPhotoUrl("https://nonexistent.com/viewmodel_photo.webp") {
+      foundSession = it
+    }
+
+    delay(100) // Wait for callback to execute
+
+    assertNull(foundSession)
+  }
 
   @Test
   fun updateSession_archivesPassedSession_withoutPhoto() = runBlocking {

--- a/app/src/androidTest/java/com/github/meeplemeet/integration/SessionOverviewViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/SessionOverviewViewModelTest.kt
@@ -1,5 +1,9 @@
 package com.github.meeplemeet.integration
 
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Color
+import androidx.test.platform.app.InstrumentationRegistry
 import com.github.meeplemeet.model.account.Account
 import com.github.meeplemeet.model.sessions.SessionOverviewViewModel
 import com.github.meeplemeet.model.shared.game.GAMES_COLLECTION_PATH
@@ -14,6 +18,8 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.tasks.await
 import org.junit.Before
 import org.junit.Test
+import java.io.File
+import java.io.FileOutputStream
 
 /**
  * Integration test for SessionOverviewViewModel.
@@ -30,10 +36,13 @@ class SessionOverviewViewModelTest : FirestoreTests() {
 
   @Before
   fun setup() = runBlocking {
+    // Sign in anonymously for Firebase access
+    auth.signInAnonymously().await()
+
     viewModel = SessionOverviewViewModel()
     account =
-        accountRepository.createAccount(
-            "sessionTestUser", "Session Tester", "session@test.com", photoUrl = null)
+      accountRepository.createAccount(
+        "sessionTestUser", "Session Tester", "session@test.com", photoUrl = null)
     addGameDoc("g_chess", "Chess", genres = listOf("1", "2"))
     existingGameId = "g_chess"
   }
@@ -51,7 +60,7 @@ class SessionOverviewViewModelTest : FirestoreTests() {
     val game = gameRepository.getGameById(existingGameId)
 
     sessionRepository.createSession(
-        discussion.uid, "Chess Night", game.uid, Timestamp.now(), testLocation, account.uid)
+      discussion.uid, "Chess Night", game.uid, Timestamp.now(), testLocation, account.uid)
 
     delay(100) // wait for Firestore snapshot
 
@@ -64,11 +73,11 @@ class SessionOverviewViewModelTest : FirestoreTests() {
   fun sessionMapFlow_removesEntry_whenSessionDeleted() = runBlocking {
     // create
     val discussion =
-        discussionRepository.createDiscussion("To Be Deleted", "Will disappear", account.uid)
+      discussionRepository.createDiscussion("To Be Deleted", "Will disappear", account.uid)
     val game = gameRepository.getGameById(existingGameId)
 
     sessionRepository.createSession(
-        discussion.uid, "Delete Me", game.uid, Timestamp.now(), testLocation, account.uid)
+      discussion.uid, "Delete Me", game.uid, Timestamp.now(), testLocation, account.uid)
     delay(100)
     assertEquals(1, viewModel.sessionMapFlow(account.uid).first().size)
 
@@ -92,11 +101,156 @@ class SessionOverviewViewModelTest : FirestoreTests() {
     assertNull(name)
   }
 
+  @Test
+  fun getArchivedSessionPhotoUrls_returnsPhotoUrls() = runBlocking {
+    // Archive a session with a photo URL
+    val discussion = discussionRepository.createDiscussion("Archive Photo", "Test", account.uid)
+    val game = gameRepository.getGameById(existingGameId)
+    val session = sessionRepository.createSession(
+      discussion.uid, "Archive Photo Session", game.uid, Timestamp.now(), testLocation, account.uid)
+    val photoUrl = "https://example.com/archived_photo.webp"
+    sessionRepository.archiveSession(session.uid, java.util.UUID.randomUUID().toString(), photoUrl)
+    // Retrieve archived photo URLs
+    val urls = viewModel.getArchivedSessionPhotoUrls(account.uid)
+    assertTrue(urls.contains(photoUrl))
+  }
+
+  @Test
+  fun getArchivedSessionByPhotoUrl_returnsSession() = runBlocking {
+    // Archive a session with a photo URL
+    val discussion = discussionRepository.createDiscussion("Find By Photo", "Test", account.uid)
+    val game = gameRepository.getGameById(existingGameId)
+    val session = sessionRepository.createSession(
+      discussion.uid, "Find By Photo Session", game.uid, Timestamp.now(), testLocation, account.uid)
+    val photoUrl = "https://example.com/find_by_photo.webp"
+    sessionRepository.archiveSession(session.uid, java.util.UUID.randomUUID().toString(), photoUrl)
+    // Find session by photo URL
+    val foundSession = viewModel.getArchivedSessionByPhotoUrl(photoUrl)
+    assertNotNull(foundSession)
+    assertEquals(photoUrl, foundSession?.photoUrl)
+  }
+
+  @Test
+  fun updateSessions_archivesPassedSessions_withoutPhoto() = runBlocking {
+    // Create a discussion and session that has passed (3 hours ago)
+    val discussion = discussionRepository.createDiscussion("Past Session", "Happened earlier", account.uid)
+    val game = gameRepository.getGameById(existingGameId)
+    
+    // Create a timestamp from 4 hours ago (session has passed after 3-hour threshold)
+    val fourHoursAgo = Timestamp(System.currentTimeMillis() / 1000 - (4 * 60 * 60), 0)
+    
+    sessionRepository.createSession(
+      discussion.uid, "Past Chess Night", game.uid, fourHoursAgo, testLocation, account.uid)
+    
+    delay(100)
+    
+    // Verify session exists before archiving
+    val sessionBefore = viewModel.sessionMapFlow(account.uid).first()
+    assertEquals(1, sessionBefore.size)
+    
+    // Call updateSessions
+    val context = InstrumentationRegistry.getInstrumentation().targetContext
+    viewModel.updateSessions(context, account.uid)
+    
+    delay(200) // wait for archiving to complete
+    
+    // Verify session is no longer in active sessions
+    val sessionAfter = viewModel.sessionMapFlow(account.uid).first()
+    assertTrue(sessionAfter.isEmpty())
+    
+    // Verify session appears in archived sessions
+    val archivedUrls = viewModel.getArchivedSessionPhotoUrls(account.uid)
+    // No photo URL expected since session had no photo
+    assertTrue(archivedUrls.isEmpty())
+  }
+
+  @Test
+  fun updateSessions_archivesPassedSessions_withPhoto() = runBlocking {
+    // Create a discussion and session that has passed with a photo
+    val discussion = discussionRepository.createDiscussion("Past Session With Photo", "Had a photo", account.uid)
+    val game = gameRepository.getGameById(existingGameId)
+    
+    val fourHoursAgo = Timestamp(System.currentTimeMillis() / 1000 - (4 * 60 * 60), 0)
+    
+    val session = sessionRepository.createSession(
+      discussion.uid, "Photo Chess Night", game.uid, fourHoursAgo, testLocation, account.uid)
+    
+    // Add a photo to the session - create a valid image file
+    val context = InstrumentationRegistry.getInstrumentation().targetContext
+    val testImagePath = createTestImage(context, "test_session_photo.jpg")
+    
+    val photoUrl = imageRepository.saveSessionPhoto(context, discussion.uid, testImagePath)
+    sessionRepository.updateSessionPhoto(discussion.uid, photoUrl)
+    delay(100)
+    
+    // Clean up test image
+    File(testImagePath).delete()
+    
+    // Verify session has photo before archiving
+    val sessionWithPhoto = sessionRepository.getSession(discussion.uid)
+    assertNotNull(sessionWithPhoto?.photoUrl)
+    
+    // Call updateSessions
+    viewModel.updateSessions(context, account.uid)
+    
+    delay(2000)
+    
+    // Verify session is archived
+    val sessionAfter = viewModel.sessionMapFlow(account.uid).first()
+    assertTrue(sessionAfter.isEmpty())
+    
+    // Verify archived session has the moved photo URL
+    val archivedUrls = viewModel.getArchivedSessionPhotoUrls(account.uid)
+    assertEquals(1, archivedUrls.size)
+    assertTrue(archivedUrls[0].startsWith("https://") && archivedUrls[0].contains("past_sessions"))
+  }
+
+  @Test
+  fun updateSessions_doesNotArchive_nonPassedSessions() = runBlocking {
+    // Create a discussion and session with a future timestamp
+    val discussion = discussionRepository.createDiscussion("Future Session", "Will happen later", account.uid)
+    val game = gameRepository.getGameById(existingGameId)
+    
+    // Create a timestamp for 1 hour from now
+    val oneHourFromNow = Timestamp(System.currentTimeMillis() / 1000 + (1 * 60 * 60), 0)
+    
+    sessionRepository.createSession(
+      discussion.uid, "Future Chess Night", game.uid, oneHourFromNow, testLocation, account.uid)
+    
+    delay(100)
+    
+    // Verify session exists
+    val sessionBefore = viewModel.sessionMapFlow(account.uid).first()
+    assertEquals(1, sessionBefore.size)
+    
+    // Call updateSessions
+    val context = InstrumentationRegistry.getInstrumentation().targetContext
+    viewModel.updateSessions(context, account.uid)
+    
+    delay(200)
+    
+    // Verify session still exists (not archived)
+    val sessionAfter = viewModel.sessionMapFlow(account.uid).first()
+    assertEquals(1, sessionAfter.size)
+    assertEquals("Future Chess Night", sessionAfter[discussion.uid]?.name)
+  }
+
+  private fun createTestImage(context: Context, filename: String): String {
+    val bitmap = Bitmap.createBitmap(800, 600, Bitmap.Config.ARGB_8888)
+    bitmap.eraseColor(Color.RED)
+
+    val file = File(context.cacheDir, filename)
+    FileOutputStream(file).use { out -> bitmap.compress(Bitmap.CompressFormat.JPEG, 100, out) }
+    bitmap.recycle()
+
+    return file.absolutePath
+  }
+
   private fun addGameDoc(id: String, name: String, genres: List<String> = emptyList()) =
-      runBlocking {
-        db.collection(GAMES_COLLECTION_PATH)
-            .document(id)
-            .set(GameNoUid(name = name, genres = genres))
-            .await()
-      }
+    runBlocking {
+      db.collection(GAMES_COLLECTION_PATH)
+        .document(id)
+        .set(GameNoUid(name = name, genres = genres))
+        .await()
+    }
 }

--- a/app/src/main/java/com/github/meeplemeet/model/account/Account.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/Account.kt
@@ -82,7 +82,8 @@ data class Account(
     var shopOwner: Boolean = false,
     var spaceRenter: Boolean = false,
     val relationships: Map<String, RelationshipStatus> = emptyMap(),
-    val notifications: List<Notification> = emptyList()
+    val notifications: List<Notification> = emptyList(),
+    val pastSessionIds: List<String> = emptyList()
 )
 
 /**
@@ -108,7 +109,8 @@ data class AccountNoUid(
     val photoUrl: String? = null,
     val description: String? = null,
     val shopOwner: Boolean = false,
-    val spaceRenter: Boolean = false
+    val spaceRenter: Boolean = false,
+    val pastSessionIds: List<String> = emptyList()
 )
 
 /**
@@ -149,5 +151,6 @@ fun fromNoUid(
       shopOwner = accountNoUid.shopOwner,
       spaceRenter = accountNoUid.spaceRenter,
       relationships = mappedRelationships,
-      notifications = notifications)
+      notifications = notifications,
+      pastSessionIds = accountNoUid.pastSessionIds)
 }

--- a/app/src/main/java/com/github/meeplemeet/model/account/Account.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/Account.kt
@@ -70,6 +70,8 @@ data class Relationship(
  *   friend requests, discussion invitations, and session invitations. Each notification contains
  *   metadata about the event and can be executed to perform the associated action (e.g., accepting
  *   a friend request).
+ *     @property pastSessionIds List of UUIDs representing sessions that have been archived for this
+ *       user.
  */
 data class Account(
     val uid: String,

--- a/app/src/main/java/com/github/meeplemeet/model/images/ImageRepository.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/images/ImageRepository.kt
@@ -274,7 +274,7 @@ class ImageRepository(private val dispatcher: CoroutineDispatcher = Dispatchers.
    *
    * This operation:
    * 1. Downloads the current session photo
-   * 2. Uploads it to the new location: `past_sessions/{newUuid}.webp`
+   * 2. Uploads it to the new location: `archived_sessions/{newUuid}.webp`
    * 3. Deletes the original photo
    *
    * @param context Android context for accessing cache directory
@@ -284,7 +284,7 @@ class ImageRepository(private val dispatcher: CoroutineDispatcher = Dispatchers.
    */
   suspend fun moveSessionPhoto(context: Context, discussionId: String, newUuid: String): String {
     val oldPath = sessionPhotoPath(discussionId)
-    val newPath = "past_sessions/${newUuid}.webp"
+    val newPath = "archived_sessions/${newUuid}.webp"
 
     // 1. Download the current photo
     val bytes = loadImage(context, oldPath)
@@ -301,6 +301,11 @@ class ImageRepository(private val dispatcher: CoroutineDispatcher = Dispatchers.
   /**
    * Helper to save bytes directly, used by moveSessionPhoto. This is a variation of saveImage that
    * takes bytes instead of file path.
+   *
+   * @param context Android context for accessing cache directory
+   * @param bytes The image data as a byte array
+   * @param storagePath Storage path (used for both local cache and Firebase Storage)
+   * @return The public HTTPS download URL of the saved image
    */
   private suspend fun saveImage(context: Context, bytes: ByteArray, storagePath: String): String {
     // Save to disk
@@ -564,41 +569,7 @@ class ImageRepository(private val dispatcher: CoroutineDispatcher = Dispatchers.
           throw ImageProcessingException("Failed to encode image at $inputPath", e)
         }
 
-    // Save to disk
-    try {
-      withContext(dispatcher) {
-        val diskPath = cachePath(context, storagePath)
-        val parentDir = File(diskPath).parentFile
-
-        // Check if parent directory can be created
-        if (parentDir != null && !parentDir.exists() && !parentDir.mkdirs()) {
-          throw DiskStorageException("Failed to create directory: ${parentDir.absolutePath}")
-        }
-
-        // Ensure sufficient storage space (uses StorageManager on O+ to clear cache if needed)
-        ensureStorageSpace(context, bytes.size.toLong())
-
-        FileOutputStream(diskPath).use { fos -> fos.write(bytes) }
-      }
-    } catch (e: DiskStorageException) {
-      throw e
-    } catch (e: IOException) {
-      throw DiskStorageException("Failed to write image to disk at $storagePath", e)
-    } catch (e: SecurityException) {
-      throw DiskStorageException("Permission denied writing to $storagePath", e)
-    }
-
-    // Upload to Firebase Storage
-    try {
-      val ref = storage.reference.child(storagePath)
-      ref.putBytes(bytes).await()
-      return toHttps(ref.downloadUrl.await().toString())
-    } catch (e: StorageException) {
-      throw RemoteStorageException(
-          "Firebase Storage upload failed for $storagePath: ${e.errorCode}", e)
-    } catch (e: Exception) {
-      throw RemoteStorageException("Failed to upload image to Firebase Storage at $storagePath", e)
-    }
+    return saveImage(context, bytes, storagePath)
   }
 
   /**

--- a/app/src/main/java/com/github/meeplemeet/model/images/ImageRepository.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/images/ImageRepository.kt
@@ -110,6 +110,8 @@ class ImageRepository(private val dispatcher: CoroutineDispatcher = Dispatchers.
 
   private fun spaceRenterPath(id: String) = "${RepositoryProvider.spaceRenters.collectionName}/$id"
 
+  private fun cachePath(context: Context, storagePath: String) = "${context.cacheDir}/$storagePath"
+
   private fun normalizePath(candidate: String, expectedPrefix: String): String {
     val path =
         if (candidate.contains("/o/")) {
@@ -304,7 +306,7 @@ class ImageRepository(private val dispatcher: CoroutineDispatcher = Dispatchers.
     // Save to disk
     try {
       withContext(dispatcher) {
-        val diskPath = "${context.cacheDir}/$storagePath"
+        val diskPath = cachePath(context, storagePath)
         val parentDir = File(diskPath).parentFile
 
         // Check if parent directory can be created
@@ -565,7 +567,7 @@ class ImageRepository(private val dispatcher: CoroutineDispatcher = Dispatchers.
     // Save to disk
     try {
       withContext(dispatcher) {
-        val diskPath = "${context.cacheDir}/$storagePath"
+        val diskPath = cachePath(context, storagePath)
         val parentDir = File(diskPath).parentFile
 
         // Check if parent directory can be created
@@ -784,7 +786,7 @@ class ImageRepository(private val dispatcher: CoroutineDispatcher = Dispatchers.
     try {
       withContext(dispatcher) {
         storagePaths.forEach { storagePath ->
-          val diskPath = "${context.cacheDir}/$storagePath"
+          val diskPath = cachePath(context, storagePath)
           val file = File(diskPath)
           if (file.exists() && !file.delete()) {
             throw DiskStorageException("Failed to delete cached image at $storagePath")

--- a/app/src/main/java/com/github/meeplemeet/model/sessions/SessionOverviewViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/sessions/SessionOverviewViewModel.kt
@@ -42,16 +42,20 @@ class SessionOverviewViewModel(
     viewModelScope.launch {
       val sessionIds = sessionRepository.getSessionIdsForUser(userId)
       for (id in sessionIds) {
-        if (sessionRepository.isSessionPassed(id)) {
-          val session = sessionRepository.getSession(id)
-          if (session != null) {
-            val newUuid = java.util.UUID.randomUUID().toString()
-            var newUrl: String? = null
-            if (session.photoUrl != null) {
-              newUrl = imageRepository.moveSessionPhoto(context, id, newUuid)
+        try {
+          if (sessionRepository.isSessionPassed(id)) {
+            val session = sessionRepository.getSession(id)
+            if (session != null) {
+              val newUuid = java.util.UUID.randomUUID().toString()
+              var newUrl: String? = null
+              if (session.photoUrl != null) {
+                newUrl = imageRepository.moveSessionPhoto(context, id, newUuid)
+              }
+              sessionRepository.archiveSession(id, newUuid, newUrl)
             }
-            sessionRepository.archiveSession(id, newUuid, newUrl)
           }
+        } catch (e: Exception) {
+          e.printStackTrace()
         }
       }
     }

--- a/app/src/main/java/com/github/meeplemeet/model/sessions/SessionOverviewViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/sessions/SessionOverviewViewModel.kt
@@ -47,7 +47,7 @@ class SessionOverviewViewModel(
         if (sessionRepository.isSessionPassed(id)) {
           val session = sessionRepository.getSession(id)
           if (session != null) {
-            val newUuid = java.util.UUID.randomUUID().toString()
+            val newUuid = sessionRepository.newUUID()
             var newUrl: String? = null
             if (session.photoUrl != null) {
               newUrl = imageRepository.moveSessionPhoto(context, id, newUuid)

--- a/app/src/main/java/com/github/meeplemeet/model/sessions/SessionOverviewViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/sessions/SessionOverviewViewModel.kt
@@ -1,14 +1,19 @@
 package com.github.meeplemeet.model.sessions
 
+import android.content.Context
+import androidx.lifecycle.viewModelScope
 import com.github.meeplemeet.RepositoryProvider
+import com.github.meeplemeet.model.images.ImageRepository
 import com.github.meeplemeet.model.shared.game.GameRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
 
 class SessionOverviewViewModel(
     private val sessionRepository: SessionRepository = RepositoryProvider.sessions,
-    private val gameRepository: GameRepository = RepositoryProvider.games
+    private val gameRepository: GameRepository = RepositoryProvider.games,
+    private val imageRepository: ImageRepository = RepositoryProvider.images
 ) : CreateSessionViewModel() {
   suspend fun getGameNameByGameId(gameId: String): String? =
       kotlin.runCatching { gameRepository.getGameById(gameId).name }.getOrNull()
@@ -28,4 +33,47 @@ class SessionOverviewViewModel(
                 .mapValues { it.value!! }
           }
           .flowOn(Dispatchers.IO)
+
+  /**
+   * Updates sessions for a user by archiving those that have already passed. To be called from time
+   * to time to ensure sessions are archived appropriately.
+   */
+  fun updateSessions(context: Context, userId: String) {
+    viewModelScope.launch {
+      val sessionIds = sessionRepository.getSessionIdsForUser(userId)
+      for (id in sessionIds) {
+        if (sessionRepository.isSessionPassed(id)) {
+          val session = sessionRepository.getSession(id)
+          if (session != null) {
+            val newUuid = java.util.UUID.randomUUID().toString()
+            var newUrl: String? = null
+            if (session.photoUrl != null) {
+              newUrl = imageRepository.moveSessionPhoto(context, id, newUuid)
+            }
+            sessionRepository.archiveSession(id, newUuid, newUrl)
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Retrieves all photo URLs from the archived sessions for a given account.
+   *
+   * @param pastSessionIds List of archived session UUIDs from Account.pastSessionIds
+   * @return List of photo URLs from archived sessions
+   */
+  suspend fun getArchivedSessionPhotoUrls(userId: String): List<String> {
+    return sessionRepository.getArchivedSessionPhotoUrls(userId)
+  }
+
+  /**
+   * Finds an archived session by its photo URL.
+   *
+   * @param photoUrl The photo URL to search for
+   * @return The Session object if found, or null if not found
+   */
+  suspend fun getArchivedSessionByPhotoUrl(photoUrl: String): Session? {
+    return sessionRepository.getArchivedSessionByPhotoUrl(photoUrl)
+  }
 }

--- a/app/src/main/java/com/github/meeplemeet/model/sessions/SessionOverviewViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/sessions/SessionOverviewViewModel.kt
@@ -35,28 +35,28 @@ class SessionOverviewViewModel(
           .flowOn(Dispatchers.IO)
 
   /**
-   * Updates sessions for a user by archiving those that have already passed. To be called from time
-   * to time to ensure sessions are archived appropriately.
+   * Checks if the session with the given ID has passed, and if so, archives it. This function is
+   * intended to be called when a user views the discussion associated with the session.
+   *
+   * @param context The context used for image operations.
+   * @param id The ID of the session to check and potentially archive.
    */
-  fun updateSessions(context: Context, userId: String) {
+  fun updateSession(context: Context, id: String) {
     viewModelScope.launch {
-      val sessionIds = sessionRepository.getSessionIdsForUser(userId)
-      for (id in sessionIds) {
-        try {
-          if (sessionRepository.isSessionPassed(id)) {
-            val session = sessionRepository.getSession(id)
-            if (session != null) {
-              val newUuid = java.util.UUID.randomUUID().toString()
-              var newUrl: String? = null
-              if (session.photoUrl != null) {
-                newUrl = imageRepository.moveSessionPhoto(context, id, newUuid)
-              }
-              sessionRepository.archiveSession(id, newUuid, newUrl)
+      try {
+        if (sessionRepository.isSessionPassed(id)) {
+          val session = sessionRepository.getSession(id)
+          if (session != null) {
+            val newUuid = java.util.UUID.randomUUID().toString()
+            var newUrl: String? = null
+            if (session.photoUrl != null) {
+              newUrl = imageRepository.moveSessionPhoto(context, id, newUuid)
             }
+            sessionRepository.archiveSession(id, newUuid, newUrl)
           }
-        } catch (e: Exception) {
-          e.printStackTrace()
         }
+      } catch (e: Exception) {
+        e.printStackTrace()
       }
     }
   }
@@ -67,8 +67,11 @@ class SessionOverviewViewModel(
    * @param pastSessionIds List of archived session UUIDs from Account.pastSessionIds
    * @return List of photo URLs from archived sessions
    */
-  suspend fun getArchivedSessionPhotoUrls(userId: String): List<String> {
-    return sessionRepository.getArchivedSessionPhotoUrls(userId)
+  fun getArchivedSessionPhotoUrls(userId: String, callback: (List<String>) -> Unit) {
+    viewModelScope.launch {
+      val result = sessionRepository.getArchivedSessionPhotoUrls(userId)
+      callback(result)
+    }
   }
 
   /**
@@ -77,7 +80,10 @@ class SessionOverviewViewModel(
    * @param photoUrl The photo URL to search for
    * @return The Session object if found, or null if not found
    */
-  suspend fun getArchivedSessionByPhotoUrl(photoUrl: String): Session? {
-    return sessionRepository.getArchivedSessionByPhotoUrl(photoUrl)
+  fun getArchivedSessionByPhotoUrl(photoUrl: String, callback: (Session?) -> Unit) {
+    viewModelScope.launch {
+      val result = sessionRepository.getArchivedSessionByPhotoUrl(photoUrl)
+      callback(result)
+    }
   }
 }

--- a/app/src/main/java/com/github/meeplemeet/model/sessions/SessionRepository.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/sessions/SessionRepository.kt
@@ -18,6 +18,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.tasks.await
 
+private val archivedSessions: String = "archived_sessions"
+
 /**
  * Repository for managing gaming sessions within discussions in Firestore.
  *
@@ -196,7 +198,7 @@ class SessionRepository(
 
     // 1. Save to archived_sessions collection
     val archivedRef =
-        FirebaseFirestore.getInstance().collection("archived_sessions").document(newSessionId)
+        FirebaseFirestore.getInstance().collection(archivedSessions).document(newSessionId)
     batch.set(archivedRef, archivedSession)
 
     // 2. Add session UUID to each participant's pastSessionIds
@@ -241,7 +243,7 @@ class SessionRepository(
     val endIndex = minOf(startIndex + pageSize, pastSessionIds.size)
     val sessionIdsForPage = pastSessionIds.subList(startIndex, endIndex)
 
-    val archivedSessionsCollection = FirebaseFirestore.getInstance().collection("archived_sessions")
+    val archivedSessionsCollection = FirebaseFirestore.getInstance().collection(archivedSessions)
 
     sessionIdsForPage
         .map { sessionId ->
@@ -270,8 +272,7 @@ class SessionRepository(
    */
   suspend fun getArchivedSessionByPhotoUrl(photoUrl: String): Session? {
     return try {
-      val archivedSessionsCollection =
-          FirebaseFirestore.getInstance().collection("archived_sessions")
+      val archivedSessionsCollection = FirebaseFirestore.getInstance().collection(archivedSessions)
       val querySnapshot =
           archivedSessionsCollection.whereEqualTo("photoUrl", photoUrl).limit(1).get().await()
 


### PR DESCRIPTION
**Summary :**
This pull request introduces support for archiving session photos, adds new APIs for managing session photo URLs, and enhances session lifecycle management. The changes include updates to the data models to track archived sessions, new repository methods for saving, moving, and deleting session photos, and additional integration tests to verify the archiving process and photo handling.

**Description :**
* I added a function to update the backend of passed sessions and save them to an archive, move the photo files, and put the new id into a field in the account
* I added functions to fetch all the pictures for a user, and a function to fetch the session that a photo is saved in