### PR TITLE
Add navigation button and distance display

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/integration/MapViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/MapViewModelTest.kt
@@ -98,7 +98,7 @@ class MapViewModelTest : FirestoreTests() {
     assertEquals(PinType.entries.toSet(), state.activeFilters)
     assertNull(state.errorMsg)
     assertNull(state.selectedMarkerPreview)
-    assertNull(state.selectedGeoPin)
+    assertNull(state.selectedPin)
     assertNull(state.selectedClusterPreviews)
     assertNull(state.clusterCache)
     assertEquals(0, state.cacheVersion)
@@ -508,8 +508,8 @@ class MapViewModelTest : FirestoreTests() {
 
     val state = viewModel.uiState.value
     assertNotNull(state.selectedMarkerPreview)
-    assertNotNull(state.selectedGeoPin)
-    assertEquals(shop.id, state.selectedGeoPin!!.uid)
+    assertNotNull(state.selectedPin)
+    assertEquals(shop.id, state.selectedPin!!.geoPin.uid)
     assertFalse(state.isLoadingPreview)
 
     shopRepository.deleteShop(shop.id)
@@ -539,7 +539,7 @@ class MapViewModelTest : FirestoreTests() {
 
     val state = viewModel.uiState.value
     assertNull(state.selectedMarkerPreview)
-    assertNull(state.selectedGeoPin)
+    assertNull(state.selectedPin)
 
     shopRepository.deleteShop(shop.id)
   }
@@ -621,9 +621,9 @@ class MapViewModelTest : FirestoreTests() {
 
     val finalState = viewModel.uiState.value
     assertNull(finalState.selectedClusterPreviews)
-    assertNotNull(finalState.selectedGeoPin)
+    assertNotNull(finalState.selectedPin)
     assertNotNull(finalState.selectedMarkerPreview)
-    assertEquals(pin.geoPin.uid, finalState.selectedGeoPin!!.uid)
+    assertEquals(pin.geoPin.uid, finalState.selectedPin!!.geoPin.uid)
 
     shopRepository.deleteShop(shop1.id)
     shopRepository.deleteShop(shop2.id)

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/MapScreenTest.kt
@@ -392,7 +392,9 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
         delay(1000)
 
         composeRule.onNodeWithTag(MapScreenTestTags.MARKER_PREVIEW_SHEET).assertIsDisplayed()
-        composeRule.onNodeWithTag(MapScreenTestTags.PREVIEW_TITLE).assertTextContains(shop.name)
+        composeRule
+            .onNodeWithTag(MapScreenTestTags.PREVIEW_TITLE)
+            .assertTextContains(shop.name, substring = true)
         composeRule
             .onNodeWithTag(MapScreenTestTags.PREVIEW_ADDRESS)
             .assertTextContains(testLocation.name)
@@ -511,6 +513,40 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
       }
     }
 
+    checkpoint("singlePin_distance_displayed") {
+      runBlocking {
+        val shop =
+            shopRepository.createShop(
+                owner = shopOwnerAccount,
+                name = "Distance Test Shop",
+                address = testLocation,
+                openingHours = testOpeningHours)
+
+        refreshContent()
+
+        noClusterViewModel.startGeoQuery(
+            testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
+        delay(1500)
+
+        val clusters = noClusterViewModel.getClusters()
+        val cluster = clusters.find { it.items[0].geoPin.uid == shop.id }
+        assertNotNull(cluster)
+
+        // show preview sheet
+        noClusterViewModel.selectPin(cluster!!.items[0])
+        delay(1000)
+        composeRule.onNodeWithTag(MapScreenTestTags.MARKER_PREVIEW_SHEET).assertIsDisplayed()
+
+        // The title should include the pin name and the distance
+        composeRule
+            .onNodeWithTag(MapScreenTestTags.PREVIEW_TITLE)
+            .assertTextContains("m", substring = true)
+
+        // cleanup
+        shopRepository.deleteShop(shop.id)
+      }
+    }
+
     checkpoint("sessionPin_displaysCorrectPreview") {
       runBlocking {
         db.collection(GAMES_COLLECTION_PATH)
@@ -557,7 +593,7 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
         composeRule.onNodeWithTag(MapScreenTestTags.MARKER_PREVIEW_SHEET).assertIsDisplayed()
         composeRule
             .onNodeWithTag(MapScreenTestTags.PREVIEW_TITLE)
-            .assertTextContains("Session Preview Test")
+            .assertTextContains("Session Preview Test", substring = true)
         composeRule
             .onNodeWithTag(MapScreenTestTags.PREVIEW_GAME)
             .assertTextContains("Catan", substring = true)
@@ -732,6 +768,53 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
       }
     }
 
+    checkpoint("cluster_preview_items_display_distance") {
+      runBlocking {
+        val shop1 =
+            shopRepository.createShop(
+                owner = shopOwnerAccount,
+                name = "Cluster Distance Shop 1",
+                address = testLocation,
+                openingHours = testOpeningHours)
+
+        val shop2 =
+            shopRepository.createShop(
+                owner = shopOwnerAccount,
+                name = "Cluster Distance Shop 2",
+                address = testLocation,
+                openingHours = testOpeningHours)
+
+        refreshContent()
+
+        singleClusterViewModel.startGeoQuery(
+            testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
+        delay(1500)
+
+        val clusters = singleClusterViewModel.getClusters()
+        assertTrue(clusters.isNotEmpty())
+
+        // Select the cluster and show the sheet
+        singleClusterViewModel.selectCluster(clusters[0])
+        delay(1500)
+
+        composeRule.onNodeWithTag(MapScreenTestTags.CLUSTER_SHEET).assertIsDisplayed()
+
+        // Each displayed cluster item should contain a distance string
+        composeRule
+            .onNodeWithTag(MapScreenTestTags.getTestTagForClusterItem(shop1.id))
+            .assertIsDisplayed()
+            .assertTextContains("m", substring = true)
+        composeRule
+            .onNodeWithTag(MapScreenTestTags.getTestTagForClusterItem(shop2.id))
+            .assertIsDisplayed()
+            .assertTextContains("m", substring = true)
+
+        // cleanup
+        shopRepository.deleteShop(shop1.id)
+        shopRepository.deleteShop(shop2.id)
+      }
+    }
+
     checkpoint("clusterItem_click_transitionsToSinglePinSheet") {
       runBlocking {
         val shop1 =
@@ -771,7 +854,7 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
         composeRule.onNodeWithTag(MapScreenTestTags.MARKER_PREVIEW_SHEET).assertIsDisplayed()
         composeRule
             .onNodeWithTag(MapScreenTestTags.PREVIEW_TITLE)
-            .assertTextContains("Item Click Shop 1")
+            .assertTextContains("Item Click Shop 1", substring = true)
 
         shopRepository.deleteShop(shop1.id)
         shopRepository.deleteShop(shop2.id)

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/MapScreenTest.kt
@@ -1,6 +1,9 @@
 package com.github.meeplemeet.ui
 
 import android.Manifest
+import android.app.Activity
+import android.app.Instrumentation
+import android.content.Intent
 import androidx.activity.ComponentActivity
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
@@ -14,6 +17,11 @@ import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.Intents.intended
+import androidx.test.espresso.intent.Intents.intending
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
+import androidx.test.espresso.intent.matcher.IntentMatchers.toPackage
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
@@ -44,6 +52,7 @@ import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.tasks.await
+import org.hamcrest.Matchers.allOf
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -422,6 +431,50 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
 
         composeRule.onNodeWithTag(MapScreenTestTags.MARKER_PREVIEW_SHEET).assertDoesNotExist()
 
+        shopRepository.deleteShop(shop.id)
+      }
+    }
+
+    checkpoint("singlePin_navigateButton_triggers_maps_intent_if_available") {
+      runBlocking {
+        val shop =
+            shopRepository.createShop(
+                owner = shopOwnerAccount,
+                name = "Navigate Test Shop",
+                address = testLocation,
+                openingHours = testOpeningHours)
+
+        refreshContent()
+
+        noClusterViewModel.startGeoQuery(
+            testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
+        delay(1500)
+
+        val clusters = noClusterViewModel.getClusters()
+        val cluster = clusters.find { it.items[0].geoPin.uid == shop.id }
+        assertNotNull(cluster)
+
+        // show preview sheet
+        noClusterViewModel.selectPin(cluster!!.items[0])
+        delay(1000)
+        composeRule.onNodeWithTag(MapScreenTestTags.MARKER_PREVIEW_SHEET).assertIsDisplayed()
+
+        // init Espresso-Intents to observe intents
+        Intents.init()
+        try {
+          // perform click on Navigate button but intercept opening Google Maps
+          val matcher =
+              allOf(hasAction(Intent.ACTION_VIEW), toPackage("com.google.android.apps.maps"))
+          intending(matcher).respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, null))
+
+          composeRule.onNodeWithTag(MapScreenTestTags.PREVIEW_NAVIGATE_BUTTON).performClick()
+
+          intended(matcher)
+        } finally {
+          Intents.release()
+        }
+
+        // cleanup
         shopRepository.deleteShop(shop.id)
       }
     }

--- a/app/src/main/java/com/github/meeplemeet/model/map/MapViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/map/MapViewModel.kt
@@ -59,7 +59,7 @@ data class MapUIState(
     val errorMsg: String? = null,
     val selectedMarkerPreview: MarkerPreview? = null,
     val selectedClusterPreviews: List<Pair<GeoPinWithLocation, MarkerPreview>>? = null,
-    val selectedGeoPin: StorableGeoPin? = null,
+    val selectedPin: GeoPinWithLocation? = null,
     val isLoadingPreview: Boolean = false,
 
     // Internal cluster cache
@@ -371,13 +371,13 @@ class MapViewModel(
    */
   fun selectPin(pin: GeoPinWithLocation) {
     viewModelScope.launch {
-      _uiState.update { it.copy(isLoadingPreview = true) }
+      _uiState.update { it.copy(isLoadingPreview = true, selectedPin = pin) }
       try {
         val preview = markerPreviewRepo.getMarkerPreview(pin.geoPin)
         _uiState.update {
           it.copy(
               selectedMarkerPreview = preview,
-              selectedGeoPin = pin.geoPin,
+              selectedPin = pin,
               errorMsg = null,
               isLoadingPreview = false)
         }
@@ -385,7 +385,7 @@ class MapViewModel(
         _uiState.update {
           it.copy(
               selectedMarkerPreview = null,
-              selectedGeoPin = null,
+              selectedPin = null,
               errorMsg = "Failed to fetch preview for ${pin.geoPin.uid}: ${e.message}",
               isLoadingPreview = false)
         }
@@ -395,7 +395,7 @@ class MapViewModel(
 
   /** Clears the current selection (both marker preview and geo-pin). */
   fun clearSelectedPin() {
-    _uiState.update { it.copy(selectedMarkerPreview = null, selectedGeoPin = null) }
+    _uiState.update { it.copy(selectedMarkerPreview = null, selectedPin = null) }
   }
 
   /**
@@ -441,7 +441,7 @@ class MapViewModel(
     _uiState.update {
       it.copy(
           selectedClusterPreviews = null,
-          selectedGeoPin = pin.geoPin,
+          selectedPin = pin,
           selectedMarkerPreview = preview,
           errorMsg = null)
     }

--- a/app/src/main/java/com/github/meeplemeet/ui/MapScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/MapScreen.kt
@@ -381,12 +381,12 @@ fun MapScreen(
             ModalBottomSheet(
                 sheetState = sheetState, onDismissRequest = { viewModel.clearSelectedPin() }) {
                   if (isLoading) {
-                    MarkerPreviewLoadingSheet(geoPin = uiState.selectedGeoPin!!)
+                    MarkerPreviewLoadingSheet(pin = uiState.selectedPin)
                   } else {
                     MarkerPreviewSheet(
                         preview = uiState.selectedMarkerPreview!!,
                         onClose = { viewModel.clearSelectedPin() },
-                        geoPin = uiState.selectedGeoPin!!,
+                        pin = uiState.selectedPin!!,
                         onRedirect = onRedirect)
                   }
                 }
@@ -834,10 +834,10 @@ private fun Context.openGoogleMapsDirections(lat: Double, lng: Double) {
  * Shows a centered text and a circular progress indicator. The text varies depending on the type of
  * the pin being loaded, or shows "Loading cluster..." if loading a cluster (geoPin is null).
  *
- * @param geoPin the [StorableGeoPin] for which the preview is loading
+ * @param pin the [GeoPinWithLocation] for which the preview is loading
  */
 @Composable
-private fun MarkerPreviewLoadingSheet(geoPin: StorableGeoPin?) {
+private fun MarkerPreviewLoadingSheet(pin: GeoPinWithLocation?) {
   Column(
       modifier =
           Modifier.fillMaxWidth()
@@ -846,7 +846,7 @@ private fun MarkerPreviewLoadingSheet(geoPin: StorableGeoPin?) {
       horizontalAlignment = Alignment.CenterHorizontally) {
         Text(
             text =
-                when (geoPin?.type) {
+                when (pin?.geoPin?.type) {
                   PinType.SHOP -> "Loading shop..."
                   PinType.SPACE -> "Loading space..."
                   PinType.SESSION -> "Loading session..."
@@ -881,7 +881,7 @@ private fun MarkerPreviewLoadingSheet(geoPin: StorableGeoPin?) {
 private fun MarkerPreviewSheet(
     preview: MarkerPreview,
     onClose: () -> Unit,
-    geoPin: StorableGeoPin,
+    pin: GeoPinWithLocation,
     onRedirect: (StorableGeoPin) -> Unit
 ) {
   Column(
@@ -970,7 +970,7 @@ private fun MarkerPreviewSheet(
 
         Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
           Button(
-              onClick = { onRedirect(geoPin) },
+              onClick = { onRedirect(pin.geoPin) },
               modifier = Modifier.testTag(MapScreenTestTags.PREVIEW_VIEW_DETAILS_BUTTON)) {
                 Text(text = "View details")
               }

--- a/app/src/main/java/com/github/meeplemeet/ui/MapScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/MapScreen.kt
@@ -877,7 +877,7 @@ private fun GeoPinWithLocation.distanceTo(location: Location): Double {
  */
 private fun GeoPinWithLocation.distanceToString(location: Location): String {
   val km = distanceTo(location)
-  return if (km < 1.0) "\${(km * 1000).toInt()} m" else String.format("%.1f km", km)
+  return if (km < 1.0) "${(km * 1000).toInt()} m" else String.format("%.1f km", km)
 }
 
 /**

--- a/app/src/main/java/com/github/meeplemeet/ui/MapScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/MapScreen.kt
@@ -884,6 +884,8 @@ private fun MarkerPreviewSheet(
     pin: GeoPinWithLocation,
     onRedirect: (StorableGeoPin) -> Unit
 ) {
+  val context = LocalContext.current
+
   Column(
       modifier =
           Modifier.fillMaxWidth()
@@ -978,7 +980,9 @@ private fun MarkerPreviewSheet(
           Spacer(modifier = Modifier.width(Dimensions.Spacing.medium))
 
           Button(
-              onClick = {},
+              onClick = {
+                context.openGoogleMapsDirections(pin.location.latitude, pin.location.longitude)
+              },
               modifier = Modifier.testTag(MapScreenTestTags.PREVIEW_NAVIGATE_BUTTON)) {
                 Text(text = "Navigate")
               }

--- a/app/src/main/java/com/github/meeplemeet/ui/MapScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/MapScreen.kt
@@ -1040,7 +1040,7 @@ private fun MarkerPreviewSheet(
                 context.openGoogleMapsDirections(pin.location.latitude, pin.location.longitude)
               },
               modifier = Modifier.testTag(MapScreenTestTags.PREVIEW_NAVIGATE_BUTTON)) {
-                Text(text = "Navigate")
+                Text(text = "Go To")
               }
         }
       }


### PR DESCRIPTION
### Description
This PR introduces two new features to improve the map experience:

- **"Go To" button**  
  From a cluster or item preview, users can now open Google Maps directly with navigation already set up from their current location to the selected pin.

- **Distance display**  
  When opening a cluster or a preview, the UI shows the distance between the user’s current position and the item. Distances are formatted in meters (<1 km) or kilometers (≥1 km).


https://github.com/user-attachments/assets/03c4f9fa-851a-47de-884f-8b977dd50f93

<img width="572" height="1270" alt="Capture d&#39;écran 2025-11-26 212158" src="https://github.com/user-attachments/assets/0245d594-59d6-46d5-b100-78d9c40f05a8" />

_Reformulated with Copilot._