### PR TITLE
fix: Add orphaned preview cleanup and improve data integrity

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/integration/MalformedDataTests.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/MalformedDataTests.kt
@@ -1,0 +1,244 @@
+package com.github.meeplemeet.integration
+
+import androidx.test.platform.app.InstrumentationRegistry
+import com.github.meeplemeet.model.account.Account
+import com.github.meeplemeet.model.discussions.DiscussionPreviewNoUid
+import com.github.meeplemeet.model.discussions.DiscussionsOverviewViewModel
+import com.github.meeplemeet.utils.FirestoreTests
+import com.google.firebase.Timestamp
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertNotNull
+import junit.framework.TestCase.assertNull
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.tasks.await
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Integration tests for malformed data handling and preview validation.
+ *
+ * Tests the new functionality that cleans up orphaned discussion previews and validates that
+ * preview documents reference existing discussions.
+ */
+class MalformedDataTests : FirestoreTests() {
+  private lateinit var account1: Account
+  private lateinit var account2: Account
+  private lateinit var account3: Account
+  private val context by lazy { InstrumentationRegistry.getInstrumentation().targetContext }
+
+  @Before
+  fun setup() {
+    runBlocking {
+      account1 =
+          accountRepository.createAccount(
+              "user1", "User One", email = "user1@example.com", photoUrl = null)
+      account2 =
+          accountRepository.createAccount(
+              "user2", "User Two", email = "user2@example.com", photoUrl = null)
+      account3 =
+          accountRepository.createAccount(
+              "user3", "User Three", email = "user3@example.com", photoUrl = null)
+    }
+  }
+
+  @Test
+  fun previewIsValid_handlesValidInvalidAndDeletedDiscussions() = runBlocking {
+    // Test valid discussion
+    val discussion =
+        discussionRepository.createDiscussion(
+            "Test Discussion", "Description", account1.uid, listOf(account2.uid))
+    assertTrue(
+        "Preview should be valid for existing discussion",
+        discussionRepository.previewIsValid(discussion.uid))
+
+    // Test non-existent discussion
+    val fakeDiscussionId = "nonexistent_discussion_id_12345"
+    assertFalse(
+        "Preview should be invalid for non-existent discussion",
+        discussionRepository.previewIsValid(fakeDiscussionId))
+
+    // Test deleted discussion
+    discussionRepository.deleteDiscussion(context, discussion)
+    assertFalse(
+        "Preview should be invalid after discussion deletion",
+        discussionRepository.previewIsValid(discussion.uid))
+  }
+
+  @Test
+  fun previewToDeleteRef_returnsCorrectDocumentReference() {
+    val discussionId = "test_discussion_id"
+    val ref = accountRepository.previewToDeleteRef(account1.uid, discussionId)
+    val expectedPath = "accounts/${account1.uid}/previews/$discussionId"
+    assertEquals("Document reference path should match", expectedPath, ref.path)
+  }
+
+  @Test
+  fun validatePreviews_handlesVariousScenarios() = runBlocking {
+    val viewModel = DiscussionsOverviewViewModel(discussionRepository, accountRepository)
+
+    // Scenario 1: Empty previews list
+    var acc1 = accountRepository.getAccount(account1.uid)
+    assertEquals("Should have no previews initially", 0, acc1.previews.size)
+    viewModel.validatePreviews(acc1)
+    delay(500)
+    acc1 = accountRepository.getAccount(account1.uid)
+    assertEquals("Should still have no previews", 0, acc1.previews.size)
+
+    // Scenario 2: Valid discussions with one deleted (mixed valid/invalid)
+    val validDiscussion1 =
+        discussionRepository.createDiscussion(
+            "Valid 1", "Description", account1.uid, listOf(account2.uid))
+    val validDiscussion2 =
+        discussionRepository.createDiscussion(
+            "Valid 2", "Description", account1.uid, listOf(account2.uid))
+    val toDeleteDiscussion =
+        discussionRepository.createDiscussion(
+            "To Delete", "Description", account1.uid, listOf(account2.uid))
+
+    // Manually add an orphaned preview
+    val orphanedId = "orphaned_discussion_id"
+    accountRepository
+        .previewToDeleteRef(account1.uid, orphanedId)
+        .set(
+            DiscussionPreviewNoUid(
+                lastMessage = "Orphaned",
+                lastMessageSender = account1.uid,
+                lastMessageAt = Timestamp.now(),
+                unreadCount = 5))
+        .await()
+
+    acc1 = accountRepository.getAccount(account1.uid)
+    assertEquals("Should have 4 previews", 4, acc1.previews.size)
+
+    // Delete one discussion
+    discussionRepository.deleteDiscussion(context, toDeleteDiscussion)
+
+    // Validate and verify cleanup
+    acc1 = accountRepository.getAccount(account1.uid)
+    viewModel.validatePreviews(acc1)
+    delay(1000)
+
+    acc1 = accountRepository.getAccount(account1.uid)
+    assertEquals("Should have 2 valid previews remaining", 2, acc1.previews.size)
+    assertNotNull("Valid discussion 1 should remain", acc1.previews[validDiscussion1.uid])
+    assertNotNull("Valid discussion 2 should remain", acc1.previews[validDiscussion2.uid])
+    assertNull(
+        "Deleted discussion preview should be removed", acc1.previews[toDeleteDiscussion.uid])
+    assertNull("Orphaned preview should be removed", acc1.previews[orphanedId])
+
+    // Scenario 3: Verify caching - second call should not re-check
+    viewModel.validatePreviews(acc1)
+    delay(500)
+    // If we get here without errors, caching is working
+    assertTrue("Validation should complete without checking duplicates", true)
+  }
+
+  @Test
+  fun validatePreviews_handlesMultipleOrphanedPreviewsAndMultipleAccounts() = runBlocking {
+    // Create multiple discussions with multiple participants
+    val discussions =
+        (1..5).map { i ->
+          discussionRepository.createDiscussion(
+              "Discussion $i", "Description $i", account1.uid, listOf(account2.uid, account3.uid))
+        }
+
+    // Verify all previews exist for all accounts
+    var acc1 = accountRepository.getAccount(account1.uid)
+    var acc2 = accountRepository.getAccount(account2.uid)
+    var acc3 = accountRepository.getAccount(account3.uid)
+    assertEquals("Account1 should have 5 previews", 5, acc1.previews.size)
+    assertEquals("Account2 should have 5 previews", 5, acc2.previews.size)
+    assertEquals("Account3 should have 5 previews", 5, acc3.previews.size)
+
+    // Delete 3 discussions
+    discussions.take(3).forEach { discussionRepository.deleteDiscussion(context, it) }
+
+    // Validate previews for all accounts
+    val viewModel = DiscussionsOverviewViewModel(discussionRepository, accountRepository)
+    acc1 = accountRepository.getAccount(account1.uid)
+    acc2 = accountRepository.getAccount(account2.uid)
+    acc3 = accountRepository.getAccount(account3.uid)
+
+    viewModel.validatePreviews(acc1)
+    viewModel.validatePreviews(acc2)
+    viewModel.validatePreviews(acc3)
+    delay(1000)
+
+    // Verify cleanup for all accounts
+    acc1 = accountRepository.getAccount(account1.uid)
+    acc2 = accountRepository.getAccount(account2.uid)
+    acc3 = accountRepository.getAccount(account3.uid)
+
+    assertEquals("Account1 should have 2 valid previews", 2, acc1.previews.size)
+    assertEquals("Account2 should have 2 valid previews", 2, acc2.previews.size)
+    assertEquals("Account3 should have 2 valid previews", 2, acc3.previews.size)
+
+    // Verify the correct previews remain
+    assertNotNull("Discussion 4 preview should remain", acc1.previews[discussions[3].uid])
+    assertNotNull("Discussion 5 preview should remain", acc1.previews[discussions[4].uid])
+    assertNull("Discussion 1 preview should be removed", acc1.previews[discussions[0].uid])
+    assertNull("Discussion 2 preview should be removed", acc2.previews[discussions[1].uid])
+    assertNull("Discussion 3 preview should be removed", acc3.previews[discussions[2].uid])
+  }
+
+  @Test
+  fun fullyDeleteDocument_removesDiscussionWithMessagesSubcollection() = runBlocking {
+    // Create discussion with messages
+    val discussion =
+        discussionRepository.createDiscussion(
+            "Test Discussion", "Description", account1.uid, listOf(account2.uid))
+
+    discussionRepository.sendMessageToDiscussion(discussion, account1, "Message 1")
+    discussionRepository.sendMessageToDiscussion(discussion, account1, "Message 2")
+    discussionRepository.sendMessageToDiscussion(discussion, account2, "Message 3")
+
+    // Verify messages exist
+    val messagesBefore = discussionRepository.getMessages(discussion.uid)
+    assertEquals("Should have 3 messages", 3, messagesBefore.size)
+
+    // Delete discussion
+    discussionRepository.deleteDiscussion(context, discussion)
+
+    // Verify complete deletion
+    assertFalse("Discussion should not exist", discussionRepository.previewIsValid(discussion.uid))
+    assertEquals(
+        "Messages subcollection should be empty",
+        0,
+        discussionRepository.getMessages(discussion.uid).size)
+  }
+
+  @Test
+  fun fullyDeleteDocument_removesAccountWithAllSubcollections() = runBlocking {
+    // Create account with all types of subcollections
+    val testAccount =
+        accountRepository.createAccount(
+            "testuser", "Test User", email = "test@example.com", photoUrl = null)
+
+    // Add data to all subcollections
+    discussionRepository.createDiscussion(
+        "Test", "Description", testAccount.uid, listOf(account1.uid))
+    accountRepository.sendFriendRequest(testAccount, account1.uid)
+    accountRepository.sendFriendRequestNotification(testAccount.uid, account1)
+
+    // Verify subcollections exist
+    val accountBefore = accountRepository.getAccount(testAccount.uid)
+    assertTrue("Should have previews", accountBefore.previews.isNotEmpty())
+    assertTrue("Should have relationships", accountBefore.relationships.isNotEmpty())
+    assertTrue("Should have notifications", accountBefore.notifications.isNotEmpty())
+
+    // Delete account
+    accountRepository.deleteAccount(testAccount.uid)
+
+    // Verify complete deletion
+    try {
+      accountRepository.getAccount(testAccount.uid)
+      throw AssertionError("Account should not exist after deletion")
+    } catch (e: com.github.meeplemeet.model.AccountNotFoundException) {
+      // Expected exception - account and all subcollections deleted
+      assertTrue("Account should throw AccountNotFoundException", true)
+    }
+  }
+}

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/DiscussionScreenIntegrationTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/DiscussionScreenIntegrationTest.kt
@@ -21,6 +21,7 @@ import com.github.meeplemeet.utils.FirestoreTests
 import junit.framework.TestCase.assertTrue
 import kotlin.io.println
 import kotlin.random.Random
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
@@ -406,6 +407,8 @@ class DiscussionScreenIntegrationTest : FirestoreTests() {
               DiscussionTestTags.pollVoteButton(multiMsgIndex, 2), useUnmergedTree = true)
           .performClick()
 
