### PR TITLE
Feat/session history tab

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/ui/SessionsOverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/SessionsOverviewScreenTest.kt
@@ -54,7 +54,6 @@ class SessionsOverviewScreenTest : FirestoreTests() {
     val uid = "uid_" + UUID.randomUUID().toString().take(8)
     account = accountRepository.createAccount(uid, "Tester", "test@x.com", null)
 
-    // seed minimal game
     db.collection(GAMES_COLLECTION_PATH).document(testGameId).set(GameNoUid(name = "Chess")).await()
 
     capturedDiscussionId = ""
@@ -82,11 +81,10 @@ class SessionsOverviewScreenTest : FirestoreTests() {
         val discussion =
             discussionRepository.createDiscussion("Game Night", "Let's play", account.uid)
         val game = gameRepository.getGameById(testGameId)
-        // Use a future date to ensure it appears in "Next sessions"
-        val futureDate = Timestamp(java.util.Date(System.currentTimeMillis() + 86400000)) // +1 day
+        val futureDate = Timestamp(java.util.Date(System.currentTimeMillis() + 86400000))
         sessionRepository.createSession(
             discussion.uid, "Chess Night", game.uid, futureDate, testLocation, account.uid)
-        delay(100) // snapshot
+        delay(100)
         emptyText().assertDoesNotExist()
         sessionCard(discussion.uid).assertIsDisplayed()
       }
@@ -98,8 +96,7 @@ class SessionsOverviewScreenTest : FirestoreTests() {
         val discussion =
             discussionRepository.createDiscussion("Navigate Me", "Tap test", account.uid)
         val game = gameRepository.getGameById(testGameId)
-        // Use a future date to ensure it appears in "Next sessions"
-        val futureDate = Timestamp(java.util.Date(System.currentTimeMillis() + 86400000)) // +1 day
+        val futureDate = Timestamp(java.util.Date(System.currentTimeMillis() + 86400000))
         sessionRepository.createSession(
             discussion.uid, "Tap Night", game.uid, futureDate, testLocation, account.uid)
         delay(100)
@@ -114,7 +111,6 @@ class SessionsOverviewScreenTest : FirestoreTests() {
         val discussion =
             discussionRepository.createDiscussion("Delete Me", "Will vanish", account.uid)
         val game = gameRepository.getGameById(testGameId)
-        // Ensure it's a future session so it appears in "Next"
         val futureDate = Timestamp(java.util.Date(System.currentTimeMillis() + 10000000))
         sessionRepository.createSession(
             discussion.uid, "Vanish Night", game.uid, futureDate, testLocation, account.uid)
@@ -130,14 +126,11 @@ class SessionsOverviewScreenTest : FirestoreTests() {
     /* 5. toggle history -> WIP shown ------------------------------------ */
     checkpoint("Toggle History – shows history grid") {
       compose.onNodeWithText("History").performClick()
-      // WIP text should be gone now, replaced by grid
-      compose.onNodeWithText("WIP").assertDoesNotExist()
     }
 
     /* 6. click history card -> popup appears ---------------------------- */
     checkpoint("Click history card – popup appears") {
       runBlocking {
-        // Create a past session
         val pastDate = Timestamp(java.util.Date(System.currentTimeMillis() - 10000000))
         val discussion =
             discussionRepository.createDiscussion("Past Session", "Old times", account.uid)
@@ -146,18 +139,13 @@ class SessionsOverviewScreenTest : FirestoreTests() {
             discussion.uid, "Past Night", game.uid, pastDate, testLocation, account.uid)
         delay(100)
 
-        // Verify card is in history
         compose.onNodeWithText("Past Night").assertIsDisplayed()
 
-        // Click it
         compose.onNodeWithText("Past Night").performClick()
 
-        // Check popup content
-        // There should be two "Past Night" texts now: one in the list, one in the popup
         compose.onAllNodesWithText("Past Night").assertCountEquals(2)
         compose.onNodeWithContentDescription("Close").assertIsDisplayed()
 
-        // Close popup
         compose.onNodeWithContentDescription("Close").performClick()
         compose.onNodeWithContentDescription("Close").assertDoesNotExist()
       }
@@ -166,7 +154,6 @@ class SessionsOverviewScreenTest : FirestoreTests() {
 
   @After
   fun tearDown(): Unit = runBlocking {
-    // clean-up game seed
     db.collection(GAMES_COLLECTION_PATH).document(testGameId).delete().await()
   }
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/components/SessionDetailsCard.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/SessionDetailsCard.kt
@@ -87,19 +87,6 @@ fun SessionDetailsCard(
     }
   }
 
-  val participantText =
-      when {
-        names.size < session.participants.size -> "Loading…"
-        names.isEmpty() -> "No participants"
-        names.size == 1 -> names.first()
-        names.size == 2 -> names.joinToString(", ")
-        else -> {
-          val firstTwo = names.take(2).joinToString(", ")
-          val remaining = names.size - 2
-          "$firstTwo and $remaining more participant${if (remaining > 1) "s" else ""}"
-        }
-      }
-
   val gameName by
       produceState(
           key1 = session.gameId, initialValue = session.gameId // fallback: show id while loading
@@ -137,128 +124,131 @@ fun SessionDetailsCard(
 
               // TITLE + CLOSE
               Box(modifier = Modifier.fillMaxWidth()) {
-                Column(modifier = Modifier.align(Alignment.CenterStart).padding(end = 40.dp)) {
-                  Text(
-                      text = session.name,
-                      style = MaterialTheme.typography.headlineMedium,
-                      fontWeight = FontWeight.Bold,
-                      maxLines = 2,
-                      overflow = TextOverflow.Ellipsis)
+                Column(
+                    modifier =
+                        Modifier.align(Alignment.CenterStart)
+                            .padding(end = Dimensions.Padding.huge)) {
+                      Text(
+                          text = session.name,
+                          style = MaterialTheme.typography.headlineMedium,
+                          fontWeight = FontWeight.Bold,
+                          maxLines = 2,
+                          overflow = TextOverflow.Ellipsis)
 
-                  Spacer(modifier = Modifier.height(Dimensions.Spacing.small))
+                      Spacer(modifier = Modifier.height(Dimensions.Spacing.small))
 
-                  // Game with Dice Icon
-                  Row(verticalAlignment = Alignment.CenterVertically) {
-                    Icon(
-                        imageVector = Icons.Filled.Extension,
-                        contentDescription = null,
-                        modifier = Modifier.size(Dimensions.IconSize.medium),
-                        tint = AppColors.textIconsFade)
-                    Spacer(modifier = Modifier.width(Dimensions.Spacing.small))
-                    Text(
-                        text = gameName,
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = AppColors.textIconsFade,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis)
-                  }
-
-                  Spacer(modifier = Modifier.height(Dimensions.Spacing.small))
-
-                  // Participants with People Icon
-                  Row(
-                      verticalAlignment = Alignment.CenterVertically,
-                      modifier = Modifier.fillMaxWidth()) {
+                      // Game with Dice Icon
+                      Row(verticalAlignment = Alignment.CenterVertically) {
                         Icon(
-                            imageVector = Icons.Default.People,
+                            imageVector = Icons.Filled.Extension,
                             contentDescription = null,
                             modifier = Modifier.size(Dimensions.IconSize.medium),
                             tint = AppColors.textIconsFade)
                         Spacer(modifier = Modifier.width(Dimensions.Spacing.small))
-
-                        when {
-                          names.size < session.participants.size -> {
-                            Text(
-                                text = "Loading…",
-                                style = MaterialTheme.typography.bodyLarge,
-                                color = AppColors.textIconsFade)
-                          }
-                          names.isEmpty() -> {
-                            Text(
-                                text = "No participants",
-                                style = MaterialTheme.typography.bodyLarge,
-                                color = AppColors.textIconsFade)
-                          }
-                          names.size == 1 -> {
-                            Text(
-                                text = names.first(),
-                                style = MaterialTheme.typography.bodyLarge,
-                                color = AppColors.textIconsFade,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis)
-                          }
-                          names.size == 2 -> {
-                            Text(
-                                text = names.joinToString(", "),
-                                style = MaterialTheme.typography.bodyLarge,
-                                color = AppColors.textIconsFade,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis)
-                          }
-                          else -> {
-                            val firstTwo = names.take(2).joinToString(", ")
-                            val remaining = names.size - 2
-
-                            Text(
-                                text = firstTwo,
-                                style = MaterialTheme.typography.bodyLarge,
-                                color = AppColors.textIconsFade,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                                modifier = Modifier.weight(1f, fill = false))
-                            Text(
-                                text =
-                                    " and $remaining more participant${if (remaining > 1) "s" else ""}",
-                                style = MaterialTheme.typography.bodyLarge,
-                                color = AppColors.textIconsFade,
-                                maxLines = 1)
-                          }
-                        }
+                        Text(
+                            text = gameName,
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = AppColors.textIconsFade,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis)
                       }
 
-                  Spacer(modifier = Modifier.height(Dimensions.Spacing.small))
+                      Spacer(modifier = Modifier.height(Dimensions.Spacing.small))
 
-                  // Location and Date
-                  Row(
-                      verticalAlignment = Alignment.CenterVertically,
-                      modifier = Modifier.fillMaxWidth()) {
-                        if (session.location.name.isNotBlank()) {
-                          Icon(
-                              imageVector = Icons.Default.Place,
-                              contentDescription = null,
-                              modifier = Modifier.size(Dimensions.IconSize.medium),
-                              tint = AppColors.textIconsFade)
-                          Spacer(modifier = Modifier.width(Dimensions.Spacing.small))
-                          Text(
-                              text = session.location.name,
-                              style = MaterialTheme.typography.bodyLarge,
-                              color = AppColors.textIconsFade,
-                              maxLines = 1,
-                              overflow = TextOverflow.Ellipsis,
-                              modifier = Modifier.weight(1f, fill = false))
-                          Text(
-                              text = " • $date",
-                              style = MaterialTheme.typography.bodyLarge,
-                              color = AppColors.textIconsFade,
-                              maxLines = 1)
-                        } else {
-                          Text(
-                              text = date,
-                              style = MaterialTheme.typography.bodyLarge,
-                              color = AppColors.textIconsFade)
-                        }
-                      }
-                }
+                      // Participants with People Icon
+                      Row(
+                          verticalAlignment = Alignment.CenterVertically,
+                          modifier = Modifier.fillMaxWidth()) {
+                            Icon(
+                                imageVector = Icons.Default.People,
+                                contentDescription = null,
+                                modifier = Modifier.size(Dimensions.IconSize.medium),
+                                tint = AppColors.textIconsFade)
+                            Spacer(modifier = Modifier.width(Dimensions.Spacing.small))
+
+                            when {
+                              names.size < session.participants.size -> {
+                                Text(
+                                    text = "Loading…",
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    color = AppColors.textIconsFade)
+                              }
+                              names.isEmpty() -> {
+                                Text(
+                                    text = "No participants",
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    color = AppColors.textIconsFade)
+                              }
+                              names.size == 1 -> {
+                                Text(
+                                    text = names.first(),
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    color = AppColors.textIconsFade,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis)
+                              }
+                              names.size == 2 -> {
+                                Text(
+                                    text = names.joinToString(", "),
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    color = AppColors.textIconsFade,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis)
+                              }
+                              else -> {
+                                val firstTwo = names.take(2).joinToString(", ")
+                                val remaining = names.size - 2
+
+                                Text(
+                                    text = firstTwo,
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    color = AppColors.textIconsFade,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                    modifier = Modifier.weight(1f, fill = false))
+                                Text(
+                                    text =
+                                        " and $remaining more participant${if (remaining > 1) "s" else ""}",
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    color = AppColors.textIconsFade,
+                                    maxLines = 1)
+                              }
+                            }
+                          }
+
+                      Spacer(modifier = Modifier.height(Dimensions.Spacing.small))
+
+                      // Location and Date
+                      Row(
+                          verticalAlignment = Alignment.CenterVertically,
+                          modifier = Modifier.fillMaxWidth()) {
+                            if (session.location.name.isNotBlank()) {
+                              Icon(
+                                  imageVector = Icons.Default.Place,
+                                  contentDescription = null,
+                                  modifier = Modifier.size(Dimensions.IconSize.medium),
+                                  tint = AppColors.textIconsFade)
+                              Spacer(modifier = Modifier.width(Dimensions.Spacing.small))
+                              Text(
+                                  text = session.location.name,
+                                  style = MaterialTheme.typography.bodyLarge,
+                                  color = AppColors.textIconsFade,
+                                  maxLines = 1,
+                                  overflow = TextOverflow.Ellipsis,
+                                  modifier = Modifier.weight(1f, fill = false))
+                              Text(
+                                  text = " • $date",
+                                  style = MaterialTheme.typography.bodyLarge,
+                                  color = AppColors.textIconsFade,
+                                  maxLines = 1)
+                            } else {
+                              Text(
+                                  text = date,
+                                  style = MaterialTheme.typography.bodyLarge,
+                                  color = AppColors.textIconsFade)
+                            }
+                          }
+                    }
 
                 IconButton(onClick = onClose, modifier = Modifier.align(Alignment.TopEnd)) {
                   Icon(Icons.Default.Close, contentDescription = "Close")

--- a/app/src/main/java/com/github/meeplemeet/ui/components/SessionDetailsCard.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/SessionDetailsCard.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
 import com.github.meeplemeet.model.sessions.Session
 import com.github.meeplemeet.model.sessions.SessionOverviewViewModel
@@ -28,8 +27,6 @@ import com.github.meeplemeet.ui.theme.AppColors
 import com.github.meeplemeet.ui.theme.Dimensions
 import java.text.SimpleDateFormat
 import java.util.Locale
-
-private val CUSTOM_IMAGE_HEIGHT = 180.dp
 
 /**
  * Displays a detailed card for a session, including title, game, participants, location, date and
@@ -100,7 +97,8 @@ fun SessionDetailsCard(
 
               Spacer(modifier = Modifier.height(Dimensions.Spacing.medium))
 
-              SessionImage(session = session)
+              SessionImage(
+                  session = session, modifier = Modifier.align(Alignment.CenterHorizontally))
             }
       }
 }
@@ -244,16 +242,31 @@ private fun LocationAndDateInfo(location: String, date: String) {
  * @param session Source of the image label/description.
  */
 @Composable
-private fun SessionImage(session: Session) {
-  val imageUrl =
-      "https://npr.brightspotcdn.com/dims4/default/389845d/2147483647/strip/true/crop/4373x3279+0+0/resize/880x660!/quality/90/?url=http%3A%2F%2Fnpr-brightspot.s3.amazonaws.com%2Flegacy%2Fimages%2Fnews%2Fnpr%2F2020%2F07%2F887305543_2064699070.jpg"
+private fun SessionImage(session: Session, modifier: Modifier = Modifier) {
+  val imageUrl = session.photoUrl?.takeIf { it.isNotBlank() }
 
-  Image(
-      painter = rememberAsyncImagePainter(imageUrl),
-      contentDescription = session.name,
-      contentScale = ContentScale.Crop,
-      modifier =
-          Modifier.fillMaxWidth()
-              .heightIn(max = CUSTOM_IMAGE_HEIGHT)
-              .clip(RoundedCornerShape(Dimensions.CornerRadius.large)))
+  if (imageUrl != null) {
+    Image(
+        painter = rememberAsyncImagePainter(imageUrl),
+        contentDescription = session.name,
+        contentScale = ContentScale.Crop,
+        modifier =
+            Modifier.fillMaxWidth()
+                .heightIn(max = Dimensions.ContainerSize.bottomSheetHeight)
+                .clip(RoundedCornerShape(Dimensions.CornerRadius.large)))
+  } else {
+    Box(
+        modifier =
+            modifier
+                .fillMaxWidth(0.7f)
+                .aspectRatio(Dimensions.Fractions.topBarDivider)
+                .clip(RoundedCornerShape(Dimensions.CornerRadius.large))
+                .background(androidx.compose.ui.graphics.Color.Black),
+        contentAlignment = Alignment.Center) {
+          Text(
+              text = "No Image Uploaded",
+              color = AppColors.textIconsFade,
+              style = MaterialTheme.typography.bodyLarge)
+        }
+  }
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/components/SessionDetailsCard.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/SessionDetailsCard.kt
@@ -1,0 +1,285 @@
+package com.github.meeplemeet.ui.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Extension
+import androidx.compose.material.icons.filled.People
+import androidx.compose.material.icons.filled.Place
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil.compose.rememberAsyncImagePainter
+import com.github.meeplemeet.model.sessions.Session
+import com.github.meeplemeet.model.sessions.SessionOverviewViewModel
+import com.github.meeplemeet.ui.sessions.LABEL_UNKNOWN_GAME
+import com.github.meeplemeet.ui.theme.AppColors
+import com.github.meeplemeet.ui.theme.Dimensions
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+private val CUSTOM_IMAGE_HEIGHT = 180.dp
+
+/**
+ * A detailed card displaying information about a [Session].
+ *
+ * Shows the session title, an image, info chips for location and date, and participants.
+ *
+ * @param session The [Session] object containing all information to display.
+ * @param viewModel The [SessionOverviewViewModel] to resolve game and participant names.
+ * @param modifier Optional [Modifier] for the card container.
+ * @param onClose Lambda invoked when the close button is pressed.
+ */
+@Composable
+fun SessionDetailsCard(
+    session: Session,
+    viewModel: SessionOverviewViewModel,
+    modifier: Modifier = Modifier,
+    onClose: () -> Unit = {}
+) {
+  val date =
+      remember(session.date) {
+        SimpleDateFormat("dd/MM/yyyy", Locale.getDefault()).format(session.date.toDate())
+      }
+
+  /* ---------  resolve names via the callback  --------- */
+  val names = remember { mutableStateListOf<String>() }
+
+  LaunchedEffect(session.participants) {
+    names.clear()
+    session.participants.forEach { id ->
+      if (id.isBlank()) {
+        names += "Unknown"
+      } else {
+        viewModel.getOtherAccount(id) { acc ->
+          names += acc.name // re-composition happens on each addition
+        }
+      }
+    }
+  }
+
+  val participantText =
+      when {
+        names.size < session.participants.size -> "Loading…"
+        names.isEmpty() -> "No participants"
+        names.size == 1 -> names.first()
+        names.size == 2 -> names.joinToString(", ")
+        else -> {
+          val firstTwo = names.take(2).joinToString(", ")
+          val remaining = names.size - 2
+          "$firstTwo and $remaining more participant${if (remaining > 1) "s" else ""}"
+        }
+      }
+
+  val gameName by
+      produceState(
+          key1 = session.gameId, initialValue = session.gameId // fallback: show id while loading
+          ) {
+            val name =
+                if (session.gameId == LABEL_UNKNOWN_GAME) null
+                else viewModel.getGameNameByGameId(session.gameId)
+            value = name ?: "No game selected" // suspend call
+      }
+
+  Box(
+      modifier =
+          modifier
+              .fillMaxWidth() // optional width limitation
+              .border(
+                  width = Dimensions.Padding.tiny,
+                  color = AppColors.secondary, // border color
+                  shape = RoundedCornerShape(Dimensions.CornerRadius.large))
+              .clip(
+                  RoundedCornerShape(
+                      Dimensions.CornerRadius.large)) // rounded corners for the whole card
+              .background(AppColors.primary) // card background
+              .clickable(
+                  interactionSource =
+                      remember {
+                        androidx.compose.foundation.interaction.MutableInteractionSource()
+                      },
+                  indication =
+                      null) {}, // Consume clicks to prevent closing when clicking on the card
+      contentAlignment = Alignment.Center) {
+        Column(
+            modifier =
+                Modifier.widthIn(max = Dimensions.ContainerSize.maxListHeight)
+                    .padding(Dimensions.Padding.extraLarge)) {
+
+              // TITLE + CLOSE
+              Box(modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.align(Alignment.CenterStart).padding(end = 40.dp)) {
+                  Text(
+                      text = session.name,
+                      style = MaterialTheme.typography.headlineMedium,
+                      fontWeight = FontWeight.Bold,
+                      maxLines = 2,
+                      overflow = TextOverflow.Ellipsis)
+
+                  Spacer(modifier = Modifier.height(Dimensions.Spacing.small))
+
+                  // Game with Dice Icon
+                  Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Icons.Filled.Extension,
+                        contentDescription = null,
+                        modifier = Modifier.size(Dimensions.IconSize.medium),
+                        tint = AppColors.textIconsFade)
+                    Spacer(modifier = Modifier.width(Dimensions.Spacing.small))
+                    Text(
+                        text = gameName,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = AppColors.textIconsFade,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis)
+                  }
+
+                  Spacer(modifier = Modifier.height(Dimensions.Spacing.small))
+
+                  // Participants with People Icon
+                  Row(
+                      verticalAlignment = Alignment.CenterVertically,
+                      modifier = Modifier.fillMaxWidth()) {
+                        Icon(
+                            imageVector = Icons.Default.People,
+                            contentDescription = null,
+                            modifier = Modifier.size(Dimensions.IconSize.medium),
+                            tint = AppColors.textIconsFade)
+                        Spacer(modifier = Modifier.width(Dimensions.Spacing.small))
+
+                        when {
+                          names.size < session.participants.size -> {
+                            Text(
+                                text = "Loading…",
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = AppColors.textIconsFade)
+                          }
+                          names.isEmpty() -> {
+                            Text(
+                                text = "No participants",
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = AppColors.textIconsFade)
+                          }
+                          names.size == 1 -> {
+                            Text(
+                                text = names.first(),
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = AppColors.textIconsFade,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis)
+                          }
+                          names.size == 2 -> {
+                            Text(
+                                text = names.joinToString(", "),
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = AppColors.textIconsFade,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis)
+                          }
+                          else -> {
+                            val firstTwo = names.take(2).joinToString(", ")
+                            val remaining = names.size - 2
+
+                            Text(
+                                text = firstTwo,
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = AppColors.textIconsFade,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier.weight(1f, fill = false))
+                            Text(
+                                text =
+                                    " and $remaining more participant${if (remaining > 1) "s" else ""}",
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = AppColors.textIconsFade,
+                                maxLines = 1)
+                          }
+                        }
+                      }
+
+                  Spacer(modifier = Modifier.height(Dimensions.Spacing.small))
+
+                  // Location and Date
+                  Row(
+                      verticalAlignment = Alignment.CenterVertically,
+                      modifier = Modifier.fillMaxWidth()) {
+                        if (session.location.name.isNotBlank()) {
+                          Icon(
+                              imageVector = Icons.Default.Place,
+                              contentDescription = null,
+                              modifier = Modifier.size(Dimensions.IconSize.medium),
+                              tint = AppColors.textIconsFade)
+                          Spacer(modifier = Modifier.width(Dimensions.Spacing.small))
+                          Text(
+                              text = session.location.name,
+                              style = MaterialTheme.typography.bodyLarge,
+                              color = AppColors.textIconsFade,
+                              maxLines = 1,
+                              overflow = TextOverflow.Ellipsis,
+                              modifier = Modifier.weight(1f, fill = false))
+                          Text(
+                              text = " • $date",
+                              style = MaterialTheme.typography.bodyLarge,
+                              color = AppColors.textIconsFade,
+                              maxLines = 1)
+                        } else {
+                          Text(
+                              text = date,
+                              style = MaterialTheme.typography.bodyLarge,
+                              color = AppColors.textIconsFade)
+                        }
+                      }
+                }
+
+                IconButton(onClick = onClose, modifier = Modifier.align(Alignment.TopEnd)) {
+                  Icon(Icons.Default.Close, contentDescription = "Close")
+                }
+              }
+
+              Spacer(modifier = Modifier.height(Dimensions.Spacing.medium))
+
+              // IMAGE
+              // TODO: Use real session image when available
+              val imageUrl =
+                  "https://npr.brightspotcdn.com/dims4/default/389845d/2147483647/strip/true/crop/4373x3279+0+0/resize/880x660!/quality/90/?url=http%3A%2F%2Fnpr-brightspot.s3.amazonaws.com%2Flegacy%2Fimages%2Fnews%2Fnpr%2F2020%2F07%2F887305543_2064699070.jpg"
+
+              Image(
+                  painter = rememberAsyncImagePainter(imageUrl),
+                  contentDescription = session.name,
+                  contentScale = ContentScale.Crop, // preserves natural aspect ratio
+                  modifier =
+                      Modifier.fillMaxWidth() // expand to available width
+                          .heightIn(max = CUSTOM_IMAGE_HEIGHT) // limit height
+                          .clip(RoundedCornerShape(Dimensions.CornerRadius.large)))
+            }
+      }
+}

--- a/app/src/main/java/com/github/meeplemeet/ui/components/SessionDetailsCard.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/SessionDetailsCard.kt
@@ -228,7 +228,7 @@ private fun LocationAndDateInfo(location: String, date: String) {
           color = AppColors.textIconsFade,
           maxLines = 1,
           overflow = TextOverflow.Ellipsis,
-          modifier = Modifier.weight(1f, fill = false))
+          modifier = Modifier.weight(Dimensions.Weight.full, fill = false))
       Text(text = " • $date", color = AppColors.textIconsFade)
     } else {
       Text(text = date, color = AppColors.textIconsFade)
@@ -258,7 +258,7 @@ private fun SessionImage(session: Session, modifier: Modifier = Modifier) {
     Box(
         modifier =
             modifier
-                .fillMaxWidth(0.7f)
+                .fillMaxWidth(Dimensions.Fractions.topBarDivider)
                 .aspectRatio(Dimensions.Fractions.topBarDivider)
                 .clip(RoundedCornerShape(Dimensions.CornerRadius.large))
                 .background(androidx.compose.ui.graphics.Color.Black),

--- a/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionsOverviewScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionsOverviewScreen.kt
@@ -82,70 +82,66 @@ fun SessionsOverviewScreen(
     account: Account?,
     onSelectSession: (String) -> Unit = {}
 ) {
-    val sessionMap by
-    viewModel.sessionMapFlow(account?.uid ?: "").collectAsState(initial = emptyMap())
+  val sessionMap by
+      viewModel.sessionMapFlow(account?.uid ?: "").collectAsState(initial = emptyMap())
 
-    /* --------------  NEW: toggle state  -------------- */
-    var showHistory by remember { mutableStateOf(false) }
+  /* --------------  NEW: toggle state  -------------- */
+  var showHistory by remember { mutableStateOf(false) }
 
-    Scaffold(
-        topBar = {
-            Column(Modifier.fillMaxWidth()) {
-                /* 1. original top-bar (kept) */
-                CenterAlignedTopAppBar(
-                    title = {
-                        Text(
-                            text = MeepleMeetScreen.SessionsOverview.title,
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onPrimary,
-                            modifier = Modifier.testTag(NavigationTestTags.SCREEN_TITLE))
-                    })
+  Scaffold(
+      topBar = {
+        Column(Modifier.fillMaxWidth()) {
+          /* 1. original top-bar (kept) */
+          CenterAlignedTopAppBar(
+              title = {
+                Text(
+                    text = MeepleMeetScreen.SessionsOverview.title,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onPrimary,
+                    modifier = Modifier.testTag(NavigationTestTags.SCREEN_TITLE))
+              })
 
-                SessionToggle( // <-- use the same variable
-                    showHistory = showHistory,
-                    onNext = { showHistory = false },
-                    onHistory = { showHistory = true })
+          SessionToggle( // <-- use the same variable
+              showHistory = showHistory,
+              onNext = { showHistory = false },
+              onHistory = { showHistory = true })
+        }
+      },
+      bottomBar = {
+        BottomNavigationMenu(
+            currentScreen = MeepleMeetScreen.SessionsOverview,
+            onTabSelected = { navigation.navigateTo(it) })
+      }) { innerPadding ->
+        Box(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
+          when {
+            showHistory -> {
+              val now = System.currentTimeMillis()
+
+              // Separate past sessions
+              val pastSessions =
+                  sessionMap
+                      .filter { (_, session) -> session.date.toDate().time < now }
+                      .values
+                      .sortedByDescending { it.date.toDate().time }
+
+              HistoryGrid(sessions = pastSessions)
             }
-        },
-        bottomBar = {
-            BottomNavigationMenu(
-                currentScreen = MeepleMeetScreen.SessionsOverview,
-                onTabSelected = { navigation.navigateTo(it) })
-        }) { innerPadding ->
-        Box(modifier = Modifier
-            .fillMaxSize()
-            .padding(innerPadding)) {
-            when {
-                showHistory -> {
-                    val now = System.currentTimeMillis()
-
-                    // Separate past sessions
-                    val pastSessions =
-                        sessionMap.filter { (_, session) ->
-                            session.date.toDate().time < now
-                        }.values.sortedByDescending { it.date.toDate().time }
-
-                    HistoryGrid(sessions = pastSessions)
-
-                }
-                sessionMap.isEmpty() -> EmptySessionsListText()
-                else -> {
-                    /* ----------------  NEXT SESSIONS (existing list)  ---------------- */
-                    LazyColumn(
-                        modifier = Modifier.fillMaxSize(),
-                        verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.none)) {
-                        items(sessionMap.entries.toList(), key = { it.key }) { (id, session) ->
-                            SessionCard(
-                                session = session,
-                                viewModel = viewModel,
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .testTag("sessionCard_$id"),
-                                onClick = { onSelectSession(id) })
-                        }
+            sessionMap.isEmpty() -> EmptySessionsListText()
+            else -> {
+              /* ----------------  NEXT SESSIONS (existing list)  ---------------- */
+              LazyColumn(
+                  modifier = Modifier.fillMaxSize(),
+                  verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.none)) {
+                    items(sessionMap.entries.toList(), key = { it.key }) { (id, session) ->
+                      SessionCard(
+                          session = session,
+                          viewModel = viewModel,
+                          modifier = Modifier.fillMaxWidth().testTag("sessionCard_$id"),
+                          onClick = { onSelectSession(id) })
                     }
-                }
+                  }
             }
+          }
         }
       }
 }
@@ -153,27 +149,25 @@ fun SessionsOverviewScreen(
 /** Displays a centred label when the user has no upcoming sessions. */
 @Composable
 private fun EmptySessionsListText() {
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(Dimensions.Spacing.xxxLarge),
-        contentAlignment = Alignment.Center) {
+  Box(
+      modifier = Modifier.fillMaxSize().padding(Dimensions.Spacing.xxxLarge),
+      contentAlignment = Alignment.Center) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.medium)) {
-            Icon(
-                imageVector = Icons.AutoMirrored.Filled.Article,
-                contentDescription = null,
-                modifier = Modifier.size(Dimensions.IconSize.giant),
-                tint = MessagingColors.secondaryText)
-            Spacer(modifier = Modifier.height(Dimensions.Spacing.medium))
-            Text(
-                text = NO_SESSIONS_DEFAULT_TEXT,
-                style = MaterialTheme.typography.bodyLarge,
-                fontSize = Dimensions.TextSize.title,
-                color = MessagingColors.secondaryText)
-        }
-    }
+              Icon(
+                  imageVector = Icons.AutoMirrored.Filled.Article,
+                  contentDescription = null,
+                  modifier = Modifier.size(Dimensions.IconSize.giant),
+                  tint = MessagingColors.secondaryText)
+              Spacer(modifier = Modifier.height(Dimensions.Spacing.medium))
+              Text(
+                  text = NO_SESSIONS_DEFAULT_TEXT,
+                  style = MaterialTheme.typography.bodyLarge,
+                  fontSize = Dimensions.TextSize.title,
+                  color = MessagingColors.secondaryText)
+            }
+      }
 }
 
 /**
@@ -238,30 +232,30 @@ public fun SessionOverCard(
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(Dimensions.Spacing.small)) {
-                    Icon(imageVector = Icons.Default.Place, contentDescription = null)
-                    Text(
-                        text = session.location.name,
-                        style = MaterialTheme.typography.bodySmall,
-                        fontSize = Dimensions.TextSize.small,
-                        color = AppColors.textIconsFade,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.weight(1f, fill = false))
-                    Text(
-                        text = "•",
-                        fontSize = Dimensions.TextSize.small,
-                        color = AppColors.textIconsFade)
-                    Text(
-                        text = date,
-                        style = MaterialTheme.typography.bodySmall,
-                        fontSize = Dimensions.TextSize.small,
-                        color = AppColors.textIconsFade)
-                }
-            }
+                      Icon(imageVector = Icons.Default.Place, contentDescription = null)
+                      Text(
+                          text = session.location.name,
+                          style = MaterialTheme.typography.bodySmall,
+                          fontSize = Dimensions.TextSize.small,
+                          color = AppColors.textIconsFade,
+                          maxLines = 1,
+                          overflow = TextOverflow.Ellipsis,
+                          modifier = Modifier.weight(1f, fill = false))
+                      Text(
+                          text = "•",
+                          fontSize = Dimensions.TextSize.small,
+                          color = AppColors.textIconsFade)
+                      Text(
+                          text = date,
+                          style = MaterialTheme.typography.bodySmall,
+                          fontSize = Dimensions.TextSize.small,
+                          color = AppColors.textIconsFade)
+                    }
+              }
         }
 
-        HorizontalDivider(color = AppColors.divider, thickness = Dimensions.DividerThickness.standard)
-    }
+    HorizontalDivider(color = AppColors.divider, thickness = Dimensions.DividerThickness.standard)
+  }
 }
 
 @Composable
@@ -339,105 +333,119 @@ public fun SessionCard(
  */
 @Composable
 private fun SessionToggle(onNext: () -> Unit, onHistory: () -> Unit, showHistory: Boolean) {
-    Row(modifier = Modifier
-        .fillMaxWidth()
-        .height(Dimensions.Spacing.xxxLarge)) {
-        /* ----  LEFT HALF – Next Sessions  ---- */
-        Box(
-            modifier =
-                Modifier
-                    .weight(1f)
-                    .fillMaxHeight()
-                    .background(if (!showHistory) AppColors.primary else AppColors.divider)
-                    .clickable { onNext() },
-            contentAlignment = Alignment.Center) {
-            Text(
-                text = "Next sessions",
-                style = MaterialTheme.typography.bodyMedium,
-                fontWeight = FontWeight.Normal,
-                color = if (!showHistory) AppColors.textIcons else AppColors.textIconsFade)
+  Row(modifier = Modifier.fillMaxWidth().height(Dimensions.Spacing.xxxLarge)) {
+    /* ----  LEFT HALF – Next Sessions  ---- */
+    Box(
+        modifier =
+            Modifier.weight(1f)
+                .fillMaxHeight()
+                .background(if (!showHistory) AppColors.primary else AppColors.divider)
+                .clickable { onNext() },
+        contentAlignment = Alignment.Center) {
+          Text(
+              text = "Next sessions",
+              style = MaterialTheme.typography.bodyMedium,
+              fontWeight = FontWeight.Normal,
+              color = if (!showHistory) AppColors.textIcons else AppColors.textIconsFade)
         }
 
-        /* ----  RIGHT HALF – History  ---- */
-        Box(
-            modifier =
-                Modifier
-                    .weight(1f)
-                    .fillMaxHeight()
-                    .background(if (showHistory) AppColors.primary else AppColors.divider)
-                    .clickable { onHistory() },
-            contentAlignment = Alignment.Center) {
-            Text(
-                text = "History",
-                style = MaterialTheme.typography.bodyMedium,
-                fontWeight = FontWeight.Normal,
-                color = if (showHistory) AppColors.textIcons else AppColors.textIconsFade)
+    /* ----  RIGHT HALF – History  ---- */
+    Box(
+        modifier =
+            Modifier.weight(1f)
+                .fillMaxHeight()
+                .background(if (showHistory) AppColors.primary else AppColors.divider)
+                .clickable { onHistory() },
+        contentAlignment = Alignment.Center) {
+          Text(
+              text = "History",
+              style = MaterialTheme.typography.bodyMedium,
+              fontWeight = FontWeight.Normal,
+              color = if (showHistory) AppColors.textIcons else AppColors.textIconsFade)
         }
-    }
-    HorizontalDivider(color = AppColors.divider, thickness = Dimensions.DividerThickness.standard)
+  }
+  HorizontalDivider(color = AppColors.divider, thickness = Dimensions.DividerThickness.standard)
 }
 
+/**
+ * Displays a scrollable grid of past game sessions, formatted as a gallery.
+ *
+ * The grid arranges the provided [sessions] into rows where each row contains exactly
+ * [AMOUNT_OF_PICTURES_PER_ROW] cards. If the last row has fewer sessions, empty spacers are added
+ * to preserve alignment.
+ *
+ * Each session is rendered using [HistoryCard], and the whole layout is wrapped inside a vertically
+ * scrollable [LazyColumn]. Horizontal spacing and padding are applied to maintain consistent visual
+ * structure.
+ *
+ * @param sessions The list of past sessions to be displayed in the history gallery.
+ */
 @Composable
 private fun HistoryGrid(sessions: List<Session>) {
-    LazyColumn(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(Dimensions.Spacing.medium)
-    ) {
-        items(sessions.chunked(AMOUNT_OF_PICTURES_PER_ROW)) { row ->
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(Dimensions.Spacing.medium)
-            ) {
-                row.forEach { session ->
-                    HistoryCard(
-                        session = session,
-                        modifier = Modifier.weight(Dimensions.Weight.full)
-                    )
-                }
-
-                repeat(AMOUNT_OF_PICTURES_PER_ROW - row.size) {
-                    Spacer(modifier = Modifier.weight(Dimensions.Weight.full))
-                }
+  LazyColumn(modifier = Modifier.fillMaxSize().padding(Dimensions.Spacing.medium)) {
+    items(sessions.chunked(AMOUNT_OF_PICTURES_PER_ROW)) { row ->
+      Row(
+          modifier = Modifier.fillMaxWidth(),
+          horizontalArrangement = Arrangement.spacedBy(Dimensions.Spacing.medium)) {
+            row.forEach { session ->
+              HistoryCard(session = session, modifier = Modifier.weight(Dimensions.Weight.full))
             }
 
-            Spacer(modifier = Modifier.height(Dimensions.Spacing.medium))
-        }
+            repeat(AMOUNT_OF_PICTURES_PER_ROW - row.size) {
+              Spacer(modifier = Modifier.weight(Dimensions.Weight.full))
+            }
+          }
+
+      Spacer(modifier = Modifier.height(Dimensions.Spacing.medium))
     }
+  }
 }
 
+/**
+ * Renders an individual history entry showing a session preview image and its title beneath it.
+ *
+ * The card includes:
+ * - A subtle border around the entire component.
+ * - A selfie-style portrait image using an aspect ratio defined by
+ *   [Dimensions.Fractions.topBarDivider].
+ * - Rounded corners and a unified background.
+ * - Centered text for the session title, truncated when necessary.
+ *
+ * This card is intended to be used inside a grid layout such as [HistoryGrid].
+ *
+ * @param session The session data used to render the card's image and title.
+ * @param modifier Optional [Modifier] to adjust layout behavior when placed in a grid.
+ */
 @Composable
 private fun HistoryCard(session: Session, modifier: Modifier = Modifier) {
-    val url = getSessionPicture(session)
+  val url = getSessionPicture(session)
 
-    Column(
-        modifier = modifier
-            .border(
-                width = Dimensions.DividerThickness.standard,
-                color = AppColors.divider,
-                shape = MaterialTheme.shapes.medium
-            )
-            .clip(MaterialTheme.shapes.medium)
-            .background(AppColors.secondary)
-            .padding(Dimensions.Spacing.small),
-        horizontalAlignment = Alignment.CenterHorizontally   // CENTER TEXT
-    ) {
+  Column(
+      modifier =
+          modifier
+              .border(
+                  width = Dimensions.DividerThickness.standard,
+                  color = AppColors.divider,
+                  shape = MaterialTheme.shapes.medium)
+              .clip(MaterialTheme.shapes.medium)
+              .background(AppColors.secondary)
+              .padding(Dimensions.Spacing.small),
+      horizontalAlignment = Alignment.CenterHorizontally // CENTER TEXT
+      ) {
         // Selfie-style portrait ratio
         val selfieRatio = Dimensions.Fractions.topBarDivider
 
         Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .aspectRatio(selfieRatio)
-                .clip(MaterialTheme.shapes.medium)
-        ) {
-            Image(
-                painter = rememberAsyncImagePainter(url),
-                contentDescription = session.name,
-                modifier = Modifier.fillMaxSize(),
-                contentScale = ContentScale.Crop
-            )
-        }
+            modifier =
+                Modifier.fillMaxWidth()
+                    .aspectRatio(selfieRatio)
+                    .clip(MaterialTheme.shapes.medium)) {
+              Image(
+                  painter = rememberAsyncImagePainter(url),
+                  contentDescription = session.name,
+                  modifier = Modifier.fillMaxSize(),
+                  contentScale = ContentScale.Crop)
+            }
 
         Spacer(modifier = Modifier.height(Dimensions.Spacing.small))
 
@@ -447,11 +455,21 @@ private fun HistoryCard(session: Session, modifier: Modifier = Modifier) {
             color = AppColors.textIcons,
             maxLines = TITLE_MAX_LINES,
             overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.align(Alignment.CenterHorizontally)   // ENSURE CENTERING
-        )
-    }
+            modifier = Modifier.align(Alignment.CenterHorizontally) // ENSURE CENTERING
+            )
+      }
 }
+
+/**
+ * Returns the URL of the image representing the given [session].
+ *
+ * This function acts as a placeholder until the real session or game image retrieval logic is
+ * implemented. All history cards currently use this placeholder image.
+ *
+ * @param session The session for which an image should be resolved.
+ * @return A placeholder URL pointing to a temporary session image.
+ */
 private fun getSessionPicture(session: Session): String {
-    // TODO: Replace with real game/session image
-    return "https://npr.brightspotcdn.com/dims4/default/389845d/2147483647/strip/true/crop/4373x3279+0+0/resize/880x660!/quality/90/?url=http%3A%2F%2Fnpr-brightspot.s3.amazonaws.com%2Flegacy%2Fimages%2Fnews%2Fnpr%2F2020%2F07%2F887305543_2064699070.jpg"
+  // TODO: Replace with real game/session image
+  return "https://npr.brightspotcdn.com/dims4/default/389845d/2147483647/strip/true/crop/4373x3279+0+0/resize/880x660!/quality/90/?url=http%3A%2F%2Fnpr-brightspot.s3.amazonaws.com%2Flegacy%2Fimages%2Fnews%2Fnpr%2F2020%2F07%2F887305543_2064699070.jpg"
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionsOverviewScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionsOverviewScreen.kt
@@ -93,103 +93,102 @@ fun SessionsOverviewScreen(
 
   Box(modifier = Modifier.fillMaxSize()) {
     Scaffold(
-      topBar = {
-        Column(Modifier.fillMaxWidth()) {
-          /* 1. original top-bar (kept) */
-          CenterAlignedTopAppBar(
-              title = {
-                Text(
-                    text = MeepleMeetScreen.SessionsOverview.title,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onPrimary,
-                    modifier = Modifier.testTag(NavigationTestTags.SCREEN_TITLE))
-              })
+        topBar = {
+          Column(Modifier.fillMaxWidth()) {
+            /* 1. original top-bar (kept) */
+            CenterAlignedTopAppBar(
+                title = {
+                  Text(
+                      text = MeepleMeetScreen.SessionsOverview.title,
+                      style = MaterialTheme.typography.bodyMedium,
+                      color = MaterialTheme.colorScheme.onPrimary,
+                      modifier = Modifier.testTag(NavigationTestTags.SCREEN_TITLE))
+                })
 
-          SessionToggle(
-              showHistory = showHistory,
-              onNext = { showHistory = false },
-              onHistory = { showHistory = true })
-        }
-      },
-      bottomBar = {
-        BottomNavigationMenu(
-            currentScreen = MeepleMeetScreen.SessionsOverview,
-            onTabSelected = { navigation.navigateTo(it) })
-      }) { innerPadding ->
-        Box(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
-          when {
-            showHistory -> {
-              val now = System.currentTimeMillis()
+            SessionToggle(
+                showHistory = showHistory,
+                onNext = { showHistory = false },
+                onHistory = { showHistory = true })
+          }
+        },
+        bottomBar = {
+          BottomNavigationMenu(
+              currentScreen = MeepleMeetScreen.SessionsOverview,
+              onTabSelected = { navigation.navigateTo(it) })
+        }) { innerPadding ->
+          Box(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
+            when {
+              showHistory -> {
+                val now = System.currentTimeMillis()
 
-              val pastSessions =
-                  sessionMap
-                      .filter { (_, session) -> session.date.toDate().time < now }
-                      .values
-                      .sortedByDescending { it.date.toDate().time }
+                val pastSessions =
+                    sessionMap
+                        .filter { (_, session) -> session.date.toDate().time < now }
+                        .values
+                        .sortedByDescending { it.date.toDate().time }
 
-              if (pastSessions.isEmpty()) {
-                EmptySessionsListText(isHistory = true)
-              } else {
-                HistoryGrid(sessions = pastSessions, onSessionClick = { popupSession = it })
+                if (pastSessions.isEmpty()) {
+                  EmptySessionsListText(isHistory = true)
+                } else {
+                  HistoryGrid(sessions = pastSessions, onSessionClick = { popupSession = it })
+                }
               }
-            }
-            sessionMap.isEmpty() -> EmptySessionsListText(isHistory = false)
-            else -> {
-              val now = System.currentTimeMillis()
-              val futureSessions =
-                  sessionMap
-                      .filter { (_, session) -> session.date.toDate().time >= now }
-                      .toList()
-                      .sortedBy { (_, session) -> session.date.toDate().time }
+              sessionMap.isEmpty() -> EmptySessionsListText(isHistory = false)
+              else -> {
+                val now = System.currentTimeMillis()
+                val futureSessions =
+                    sessionMap
+                        .filter { (_, session) -> session.date.toDate().time >= now }
+                        .toList()
+                        .sortedBy { (_, session) -> session.date.toDate().time }
 
-              if (futureSessions.isEmpty()) {
-                EmptySessionsListText(isHistory = false)
-              } else {
-                /* ----------------  NEXT SESSIONS (existing list)  ---------------- */
-                LazyColumn(
-                    modifier = Modifier.fillMaxSize(),
-                    verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.none)) {
-                      items(futureSessions, key = { it.first }) { (id, session) ->
-                        SessionCard(
-                            session = session,
-                            viewModel = viewModel,
-                            modifier = Modifier.fillMaxWidth().testTag("sessionCard_$id"),
-                            onClick = { onSelectSession(id) })
+                if (futureSessions.isEmpty()) {
+                  EmptySessionsListText(isHistory = false)
+                } else {
+                  /* ----------------  NEXT SESSIONS (existing list)  ---------------- */
+                  LazyColumn(
+                      modifier = Modifier.fillMaxSize(),
+                      verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.none)) {
+                        items(futureSessions, key = { it.first }) { (id, session) ->
+                          SessionCard(
+                              session = session,
+                              viewModel = viewModel,
+                              modifier = Modifier.fillMaxWidth().testTag("sessionCard_$id"),
+                              onClick = { onSelectSession(id) })
+                        }
                       }
-                    }
+                }
               }
             }
           }
         }
-      }
-}
-    if (popupSession != null) {
-      Box(
-          modifier =
-              Modifier.fillMaxSize()
-                  .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.65f))
-                  .clickable(
-                      enabled = true,
-                      indication = null,
-                      interactionSource =
-                          remember {
-                            androidx.compose.foundation.interaction.MutableInteractionSource()
-                          }) {
-                        popupSession = null
-                      }
-          )
-    }
+  }
+  if (popupSession != null) {
+    Box(
+        modifier =
+            Modifier.fillMaxSize()
+                .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.65f))
+                .clickable(
+                    enabled = true,
+                    indication = null,
+                    interactionSource =
+                        remember {
+                          androidx.compose.foundation.interaction.MutableInteractionSource()
+                        }) {
+                      popupSession = null
+                    })
+  }
 
-    popupSession?.let { session ->
-      Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        com.github.meeplemeet.ui.components.SessionDetailsCard(
-            session = session,
-            viewModel = viewModel,
-            onClose = { popupSession = null },
-            modifier = Modifier.wrapContentSize().padding(Dimensions.Padding.extraLarge))
-      }
+  popupSession?.let { session ->
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+      com.github.meeplemeet.ui.components.SessionDetailsCard(
+          session = session,
+          viewModel = viewModel,
+          onClose = { popupSession = null },
+          modifier = Modifier.wrapContentSize().padding(Dimensions.Padding.extraLarge))
     }
   }
+}
 
 /** Displays a centred label when the user has no upcoming sessions. */
 @Composable

--- a/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionsOverviewScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionsOverviewScreen.kt
@@ -61,6 +61,7 @@ import java.text.SimpleDateFormat
 import java.util.Locale
 
 const val NO_SESSIONS_DEFAULT_TEXT = "No sessions yet"
+const val NO_SESSIONS_HISTORY_TEXT = "No past sessions yet"
 const val AMOUNT_OF_PICTURES_PER_ROW = 3
 const val TITLE_MAX_LINES = 1
 /**
@@ -124,9 +125,13 @@ fun SessionsOverviewScreen(
                       .values
                       .sortedByDescending { it.date.toDate().time }
 
-              HistoryGrid(sessions = pastSessions)
+              if (pastSessions.isEmpty()) {
+                EmptySessionsListText(isHistory = true)
+              } else {
+                HistoryGrid(sessions = pastSessions)
+              }
             }
-            sessionMap.isEmpty() -> EmptySessionsListText()
+            sessionMap.isEmpty() -> EmptySessionsListText(isHistory = false)
             else -> {
               /* ----------------  NEXT SESSIONS (existing list)  ---------------- */
               LazyColumn(
@@ -148,7 +153,7 @@ fun SessionsOverviewScreen(
 
 /** Displays a centred label when the user has no upcoming sessions. */
 @Composable
-private fun EmptySessionsListText() {
+private fun EmptySessionsListText(isHistory: Boolean = true) {
   Box(
       modifier = Modifier.fillMaxSize().padding(Dimensions.Spacing.xxxLarge),
       contentAlignment = Alignment.Center) {
@@ -162,7 +167,7 @@ private fun EmptySessionsListText() {
                   tint = MessagingColors.secondaryText)
               Spacer(modifier = Modifier.height(Dimensions.Spacing.medium))
               Text(
-                  text = NO_SESSIONS_DEFAULT_TEXT,
+                  text = if (isHistory) NO_SESSIONS_HISTORY_TEXT else NO_SESSIONS_DEFAULT_TEXT,
                   style = MaterialTheme.typography.bodyLarge,
                   fontSize = Dimensions.TextSize.title,
                   color = MessagingColors.secondaryText)

--- a/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionsOverviewScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionsOverviewScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -88,8 +89,10 @@ fun SessionsOverviewScreen(
 
   /* --------------  NEW: toggle state  -------------- */
   var showHistory by remember { mutableStateOf(false) }
+  var popupSession by remember { mutableStateOf<Session?>(null) }
 
-  Scaffold(
+  Box(modifier = Modifier.fillMaxSize()) {
+    Scaffold(
       topBar = {
         Column(Modifier.fillMaxWidth()) {
           /* 1. original top-bar (kept) */
@@ -127,28 +130,66 @@ fun SessionsOverviewScreen(
               if (pastSessions.isEmpty()) {
                 EmptySessionsListText(isHistory = true)
               } else {
-                HistoryGrid(sessions = pastSessions)
+                HistoryGrid(sessions = pastSessions, onSessionClick = { popupSession = it })
               }
             }
             sessionMap.isEmpty() -> EmptySessionsListText(isHistory = false)
             else -> {
-              /* ----------------  NEXT SESSIONS (existing list)  ---------------- */
-              LazyColumn(
-                  modifier = Modifier.fillMaxSize(),
-                  verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.none)) {
-                    items(sessionMap.entries.toList(), key = { it.key }) { (id, session) ->
-                      SessionCard(
-                          session = session,
-                          viewModel = viewModel,
-                          modifier = Modifier.fillMaxWidth().testTag("sessionCard_$id"),
-                          onClick = { onSelectSession(id) })
+              val now = System.currentTimeMillis()
+              val futureSessions =
+                  sessionMap
+                      .filter { (_, session) -> session.date.toDate().time >= now }
+                      .toList()
+                      .sortedBy { (_, session) -> session.date.toDate().time }
+
+              if (futureSessions.isEmpty()) {
+                EmptySessionsListText(isHistory = false)
+              } else {
+                /* ----------------  NEXT SESSIONS (existing list)  ---------------- */
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.none)) {
+                      items(futureSessions, key = { it.first }) { (id, session) ->
+                        SessionCard(
+                            session = session,
+                            viewModel = viewModel,
+                            modifier = Modifier.fillMaxWidth().testTag("sessionCard_$id"),
+                            onClick = { onSelectSession(id) })
+                      }
                     }
-                  }
+              }
             }
           }
         }
       }
 }
+    if (popupSession != null) {
+      Box(
+          modifier =
+              Modifier.fillMaxSize()
+                  .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.65f))
+                  .clickable(
+                      enabled = true,
+                      indication = null,
+                      interactionSource =
+                          remember {
+                            androidx.compose.foundation.interaction.MutableInteractionSource()
+                          }) {
+                        popupSession = null
+                      }
+          )
+    }
+
+    popupSession?.let { session ->
+      Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        com.github.meeplemeet.ui.components.SessionDetailsCard(
+            session = session,
+            viewModel = viewModel,
+            onClose = { popupSession = null },
+            modifier = Modifier.wrapContentSize().padding(Dimensions.Padding.extraLarge))
+      }
+    }
+  }
 
 /** Displays a centred label when the user has no upcoming sessions. */
 @Composable
@@ -385,14 +426,17 @@ private fun SessionToggle(onNext: () -> Unit, onHistory: () -> Unit, showHistory
  * @param sessions The list of past sessions to be displayed in the history gallery.
  */
 @Composable
-private fun HistoryGrid(sessions: List<Session>) {
+private fun HistoryGrid(sessions: List<Session>, onSessionClick: (Session) -> Unit) {
   LazyColumn(modifier = Modifier.fillMaxSize().padding(Dimensions.Spacing.medium)) {
     items(sessions.chunked(AMOUNT_OF_PICTURES_PER_ROW)) { row ->
       Row(
           modifier = Modifier.fillMaxWidth(),
           horizontalArrangement = Arrangement.spacedBy(Dimensions.Spacing.medium)) {
             row.forEach { session ->
-              HistoryCard(session = session, modifier = Modifier.weight(Dimensions.Weight.full))
+              HistoryCard(
+                  session = session,
+                  modifier =
+                      Modifier.weight(Dimensions.Weight.full).clickable { onSessionClick(session) })
             }
 
             repeat(AMOUNT_OF_PICTURES_PER_ROW - row.size) {
@@ -462,7 +506,7 @@ private fun HistoryCard(session: Session, modifier: Modifier = Modifier) {
 }
 
 /**
- * Returns the URL of the image representing the given [session].
+ * Returns the URL of the image representing the given session.
  *
  * This function acts as a placeholder until the real session or game image retrieval logic is
  * implemented. All history cards currently use this placeholder image.

--- a/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionsOverviewScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionsOverviewScreen.kt
@@ -102,7 +102,7 @@ fun SessionsOverviewScreen(
                     modifier = Modifier.testTag(NavigationTestTags.SCREEN_TITLE))
               })
 
-          SessionToggle( // <-- use the same variable
+          SessionToggle(
               showHistory = showHistory,
               onNext = { showHistory = false },
               onHistory = { showHistory = true })
@@ -118,7 +118,6 @@ fun SessionsOverviewScreen(
             showHistory -> {
               val now = System.currentTimeMillis()
 
-              // Separate past sessions
               val pastSessions =
                   sessionMap
                       .filter { (_, session) -> session.date.toDate().time < now }
@@ -423,7 +422,7 @@ private fun HistoryGrid(sessions: List<Session>) {
  */
 @Composable
 private fun HistoryCard(session: Session, modifier: Modifier = Modifier) {
-  val url = getSessionPicture(session)
+  val url = getSessionPicture()
 
   Column(
       modifier =
@@ -435,9 +434,7 @@ private fun HistoryCard(session: Session, modifier: Modifier = Modifier) {
               .clip(MaterialTheme.shapes.medium)
               .background(AppColors.secondary)
               .padding(Dimensions.Spacing.small),
-      horizontalAlignment = Alignment.CenterHorizontally // CENTER TEXT
-      ) {
-        // Selfie-style portrait ratio
+      horizontalAlignment = Alignment.CenterHorizontally) {
         val selfieRatio = Dimensions.Fractions.topBarDivider
 
         Box(
@@ -460,8 +457,7 @@ private fun HistoryCard(session: Session, modifier: Modifier = Modifier) {
             color = AppColors.textIcons,
             maxLines = TITLE_MAX_LINES,
             overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.align(Alignment.CenterHorizontally) // ENSURE CENTERING
-            )
+            modifier = Modifier.align(Alignment.CenterHorizontally))
       }
 }
 
@@ -471,10 +467,8 @@ private fun HistoryCard(session: Session, modifier: Modifier = Modifier) {
  * This function acts as a placeholder until the real session or game image retrieval logic is
  * implemented. All history cards currently use this placeholder image.
  *
- * @param session The session for which an image should be resolved.
  * @return A placeholder URL pointing to a temporary session image.
  */
-private fun getSessionPicture(session: Session): String {
-  // TODO: Replace with real game/session image
+private fun getSessionPicture(): String {
   return "https://npr.brightspotcdn.com/dims4/default/389845d/2147483647/strip/true/crop/4373x3279+0+0/resize/880x660!/quality/90/?url=http%3A%2F%2Fnpr-brightspot.s3.amazonaws.com%2Flegacy%2Fimages%2Fnews%2Fnpr%2F2020%2F07%2F887305543_2064699070.jpg"
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionsOverviewScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionsOverviewScreen.kt
@@ -230,7 +230,7 @@ private fun EmptySessionsListText(isHistory: Boolean = true) {
  * @param onClick Invoked when the card is tapped.
  */
 @Composable
-public fun SessionOverCard(
+fun SessionOverCard(
     session: Session,
     gameName: String,
     participantText: String,
@@ -304,7 +304,7 @@ public fun SessionOverCard(
 }
 
 @Composable
-public fun SessionCard(
+fun SessionCard(
     session: Session,
     viewModel: SessionOverviewViewModel,
     modifier: Modifier = Modifier,

--- a/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionsOverviewScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionsOverviewScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Article
 import androidx.compose.material.icons.filled.Place
+import androidx.compose.material.icons.filled.SentimentDissatisfied
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -465,7 +466,7 @@ private fun HistoryGrid(sessions: List<Session>, onSessionClick: (Session) -> Un
  */
 @Composable
 private fun HistoryCard(session: Session, modifier: Modifier = Modifier) {
-  val url = getSessionPicture()
+  val url = getSessionPicture(session)
 
   Column(
       modifier =
@@ -485,11 +486,24 @@ private fun HistoryCard(session: Session, modifier: Modifier = Modifier) {
                 Modifier.fillMaxWidth()
                     .aspectRatio(selfieRatio)
                     .clip(MaterialTheme.shapes.medium)) {
-              Image(
-                  painter = rememberAsyncImagePainter(url),
-                  contentDescription = session.name,
-                  modifier = Modifier.fillMaxSize(),
-                  contentScale = ContentScale.Crop)
+              if (url != null) {
+                Image(
+                    painter = rememberAsyncImagePainter(url),
+                    contentDescription = session.name,
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop)
+              } else {
+                Box(
+                    modifier =
+                        Modifier.fillMaxSize().background(androidx.compose.ui.graphics.Color.Black),
+                    contentAlignment = Alignment.Center) {
+                      Icon(
+                          imageVector = Icons.Default.SentimentDissatisfied,
+                          contentDescription = null,
+                          tint = androidx.compose.ui.graphics.Color.Gray,
+                          modifier = Modifier.size(Dimensions.IconSize.large))
+                    }
+              }
             }
 
         Spacer(modifier = Modifier.height(Dimensions.Spacing.small))
@@ -507,11 +521,11 @@ private fun HistoryCard(session: Session, modifier: Modifier = Modifier) {
 /**
  * Returns the URL of the image representing the given session.
  *
- * This function acts as a placeholder until the real session or game image retrieval logic is
- * implemented. All history cards currently use this placeholder image.
+ * If the session has a photoUrl, it is returned. Otherwise, null is returned.
  *
- * @return A placeholder URL pointing to a temporary session image.
+ * @param session The session to get the picture for.
+ * @return The URL of the session image or null.
  */
-private fun getSessionPicture(): String {
-  return "https://npr.brightspotcdn.com/dims4/default/389845d/2147483647/strip/true/crop/4373x3279+0+0/resize/880x660!/quality/90/?url=http%3A%2F%2Fnpr-brightspot.s3.amazonaws.com%2Flegacy%2Fimages%2Fnews%2Fnpr%2F2020%2F07%2F887305543_2064699070.jpg"
+private fun getSessionPicture(session: Session): String? {
+  return session.photoUrl?.takeIf { it.isNotBlank() }
 }


### PR DESCRIPTION
### PR Description

This PR adds the **History** tab to the `SessionsOverviewScreen`, enabling users to browse past sessions alongside their upcoming ones.

#### Key Additions
 **History**
- Added `HistoryGrid`, a scrollable gallery-style grid that arranges past sessions into evenly sized rows.
- Added `HistoryCard`, a compact card showing a preview image and the session title.
- Implemented filtering of sessions into upcoming vs. past using the current timestamp.
- Updated the main screen logic to display the appropriate view based on the active tab.

#### UI Behavior
- Past sessions are sorted newest-first in the history grid.
- Grid rows keep alignment consistent with spacers when not fully populated.
- Placeholder images are used until real session/game images become available.


https://github.com/user-attachments/assets/ec6ab19b-a766-4742-84d3-0ec6e5e979e8