+      runBlocking { delay(250) }
+
       checkpoint("Popcorn 50 %") { waitUntilPercentIs(multiMsgIndex, 0, "50%") }
       checkpoint("Soda 50 %") { waitUntilPercentIs(multiMsgIndex, 2, "50%") }
 
@@ -414,6 +417,9 @@ class DiscussionScreenIntegrationTest : FirestoreTests() {
           .onNodeWithTag(
               DiscussionTestTags.pollVoteButton(multiMsgIndex, 0), useUnmergedTree = true)
           .performClick()
+
+      runBlocking { delay(250) }
+
       checkpoint("Popcorn 0 %") { waitUntilPercentIs(multiMsgIndex, 0, "0%") }
       checkpoint("Soda now 100 %") { waitUntilPercentIs(multiMsgIndex, 2, "100%") }
 

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/MapScreenTest.kt
@@ -45,6 +45,8 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
+private const val DEFAULT_TEST_KM = 10.0
+
 /**
  * Comprehensive UI test suite for MapScreen with real Firestore data.
  *
@@ -69,7 +71,6 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
 
   private fun checkpoint(name: String, block: () -> Unit) = ck.ck(name, block)
 
-  private val DEFAULT_TEST_KM = 10.0
   private lateinit var mapViewModel: MapViewModel
   private lateinit var mockNavigation: NavigationActions
 
@@ -168,6 +169,8 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
         }
       }
     }
+
+    Thread.sleep(500)
 
     checkpoint("mapScreen_initialDisplay_showsMapAndFilterButton") {
       composeRule.waitForIdle()

--- a/app/src/main/java/com/github/meeplemeet/model/FirestoreRepository.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/FirestoreRepository.kt
@@ -3,7 +3,9 @@ package com.github.meeplemeet.model
 // Claude Code generated the documentation
 
 import com.github.meeplemeet.FirebaseProvider
+import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.tasks.await
 
 /**
  * Base repository class for Firestore collections.
@@ -17,12 +19,13 @@ import com.google.firebase.firestore.FirebaseFirestore
  */
 open class FirestoreRepository(
     val collectionName: String,
-    val db: FirebaseFirestore = FirebaseProvider.db
+    val subCollections: List<String> = emptyList()
 ) {
   init {
     require(collectionName.isNotBlank())
   }
 
+  val db: FirebaseFirestore = FirebaseProvider.db
   // The Firestore collection reference for this repository
   val collection = db.collection(collectionName)
 
@@ -32,4 +35,49 @@ open class FirestoreRepository(
    * @return A unique document ID that can be used when creating new documents
    */
   fun newUUID() = collection.document().id
+
+  /**
+   * Fully deletes a document and all its subcollections from Firestore.
+   *
+   * This function performs a complete deletion of a document including all documents in its
+   * subcollections as defined by [subCollections]. It uses batched writes to efficiently handle
+   * large amounts of data while respecting Firestore's transaction limits.
+   *
+   * The deletion process:
+   * 1. Iterates through all subcollections specified in [subCollections]
+   * 2. Retrieves all documents in each subcollection
+   * 3. Batches delete operations (up to 450 per batch to stay under Firestore's 500 operation
+   *    limit)
+   * 4. Commits batches as they fill up
+   * 5. Finally deletes the parent document itself
+   *
+   * Note: This operation is not atomic across multiple batches. If the operation fails partway
+   * through, some documents may be deleted while others remain.
+   *
+   * @param parent The DocumentReference of the parent document to delete along with its
+   *   subcollections
+   * @throws Exception if any Firestore operation fails during the deletion process
+   */
+  suspend fun fullyDeleteDocument(parent: DocumentReference) {
+    val db = parent.firestore
+    val batch = db.batch()
+    var count = 0
+
+    for (name in subCollections) {
+      val col = parent.collection(name)
+      val snap = col.get().await()
+
+      for (doc in snap.documents) {
+        batch.delete(doc.reference)
+        count += 1
+        if (count == 450) {
+          batch.commit().await()
+          count = 0
+        }
+      }
+    }
+
+    batch.delete(parent)
+    batch.commit().await()
+  }
 }

--- a/app/src/main/java/com/github/meeplemeet/model/account/AccountViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/AccountViewModel.kt
@@ -17,17 +17,6 @@ interface AccountViewModel {
   val scope: CoroutineScope
 
   /**
-   * Retrieves an account by its ID.
-   *
-   * @param id The account ID to retrieve
-   * @throws IllegalArgumentException if the ID is blank
-   */
-  fun getAccount(id: String) {
-    if (id.isBlank()) throw IllegalArgumentException("Account id cannot be blank")
-    scope.launch { RepositoryProvider.accounts.getAccount(id, false) }
-  }
-
-  /**
    * Retrieves an account by ID and provides it to a callback.
    *
    * This method is useful when you need to fetch account data without updating the current

--- a/app/src/main/java/com/github/meeplemeet/model/discussions/DiscussionRepository.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/discussions/DiscussionRepository.kt
@@ -110,6 +110,18 @@ class DiscussionRepository(
     return discussion
   }
 
+  /**
+   * Checks if a discussion preview is valid by verifying the discussion document exists.
+   *
+   * Used to clean up orphaned preview documents that reference deleted discussions. This prevents
+   * the UI from showing stale previews for non-existent discussions.
+   *
+   * @param discussionId The discussion ID to check
+   * @return true if the discussion document exists in Firestore, false otherwise
+   */
+  suspend fun previewIsValid(discussionId: String): Boolean =
+      collection.document(discussionId).get().await().exists()
+
   /** Retrieve a discussion document by ID. */
   suspend fun getDiscussion(id: String): Discussion {
     val snapshot = collection.document(id).get().await()

--- a/app/src/main/java/com/github/meeplemeet/model/discussions/DiscussionsOverviewViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/discussions/DiscussionsOverviewViewModel.kt
@@ -3,13 +3,18 @@ package com.github.meeplemeet.model.discussions
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.github.meeplemeet.FirebaseProvider
 import com.github.meeplemeet.RepositoryProvider
+import com.github.meeplemeet.model.account.Account
+import com.github.meeplemeet.model.account.AccountRepository
 import com.github.meeplemeet.model.account.AccountViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
 
 /**
  * ViewModel for displaying an overview of discussions.
@@ -20,7 +25,8 @@ import kotlinx.coroutines.flow.stateIn
  * @property discussionRepository Repository for discussion operations
  */
 class DiscussionsOverviewViewModel(
-    private val discussionRepository: DiscussionRepository = RepositoryProvider.discussions
+    private val discussionRepository: DiscussionRepository = RepositoryProvider.discussions,
+    private val accountRepository: AccountRepository = RepositoryProvider.accounts
 ) : ViewModel(), AccountViewModel {
   override val scope: CoroutineScope
     get() = this.viewModelScope
@@ -29,6 +35,49 @@ class DiscussionsOverviewViewModel(
    * Holds cached [StateFlow]s of discussions keyed by discussion ID to avoid duplicate listeners.
    */
   private val discussionFlows = mutableMapOf<String, StateFlow<Discussion?>>()
+
+  /**
+   * Cache of discussion IDs that have been validated to exist.
+   *
+   * Prevents redundant validation checks for the same discussions within a session.
+   */
+  private val checkedPreviews = mutableSetOf<String>()
+
+  /**
+   * Validates discussion previews for an account and removes orphaned previews.
+   *
+   * This method checks if each preview references a valid discussion document. If a discussion no
+   * longer exists (e.g., it was deleted), the corresponding preview is removed from the account's
+   * previews subcollection.
+   *
+   * The validation is performed in the background using a batched write for efficiency. Each
+   * preview is only checked once per session to minimize Firestore reads.
+   *
+   * ## Use Case
+   * Called when loading the discussions overview screen to ensure the preview list is synchronized
+   * with actual discussions in Firestore.
+   *
+   * @param account The account whose previews should be validated
+   */
+  fun validatePreviews(account: Account) {
+    val targets = account.previews.keys.filter { it !in checkedPreviews }
+
+    if (targets.isEmpty()) return
+
+    viewModelScope.launch {
+      val batch = FirebaseProvider.db.batch()
+      val toMarkValid = mutableListOf<String>()
+
+      for (id in targets) {
+        val exists = discussionRepository.previewIsValid(id)
+        if (exists) toMarkValid.add(id)
+        else batch.delete(accountRepository.previewToDeleteRef(account.uid, id))
+      }
+
+      batch.commit().await()
+      checkedPreviews.addAll(toMarkValid)
+    }
+  }
 
   /**
    * Returns a real-time flow of discussion data for the specified discussion ID.

--- a/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionDetailsScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionDetailsScreen.kt
@@ -202,15 +202,8 @@ fun DiscussionDetailsScreen(
 
   /** Populate selectedMembers with current discussion participants */
   LaunchedEffect(discussion.participants) {
-    val uids = discussion.participants
     selectedMembers.clear()
-    for (uid in uids) {
-      viewModel.getOtherAccount(uid) { acc ->
-        if (selectedMembers.none { it.uid == acc.uid }) {
-          selectedMembers.add(acc)
-        }
-      }
-    }
+    viewModel.getAccounts(discussion.participants) { accounts -> selectedMembers.addAll(accounts) }
     /** Add current account only if not already present */
     account.let {
       if (selectedMembers.none { member -> member.uid == it.uid }) {

--- a/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionScreen.kt
@@ -225,8 +225,6 @@ fun DiscussionScreen(
   val discussionState by viewModel.discussionFlow(discussion.uid).collectAsState()
   val messages by viewModel.messagesFlow(discussion.uid).collectAsState()
 
-  LaunchedEffect(discussion.uid) { viewModel.readDiscussionMessages(account, discussion) }
-
   LaunchedEffect(discussionState) { discussionState?.let { disc -> discussionName = disc.name } }
 
   LaunchedEffect(messages) {
@@ -281,13 +279,17 @@ fun DiscussionScreen(
                         }
                   },
                   navigationIcon = {
-                    IconButton(onClick = onBack) {
-                      Icon(
-                          Icons.AutoMirrored.Filled.ArrowBack,
-                          contentDescription = "Back",
-                          tint = MaterialTheme.colorScheme.onSurface,
-                          modifier = Modifier.testTag(NavigationTestTags.GO_BACK_BUTTON))
-                    }
+                    IconButton(
+                        onClick = {
+                          viewModel.readDiscussionMessages(account, discussion)
+                          onBack()
+                        }) {
+                          Icon(
+                              Icons.AutoMirrored.Filled.ArrowBack,
+                              contentDescription = "Back",
+                              tint = MaterialTheme.colorScheme.onSurface,
+                              modifier = Modifier.testTag(NavigationTestTags.GO_BACK_BUTTON))
+                        }
                   },
                   actions = {
                     val icon =

--- a/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionScreen.kt
@@ -335,7 +335,8 @@ fun DiscussionScreen(
 
                   // Check if the previous message is from the same sender
                   val prevMessage = messages.getOrNull(index - 1)
-                  prevMessage?.senderId == message.senderId && !showDateHeader
+                  val isFirstFromSender =
+                      prevMessage?.senderId != message.senderId || showDateHeader
 
                   when {
                     message.poll != null ->
@@ -361,10 +362,11 @@ fun DiscussionScreen(
                             isMine,
                             sender,
                             isLastFromSender,
+                            isFirstFromSender,
                             messages,
                             userCache,
                             account.uid)
-                    else -> ChatBubble(message, isMine, sender, isLastFromSender)
+                    else -> ChatBubble(message, isMine, sender, isLastFromSender, isFirstFromSender)
                   }
 
                   // Add spacing between messages
@@ -832,6 +834,7 @@ private fun PhotoBubble(
     isMine: Boolean,
     senderName: String,
     showProfilePicture: Boolean = true,
+    showSenderName: Boolean = true,
     allMessages: List<Message> = emptyList(),
     userCache: Map<String, Account> = emptyMap(),
     currentUserId: String = ""
@@ -878,7 +881,7 @@ private fun PhotoBubble(
                         horizontal = Dimensions.Spacing.small,
                         vertical = Dimensions.Spacing.small)) {
               Column(verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.small)) {
-                if (!isMine) {
+                if (!isMine && showSenderName) {
                   Text(
                       senderName,
                       style = MaterialTheme.typography.labelSmall,
@@ -1086,13 +1089,15 @@ fun FullscreenImageDialog(
  * @param isMine Whether the message was sent by the current user (aligns right).
  * @param senderName Display name of the sender (null for own messages).
  * @param showProfilePicture Whether to show the profile picture for this message.
+ * @param showSenderName Whether to show the sender name for this message.
  */
 @Composable
 private fun ChatBubble(
     message: Message,
     isMine: Boolean,
     senderName: String?,
-    showProfilePicture: Boolean = true
+    showProfilePicture: Boolean = true,
+    showSenderName: Boolean = true
 ) {
   Row(
       modifier = Modifier.fillMaxWidth().padding(horizontal = Dimensions.Spacing.small),
@@ -1138,7 +1143,7 @@ private fun ChatBubble(
                         horizontal = Dimensions.Spacing.large,
                         vertical = Dimensions.Spacing.medium)) {
               Column {
-                if (senderName != null && !isMine) {
+                if (senderName != null && !isMine && showSenderName) {
                   Text(
                       senderName,
                       style = MaterialTheme.typography.labelSmall,

--- a/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionsOverviewScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionsOverviewScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
@@ -67,7 +68,7 @@ import kotlinx.coroutines.delay
 const val DEFAULT_DISCUSSION_NAME = "Discussion"
 const val NO_DISCUSSIONS_DEFAULT_TEXT = "No discussions yet"
 
-private const val MAXLINE = 1
+private const val MAX_LINE = 1
 
 object DiscussionOverviewTestTags {
   const val ADD_DISCUSSION_BUTTON = "Add Discussion"
@@ -98,6 +99,7 @@ fun DiscussionsOverviewScreen(
       remember(account.previews) {
         account.previews.values.sortedByDescending { it.lastMessageAt.toDate() }
       }
+  LaunchedEffect(account.previews) { viewModel.validatePreviews(account) }
 
   Scaffold(
       floatingActionButton = {
@@ -262,7 +264,7 @@ private fun DiscussionCard(
                     fontSize = Dimensions.TextSize.title,
                     color = MaterialTheme.colorScheme.onSurface,
                     fontWeight = if (unreadMsgCount > 0) FontWeight.SemiBold else FontWeight.Normal,
-                    maxLines = MAXLINE,
+                    maxLines = MAX_LINE,
                     overflow = TextOverflow.Ellipsis)
 
                 Text(
@@ -270,7 +272,7 @@ private fun DiscussionCard(
                     style = MaterialTheme.typography.bodyMedium,
                     fontSize = Dimensions.TextSize.body,
                     color = MessagingColors.secondaryText,
-                    maxLines = MAXLINE,
+                    maxLines = MAX_LINE,
                     overflow = TextOverflow.Ellipsis)
               }
 

--- a/app/src/main/java/com/github/meeplemeet/ui/posts/PostScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/posts/PostScreen.kt
@@ -236,9 +236,7 @@ fun PostScreen(
               walk(p.comments)
             }
             .filterNot { it.isBlank() || it in userCache }
-    toFetch.forEach { uid: String ->
-      accountViewModel.getOtherAccount(uid) { acc -> userCache[uid] = acc }
-    }
+    accountViewModel.getAccounts(toFetch) { it.forEach { acc -> userCache[acc.uid] = acc } }
   }
 
   Scaffold(

--- a/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionsOverviewScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionsOverviewScreen.kt
@@ -189,15 +189,7 @@ private fun SessionCard(
 
   LaunchedEffect(session.participants) {
     names.clear()
-    session.participants.forEach { id ->
-      if (id.isBlank()) {
-        names += "Unknown"
-      } else {
-        viewModel.getOtherAccount(id) { acc ->
-          names += acc.name // re-composition happens on each addition
-        }
-      }
-    }
+    viewModel.getAccounts(session.participants) { it.forEach { acc -> names += acc.name } }
   }
   /* ----------------------------------------------------- */
 


### PR DESCRIPTION
This PR fixes several data integrity issues and improves the discussions UI experience.

  ### Key Changes

  **Data Integrity**
  - Implement automatic cleanup of orphaned discussion previews that reference deleted discussions
  - Add `fullyDeleteDocument()` to properly delete Firestore documents with all subcollections
  - Fix account and discussion deletion to remove all associated subcollections (previews, relationships, notifications, messages)

  **Preview Validation**
  - Add `previewIsValid()` to check if discussion documents exist
  - Add `validatePreviews()` in DiscussionsOverviewViewModel to automatically clean up stale previews on screen load
  - Cache validated previews to minimize redundant Firestore reads

  **UI Improvements**
  - Only show sender name once per consecutive message group in discussions
  - Mark messages as read when leaving the discussion screen (not on entry)
  - Optimize `getAccounts()` usage across multiple screens

  ### Technical Details
  - Batched Firestore operations for efficient cleanup (up to 450 operations per batch)
  - Session-based caching to prevent duplicate validation checks
  - Full documentation added for all new functions

  Fixes issues where deleted discussions would still appear in user preview lists and improves overall data consistency.