### PR TITLE
Feat/profile screen notifications tab

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/end2end/E2E_M1.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/end2end/E2E_M1.kt
@@ -60,6 +60,7 @@ class E2E_M1 : FirestoreTests() {
     val initialMessageFromAlice = "Hi Bob, welcome to our discussion!"
 
     // ===== PART 1: Create first account (Alice) =====
+    composeTestRule.waitForIdle()
     composeTestRule.signUpUser(user1Email, password, user1Handle, user1Name)
     composeTestRule.signOutWithBottomBar()
 

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/NotificationsTabTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/NotificationsTabTest.kt
@@ -337,7 +337,6 @@ class NotificationsTabTest : FirestoreTests() {
         }
       }
 
-      Thread.sleep(5000)
       sheetTitle().assertTextContains(discussion.name)
       sheetDescription().assertTextContains(discussion.description)
       sheetAcceptButton().assertIsDisplayed()
@@ -362,7 +361,6 @@ class NotificationsTabTest : FirestoreTests() {
       }
 
       sheetTitle().assertTextContains(session.name)
-      Thread.sleep(5000)
       sheetAcceptButton().assertIsDisplayed()
       sheetDeclineButton().assertIsDisplayed()
 

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/NotificationsTabTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/NotificationsTabTest.kt
@@ -1,0 +1,338 @@
+package com.github.meeplemeet.ui
+
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeLeft
+import androidx.compose.ui.test.swipeRight
+import androidx.compose.ui.test.printToLog
+import com.github.meeplemeet.model.account.Account
+import com.github.meeplemeet.model.account.Notification
+import com.github.meeplemeet.model.account.NotificationType
+import com.github.meeplemeet.model.account.NotificationsViewModel
+import com.github.meeplemeet.ui.account.NotificationsTab
+import com.github.meeplemeet.ui.account.NotificationsTabTestTags
+import com.github.meeplemeet.ui.theme.AppTheme
+import com.github.meeplemeet.utils.Checkpoint
+import com.github.meeplemeet.utils.FirestoreTests
+import com.google.firebase.Timestamp
+import java.util.Date
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.tasks.await
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class NotificationsTabTest : FirestoreTests() {
+
+  @get:Rule val compose = createComposeRule()
+  @get:Rule val ck = Checkpoint.Rule()
+
+  private fun checkpoint(name: String, block: () -> Unit) = ck.ck(name, block)
+
+  private lateinit var viewModel: NotificationsViewModel
+  private lateinit var currentUser: Account
+  private lateinit var otherUser: Account
+  private lateinit var friendRequestNotification: Notification
+  private lateinit var discussionNotification: Notification
+  private lateinit var sessionNotification: Notification
+
+  // --- Helpers ---
+  private fun headerTitle() = compose.onNodeWithTag(NotificationsTabTestTags.HEADER_TITLE)
+  private fun notificationList() = compose.onNodeWithTag(NotificationsTabTestTags.NOTIFICATION_LIST)
+  private fun filterChip(filter: String) = compose.onNodeWithTag(NotificationsTabTestTags.FILTER_CHIP_PREFIX + filter)
+  private fun notificationItem(uid: String) = compose.onNodeWithTag(NotificationsTabTestTags.NOTIFICATION_ITEM_PREFIX + uid)
+  private fun unreadDot(uid: String) = compose.onNodeWithTag(NotificationsTabTestTags.UNREAD_DOT_PREFIX + uid)
+  private fun emptyStateText() = compose.onNodeWithTag(NotificationsTabTestTags.EMPTY_STATE_TEXT)
+  private fun sheetTitle() = compose.onNodeWithTag(NotificationsTabTestTags.SHEET_TITLE)
+  private fun sheetAcceptButton() = compose.onNodeWithTag(NotificationsTabTestTags.SHEET_ACCEPT_BUTTON)
+  private fun sheetDeclineButton() = compose.onNodeWithTag(NotificationsTabTestTags.SHEET_DECLINE_BUTTON)
+
+  @Before
+  fun setup() {
+    viewModel = NotificationsViewModel(
+        accountRepository = accountRepository,
+        handlesRepository = handlesRepository,
+        imageRepository = imageRepository,
+        discussionRepository = discussionRepository,
+        gameRepository = gameRepository
+    )
+
+    runBlocking {
+      // Create current user
+      currentUser =
+          accountRepository.createAccount(
+              userHandle = "currentUser",
+              name = "Current User",
+              email = "current@test.com",
+              photoUrl = null)
+
+      // Create other user for friend request
+      otherUser =
+          accountRepository.createAccount(
+              userHandle = "otherUser",
+              name = "Other User",
+              email = "other@test.com",
+              photoUrl = null)
+
+      // Create a real discussion for the notification
+      val discussion = discussionRepository.createDiscussion(
+          creatorId = otherUser.uid,
+          name = "Board Game Night",
+          description = "Let's play some games!"
+      )
+
+      // Create a Game for the session
+      val gameId = "game_1"
+      val game = com.github.meeplemeet.model.shared.game.GameNoUid(
+          name = "Catan",
+          description = "Trade, build, settle",
+          minPlayers = 3,
+          maxPlayers = 4
+      )
+      db.collection("games").document(gameId).set(game).await()
+
+      // Create a Session and update the discussion
+      val session = com.github.meeplemeet.model.sessions.Session(
+          name = "Catan Session",
+          gameId = gameId,
+          date = Timestamp(Date(System.currentTimeMillis() + 86400000)), // Tomorrow
+          location = com.github.meeplemeet.model.shared.location.Location(0.0, 0.0, "Game Store"),
+          participants = listOf(otherUser.uid)
+      )
+      
+      // Create a discussion for the session
+      val sessionDiscussion = discussionRepository.createDiscussion(
+          creatorId = otherUser.uid,
+          name = "Catan Session Chat",
+          description = "Chat for Catan"
+      )
+      
+      // Update discussion with session
+      db.collection("discussions").document(sessionDiscussion.uid).update("session", session).await()
+
+      // Create notifications
+      val now = System.currentTimeMillis()
+      friendRequestNotification =
+          Notification(
+              uid = "n1",
+              senderOrDiscussionId = otherUser.uid,
+              receiverId = currentUser.uid,
+              read = false,
+              type = NotificationType.FRIEND_REQUEST,
+              sentAt = Timestamp(Date(now)))
+
+      discussionNotification =
+          Notification(
+              uid = "n2",
+              senderOrDiscussionId = discussion.uid,
+              receiverId = currentUser.uid,
+              read = true,
+              type = NotificationType.JOIN_DISCUSSION,
+              sentAt = Timestamp(Date(now - 3600000)) // 1 hour ago
+              )
+
+      sessionNotification =
+          Notification(
+              uid = "n3",
+              senderOrDiscussionId = sessionDiscussion.uid,
+              receiverId = currentUser.uid,
+              read = false,
+              type = NotificationType.JOIN_SESSION,
+              sentAt = Timestamp(Date(now - 7200000)) // 2 hours ago
+          )
+
+      // Seed notifications in Firestore
+      val notificationsRef = db.collection("accounts").document(currentUser.uid).collection("notifications")
+      
+      val notifications = listOf(friendRequestNotification, discussionNotification, sessionNotification)
+      
+      notifications.forEach { notif ->
+          notificationsRef.document(notif.uid).set(
+              com.github.meeplemeet.model.account.NotificationNoUid(
+                  senderOrDiscussionId = notif.senderOrDiscussionId,
+                  read = notif.read,
+                  type = notif.type,
+                  sentAt = notif.sentAt
+              )
+          ).await()
+      }
+
+      // Update current user with notifications
+      currentUser = currentUser.copy(notifications = notifications)
+    }
+  }
+
+  @Test
+  fun smoke_all_notifications_tests() {
+    compose.setContent {
+      AppTheme {
+        NotificationsTab(account = currentUser, viewModel = viewModel, onBack = {})
+      }
+    }
+
+    checkpoint("Initial State") {
+      headerTitle().assertIsDisplayed().assertTextContains("Notifications")
+      notificationList().assertIsDisplayed()
+    }
+
+    checkpoint("Notifications List Content") {
+      // Wait a bit for composition
+      compose.waitForIdle()
+      Thread.sleep(500)
+      
+      notificationItem(friendRequestNotification.uid).assertIsDisplayed()
+      notificationItem(discussionNotification.uid).assertIsDisplayed()
+      notificationItem(sessionNotification.uid).assertIsDisplayed()
+    }
+
+    checkpoint("Filter Chips Displayed") {
+      // Print all nodes to debug
+      compose.onRoot().printToLog("NOTIFICATION_SCREEN")
+      
+      // Filter chips might be in a scrollable view, use unmerged tree
+      filterChip("ALL").assertExists()
+      filterChip("UNREAD").assertExists()
+      filterChip("FRIEND_REQUESTS").assertExists()
+      filterChip("DISCUSSIONS").assertExists()
+      filterChip("SESSIONS").assertExists()
+    }
+
+    checkpoint("Filter - Unread") {
+      filterChip("UNREAD").performClick()
+      compose.waitForIdle()
+      Thread.sleep(200)
+
+      notificationItem(friendRequestNotification.uid).assertExists()
+      notificationItem(sessionNotification.uid).assertExists()
+      notificationItem(discussionNotification.uid).assertDoesNotExist()
+      
+      // Reset to ALL
+      filterChip("ALL").performClick()
+      compose.waitForIdle()
+    }
+
+    checkpoint("Filter - Friend Requests") {
+      filterChip("FRIEND_REQUESTS").performClick()
+      compose.waitForIdle()
+      Thread.sleep(200)
+
+      notificationItem(friendRequestNotification.uid).assertExists()
+      notificationItem(discussionNotification.uid).assertDoesNotExist()
+      notificationItem(sessionNotification.uid).assertDoesNotExist()
+      
+      // Reset to ALL
+      filterChip("ALL").performClick()
+      compose.waitForIdle()
+    }
+    
+    checkpoint("Filter - Discussions") {
+      // Scroll filter row to reveal DISCUSSIONS chip if needed
+      filterChip("ALL").performTouchInput { swipeLeft() }
+      compose.waitForIdle()
+      Thread.sleep(100)
+      
+      filterChip("DISCUSSIONS").performClick()
+      compose.waitForIdle()
+      Thread.sleep(200)
+
+      notificationItem(discussionNotification.uid).assertExists()
+      notificationItem(friendRequestNotification.uid).assertDoesNotExist()
+      notificationItem(sessionNotification.uid).assertDoesNotExist()
+      
+      // Reset to ALL
+      filterChip("ALL").performClick()
+      compose.waitForIdle()
+    }
+    
+    checkpoint("Filter - Sessions") {
+      // Scroll filter row multiple times to ensure SESSIONS chip is visible (it's at end of list)
+      filterChip("ALL").performTouchInput { swipeLeft() }
+      compose.waitForIdle()
+      Thread.sleep(100)
+      filterChip("UNREAD").performTouchInput { swipeLeft() }
+      compose.waitForIdle()
+      Thread.sleep(200)
+      
+      filterChip("SESSIONS").performClick()
+      compose.waitForIdle()
+      Thread.sleep(800)
+
+      notificationItem(sessionNotification.uid).assertExists()
+      notificationItem(friendRequestNotification.uid).assertDoesNotExist()
+      notificationItem(discussionNotification.uid).assertDoesNotExist()
+      
+      // Reset to ALL - scroll back first
+      filterChip("SESSIONS").performTouchInput { swipeRight() }
+      compose.waitForIdle()
+      Thread.sleep(100)
+      filterChip("DISCUSSIONS").performTouchInput { swipeRight() }
+      compose.waitForIdle()
+      filterChip("ALL").performClick()
+      compose.waitForIdle()
+      Thread.sleep(200)
+    }
+
+    checkpoint("Open Friend Request Notification Sheet") {
+      notificationItem(friendRequestNotification.uid).performClick()
+      compose.waitForIdle()
+
+      compose.waitUntil(5000) {
+          try {
+              sheetTitle().assertIsDisplayed()
+              true
+          } catch (e: AssertionError) {
+              false
+          }
+      }
+
+      sheetTitle().assertTextContains(otherUser.name)
+      sheetAcceptButton().assertIsDisplayed()
+      sheetDeclineButton().assertIsDisplayed()
+    }
+  }
+
+  @Test
+  fun smoke_empty_state() {
+    val emptyAccount = currentUser.copy(notifications = emptyList())
+
+    compose.setContent {
+      AppTheme {
+        NotificationsTab(account = emptyAccount, viewModel = viewModel, onBack = {})
+      }
+    }
+
+    checkpoint("Empty State Displayed") {
+      emptyStateText().assertIsDisplayed().assertTextContains("You have no notifications yet.")
+    }
+    
+    checkpoint("Empty State - Filter Unread") {
+        filterChip("UNREAD").performClick()
+        compose.waitForIdle()
+        Thread.sleep(200)
+        emptyStateText().assertIsDisplayed().assertTextContains("You're all caught up! No unread notifications.")
+    }
+    
+    checkpoint("Empty State - Filter Sessions") {
+        // Scroll filter row multiple times to reveal SESSIONS chip
+        filterChip("ALL").performTouchInput { swipeLeft() }
+        compose.waitForIdle()
+        Thread.sleep(100)
+        filterChip("UNREAD").performTouchInput { swipeLeft() }
+        compose.waitForIdle()
+        Thread.sleep(100)
+        
+        filterChip("SESSIONS").performClick()
+        compose.waitForIdle()
+        Thread.sleep(400)
+        emptyStateText().assertExists().assertTextContains("No session invitations.")
+    }
+  }
+}

--- a/app/src/main/java/com/github/meeplemeet/MainActivity.kt
+++ b/app/src/main/java/com/github/meeplemeet/MainActivity.kt
@@ -408,7 +408,6 @@ fun MeepleMeetApp(
             },
             onClickNotifications = {
               navigationActions.navigateTo(MeepleMeetScreen.NotificationsTab)
-            })
             },
             onDelete = {
               FirebaseProvider.auth.signOut()

--- a/app/src/main/java/com/github/meeplemeet/MainActivity.kt
+++ b/app/src/main/java/com/github/meeplemeet/MainActivity.kt
@@ -48,6 +48,7 @@ import com.github.meeplemeet.model.space_renter.SpaceRenterRepository
 import com.github.meeplemeet.ui.MapScreen
 import com.github.meeplemeet.ui.account.CreateAccountScreen
 import com.github.meeplemeet.ui.account.FriendsScreen
+import com.github.meeplemeet.ui.account.NotificationsTab
 import com.github.meeplemeet.ui.account.ProfileScreen
 import com.github.meeplemeet.ui.auth.SignInScreen
 import com.github.meeplemeet.ui.auth.SignUpScreen
@@ -405,10 +406,20 @@ fun MeepleMeetApp(
               navigationActions.navigateTo(MeepleMeetScreen.SignIn)
               signedOut = true
             },
+            onClickNotifications = {
+              navigationActions.navigateTo(MeepleMeetScreen.NotificationsTab)
+            })
+            },
             onDelete = {
               FirebaseProvider.auth.signOut()
             }) // Sign out the user before deleting his account, avoiding an infinite loading screen
       } ?: navigationActions.navigateTo(MeepleMeetScreen.SignIn)
+    }
+
+    composable(MeepleMeetScreen.NotificationsTab.name) {
+      account?.let {
+        NotificationsTab(account = account!!, onBack = { navigationActions.goBack() })
+      }
     }
 
     composable(MeepleMeetScreen.ShopDetails.name) {

--- a/app/src/main/java/com/github/meeplemeet/model/account/NotificationsViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/NotificationsViewModel.kt
@@ -1,0 +1,273 @@
+package com.github.meeplemeet.model.account
+
+// Claude Code generated the documentation
+
+import android.content.Context
+import androidx.lifecycle.viewModelScope
+import com.github.meeplemeet.RepositoryProvider
+import com.github.meeplemeet.model.discussions.Discussion
+import com.github.meeplemeet.model.discussions.DiscussionRepository
+import com.github.meeplemeet.model.images.ImageRepository
+import com.github.meeplemeet.model.shared.game.BggGameRepository
+import com.github.meeplemeet.model.shared.game.Game
+import com.github.meeplemeet.ui.account.NotificationPopupData
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+
+/**
+ * ViewModel for managing user profile interactions and friend system operations.
+ *
+ * This ViewModel provides methods for handling friend requests, accepting requests, blocking users,
+ * and resetting relationships. It includes validation logic to prevent invalid operations (e.g.,
+ * sending duplicate friend requests, accepting non-existent requests).
+ *
+ * @property accountRepository The AccountRepository used for data operations. Defaults to the
+ *   shared instance from RepositoryProvider.
+ */
+class NotificationsViewModel(
+    private val accountRepository: AccountRepository = RepositoryProvider.accounts,
+    handlesRepository: HandlesRepository = RepositoryProvider.handles,
+    private val imageRepository: ImageRepository = RepositoryProvider.images,
+    private val discussionRepository: DiscussionRepository = RepositoryProvider.discussions,
+    private val gameRepository: BggGameRepository = RepositoryProvider.gamesApi
+) : CreateAccountViewModel(handlesRepository) {
+
+  /**
+   * Used to fetch a discussion and a session for their data
+   *
+   * @param discussionId Discussion id to fetch data from
+   * @param onResult callback for access to the fetched Discussion
+   */
+  fun getDiscussion(discussionId: String, onResult: (Discussion) -> Unit) {
+    viewModelScope.launch {
+      val disc = discussionRepository.getDiscussion(discussionId)
+      onResult(disc)
+    }
+  }
+
+  /**
+   * Used to fetch a game for its data
+   *
+   * @param gameId Game id to fetch data from
+   * @param onResult callback for access to fetched game
+   */
+  fun getGame(gameId: String, onResult: (Game) -> Unit) {
+    viewModelScope.launch {
+      val game = gameRepository.getGameById(gameId)
+      onResult(game)
+    }
+  }
+
+  fun loadAccountImage(accountId: String, context: Context, onLoaded: (ByteArray?) -> Unit) {
+    viewModelScope.launch {
+      val bytes =
+          try {
+            imageRepository.loadAccountProfilePicture(accountId, context)
+          } catch (_: Exception) {
+            ByteArray(0)
+          }
+      onLoaded(bytes.takeIf { it.isNotEmpty() })
+    }
+  }
+
+  fun loadDiscussionImage(discussionId: String, context: Context, onLoaded: (ByteArray?) -> Unit) {
+    viewModelScope.launch {
+      val bytes =
+          try {
+            imageRepository.loadDiscussionProfilePicture(context, discussionId)
+          } catch (_: Exception) {
+            ByteArray(0)
+          }
+      onLoaded(bytes.takeIf { it.isNotEmpty() })
+    }
+  }
+
+  /**
+   * Checks if two accounts are the same user or if either has blocked the other.
+   *
+   * This helper method is used to prevent relationship operations between users who should not be
+   * able to interact (same user or blocked relationship).
+   *
+   * @param account The first account to check
+   * @param other The second account to check
+   * @return True if the accounts are the same user, or if either has blocked the other
+   */
+  private fun sameOrBlocked(account: Account, other: Account) =
+      account.uid == other.uid ||
+          account.relationships[other.uid] == RelationshipStatus.BLOCKED ||
+          other.relationships[account.uid] == RelationshipStatus.BLOCKED
+
+  /**
+   * Accepts a pending friend request, establishing a mutual friendship.
+   *
+   * This method validates that a friend request can be accepted before proceeding. It requires:
+   * - The current account has a Pending relationship status with the other user
+   * - The other user has a Sent relationship status with the current account
+   * - Neither user has blocked the other
+   * - The accounts are not the same user
+   *
+   * The validation ensures the relationship states are consistent with a valid friend request that
+   * can be accepted.
+   *
+   * If validation passes, the friendship is established asynchronously via the repository.
+   *
+   * @param account The account accepting the friend request
+   * @param notification The account whose friend request is being accepted
+   */
+  fun acceptFriendRequest(account: Account, notification: Notification) {
+    val other: Account
+    runBlocking { other = accountRepository.getAccount(notification.senderOrDiscussionId) }
+    val accountRels = account.relationships[other.uid]
+    val otherRels = other.relationships[account.uid]
+
+    if (sameOrBlocked(account, other) ||
+        accountRels != RelationshipStatus.PENDING ||
+        otherRels != RelationshipStatus.SENT)
+        return
+
+    viewModelScope.launch { accountRepository.acceptFriendRequest(account.uid, other.uid) }
+    executeNotification(account, notification)
+  }
+
+  /**
+   * Cancels or deny's a sent friend request from the current account to another user.
+   *
+   * This method validates that the operation is valid before proceeding. It prevents canceling in
+   * the following cases:
+   * - The accounts are the same user
+   * - Either user has blocked the other
+   *
+   * If validation passes, the relationship is reset asynchronously via the repository.
+   *
+   * @param account The account canceling the sent friend request
+   * @param other The account to whom the friend request was sent
+   */
+  fun rejectFriendRequest(account: Account, other: Account) {
+    if (sameOrBlocked(account, other)) return
+
+    viewModelScope.launch {
+      accountRepository.resetRelationship(account.uid, other.uid)
+      // Clear out previous notifications
+      account.notifications
+          .find { not -> not.senderOrDiscussionId == other.uid }
+          ?.let { not -> accountRepository.deleteNotification(account.uid, not.uid) }
+      other.notifications
+          .find { not -> not.senderOrDiscussionId == account.uid }
+          ?.let { not -> accountRepository.deleteNotification(other.uid, not.uid) }
+    }
+  }
+
+  /**
+   * Executes the action associated with a notification.
+   *
+   * This method validates that the notification belongs to the current account before executing it.
+   * The execution behavior depends on the notification type:
+   * - **FriendRequest**: Accepts the friend request
+   * - **JoinDiscussion**: Adds the user to the discussion
+   * - **JoinSession**: Adds the user as a participant in the session
+   *
+   * The method is idempotent - executing the same notification multiple times has no additional
+   * effect after the first execution.
+   *
+   * @param account The account executing the notification (must match the notification's receiver)
+   * @param notification The notification to execute
+   * @see Notification.execute for the specific actions performed by each notification type
+   */
+  private fun executeNotification(account: Account, notification: Notification) {
+    if (notification.receiverId != account.uid) return
+
+    viewModelScope.launch { notification.execute() }
+  }
+
+  /**
+   * Marks a notification as read.
+   *
+   * This method validates that the notification belongs to the current account before marking it as
+   * read. Read notifications are typically displayed differently in the UI to indicate the user has
+   * seen them.
+   *
+   * @param account The account that owns the notification (must match the notification's receiver)
+   * @param notification The notification to mark as read
+   */
+  fun readNotification(account: Account, notification: Notification) {
+    if (notification.receiverId != account.uid) return
+
+    viewModelScope.launch { accountRepository.readNotification(account.uid, notification.uid) }
+  }
+
+  /**
+   * Deletes a notification from the user's notification list.
+   *
+   * This method validates that the notification belongs to the current account before deleting it.
+   * Once deleted, the notification is permanently removed from Firestore and cannot be recovered.
+   *
+   * @param account The account that owns the notification (must match the notification's receiver)
+   * @param notification The notification to delete
+   */
+  fun deleteNotification(account: Account, notification: Notification) {
+    if (notification.receiverId != account.uid) return
+
+    viewModelScope.launch { accountRepository.deleteNotification(account.uid, notification.uid) }
+  }
+
+  /**
+   * Used to load data before showing a popup, avoiding weird UI displays
+   *
+   * @param notif Notif to load data from
+   * @param context Context where this was invoked
+   * @param onReady Callback to execute when the data is ready
+   */
+  fun preparePopupData(
+      notif: Notification,
+      context: Context,
+      onReady: (NotificationPopupData) -> Unit
+  ) {
+    when (notif.type) {
+      NotificationType.FRIEND_REQUEST -> {
+        getOtherAccount(notif.senderOrDiscussionId) { acc ->
+          loadAccountImage(acc.uid, context) { bytes ->
+            onReady(
+                NotificationPopupData.FriendRequest(
+                    username = acc.name,
+                    handle = acc.handle,
+                    bio = acc.description ?: "No description provided.",
+                    avatar = bytes))
+          }
+        }
+      }
+      NotificationType.JOIN_DISCUSSION -> {
+        getDiscussion(notif.senderOrDiscussionId) { disc ->
+          loadDiscussionImage(disc.uid, context) { bytes ->
+            onReady(
+                NotificationPopupData.Discussion(
+                    title = disc.name,
+                    participants = disc.participants.size,
+                    dateLabel = disc.createdAt.toString(),
+                    description = disc.description,
+                    icon = bytes))
+          }
+        }
+      }
+      NotificationType.JOIN_SESSION -> {
+        getDiscussion(notif.senderOrDiscussionId) { disc ->
+          loadDiscussionImage(disc.uid, context) { bytes ->
+            val session = disc.session
+            if (session != null) {
+
+              getGame(session.gameId) { game ->
+                onReady(
+                    NotificationPopupData.Session(
+                        title = session.name,
+                        participants = session.participants.size,
+                        dateLabel = session.date.toString(),
+                        description =
+                            "Play ${game?.name ?: "Unknown game"} at ${session.date} at ${session.location.name}",
+                        icon = bytes))
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/src/main/java/com/github/meeplemeet/model/account/NotificationsViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/NotificationsViewModel.kt
@@ -14,7 +14,6 @@ import com.github.meeplemeet.ui.account.NotificationPopupData
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 
 /**
  * ViewModel for managing user profile interactions and friend system operations.

--- a/app/src/main/java/com/github/meeplemeet/model/account/NotificationsViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/NotificationsViewModel.kt
@@ -8,10 +8,11 @@ import com.github.meeplemeet.RepositoryProvider
 import com.github.meeplemeet.model.discussions.Discussion
 import com.github.meeplemeet.model.discussions.DiscussionRepository
 import com.github.meeplemeet.model.images.ImageRepository
-import com.github.meeplemeet.model.shared.game.BggGameRepository
 import com.github.meeplemeet.model.shared.game.Game
 import com.github.meeplemeet.model.shared.game.GameRepository
 import com.github.meeplemeet.ui.account.NotificationPopupData
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
@@ -243,7 +244,14 @@ class NotificationsViewModel(
                 NotificationPopupData.Discussion(
                     title = disc.name,
                     participants = disc.participants.size,
-                    dateLabel = disc.createdAt.toString(),
+                    dateLabel =
+                        "Created at" +
+                            disc.createdAt
+                                .toDate()
+                                .toInstant()
+                                .atZone(ZoneId.systemDefault())
+                                .toLocalDate()
+                                .format(DateTimeFormatter.ofPattern("dd/MM/yyyy")),
                     description = disc.description,
                     icon = bytes))
           }
@@ -256,13 +264,20 @@ class NotificationsViewModel(
             if (session != null) {
 
               getGame(session.gameId) { game ->
+                val dateTime =
+                    session.date
+                        .toDate()
+                        .toInstant()
+                        .atZone(ZoneId.systemDefault())
+                        .toLocalDateTime()
+
                 onReady(
                     NotificationPopupData.Session(
                         title = session.name,
                         participants = session.participants.size,
-                        dateLabel = session.date.toString(),
+                        dateLabel = dateTime.format(DateTimeFormatter.ofPattern("MMM d")),
                         description =
-                            "Play ${game?.name ?: "Unknown game"} at ${session.date} at ${session.location.name}",
+                            "Play ${game.name} at ${dateTime.format(DateTimeFormatter.ofPattern("h:mm a"))} at ${session.location.name}.",
                         icon = bytes))
               }
             }

--- a/app/src/main/java/com/github/meeplemeet/model/account/NotificationsViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/NotificationsViewModel.kt
@@ -10,6 +10,7 @@ import com.github.meeplemeet.model.discussions.DiscussionRepository
 import com.github.meeplemeet.model.images.ImageRepository
 import com.github.meeplemeet.model.shared.game.BggGameRepository
 import com.github.meeplemeet.model.shared.game.Game
+import com.github.meeplemeet.model.shared.game.GameRepository
 import com.github.meeplemeet.ui.account.NotificationPopupData
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -29,7 +30,7 @@ class NotificationsViewModel(
     handlesRepository: HandlesRepository = RepositoryProvider.handles,
     private val imageRepository: ImageRepository = RepositoryProvider.images,
     private val discussionRepository: DiscussionRepository = RepositoryProvider.discussions,
-    private val gameRepository: BggGameRepository = RepositoryProvider.gamesApi
+    private val gameRepository: GameRepository = RepositoryProvider.gamesApi
 ) : CreateAccountViewModel(handlesRepository) {
 
   /**

--- a/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
@@ -435,7 +435,8 @@ fun PublicInfoActions(
                           modifier = Modifier.size(Dimensions.IconSize.extraLarge))
                     }
 
-                val notificationCount = account.notifications.size
+                val notificationCount = account.notifications.filter { !it.read }.size
+
                 if (notificationCount > 0) {
                   Box(
                       modifier =

--- a/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
@@ -269,8 +269,8 @@ object MainTabUi {
 fun MainTab(
     viewModel: ProfileScreenViewModel = viewModel(),
     account: Account,
-    onFriendsClick: (account: Account) -> Unit,
-    onNotificationClick: (account: Account) -> Unit,
+    onFriendsClick: () -> Unit,
+    onNotificationClick: () -> Unit,
     onSignOutOrDel: () -> Unit,
     onDelete: () -> Unit
 ) {
@@ -341,8 +341,8 @@ fun MainTab(
 fun PublicInfo(
     account: Account,
     viewModel: ProfileScreenViewModel,
-    onFriendsClick: (account: Account) -> Unit,
-    onNotificationClick: (account: Account) -> Unit,
+    onFriendsClick: () -> Unit,
+    onNotificationClick: () -> Unit,
     onSignOut: () -> Unit
 ) {
   Box(
@@ -388,8 +388,8 @@ fun PublicInfo(
 fun PublicInfoActions(
     account: Account,
     viewModel: ProfileScreenViewModel,
-    onFriendsClick: (Account) -> Unit,
-    onNotificationClick: (Account) -> Unit,
+    onFriendsClick: () -> Unit,
+    onNotificationClick: () -> Unit,
     onSignOut: () -> Unit
 ) {
   Column(
@@ -403,7 +403,7 @@ fun PublicInfoActions(
                   modifier =
                       Modifier.size(MainTabUi.ACTION_BUTTON_SIZE)
                           .testTag(PublicInfoTestTags.ACTION_FRIENDS),
-                  onClick = { onFriendsClick(account) },
+                  onClick = { onFriendsClick() },
                   shape = RoundedCornerShape(Dimensions.CornerRadius.extraLarge),
                   contentPadding = PaddingValues(0.dp),
                   colors =
@@ -421,7 +421,7 @@ fun PublicInfoActions(
                 Button(
                     modifier =
                         Modifier.matchParentSize().testTag(PublicInfoTestTags.ACTION_NOTIFICATIONS),
-                    onClick = { onNotificationClick(account) },
+                    onClick = { onNotificationClick() },
                     shape = RoundedCornerShape(Dimensions.CornerRadius.extraLarge),
                     contentPadding = PaddingValues(0.dp),
                     colors =

--- a/app/src/main/java/com/github/meeplemeet/ui/account/NotificationsTab.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/NotificationsTab.kt
@@ -90,114 +90,250 @@ import java.time.format.DateTimeFormatter
 import kotlinx.coroutines.launch
 
 object NotificationsTabTestTags {
-  const val HEADER_TITLE = "header_title"
-  const val FILTER_CHIP_PREFIX = "filter_chip_"
-  const val EMPTY_STATE_TEXT = "empty_state_text"
-  const val NOTIFICATION_LIST = "notification_list"
-  const val NOTIFICATION_ITEM_PREFIX = "notification_item_"
-  const val SHEET_TITLE = "sheet_title"
-  const val SHEET_DESCRIPTION = "sheet_description"
-  const val SHEET_ACCEPT_BUTTON = "sheet_accept_button"
-  const val SHEET_DECLINE_BUTTON = "sheet_decline_button"
-  const val UNREAD_DOT_PREFIX = "unread_dot_"
+    const val HEADER_TITLE = "header_title"
+    const val FILTER_CHIP_PREFIX = "filter_chip_"
+    const val EMPTY_STATE_TEXT = "empty_state_text"
+    const val NOTIFICATION_LIST = "notification_list"
+    const val NOTIFICATION_ITEM_PREFIX = "notification_item_"
+    const val SHEET_TITLE = "sheet_title"
+    const val SHEET_DESCRIPTION = "sheet_description"
+    const val SHEET_ACCEPT_BUTTON = "sheet_accept_button"
+    const val SHEET_DECLINE_BUTTON = "sheet_decline_button"
+    const val UNREAD_DOT_PREFIX = "unread_dot_"
+}
+
+object NotificationsTabUi {
+    object Header {
+        const val TITLE = "Notifications"
+        const val BACK_ICON_DESCRIPTION = "Back"
+    }
+
+    object NotificationLabels {
+        const val FRIEND_REQUEST = "Incoming friend request"
+        const val JOIN_DISCUSSION = "Discussion invite"
+        const val JOIN_SESSION = "Session invite"
+    }
+
+    object DateSections {
+        const val TODAY = "Today"
+        const val YESTERDAY = "Yesterday"
+        const val EARLIER = "Earlier"
+        const val DAYS_BEFORE_YESTERDAY = 1L
+    }
+
+    object Filters {
+        const val PADDING_LIMIT = 24
+        const val GRADIENT_ALPHA = 0.7f
+    }
+
+    object NotificationCard {
+        const val UNREAD_DOT_CORNER_RADIUS = 50
+        val AVATAR_CORNER_RADIUS: Dp = 22.dp
+        val UNREAD_DOT_SIZE: Dp = 18.dp
+        val AVATAR_SIZE: Dp = 44.dp
+
+        object TimeFormats {
+            const val TIME_PATTERN = "h:mm a"
+            const val DATE_PATTERN = "dd/MM/yyyy"
+        }
+
+        object Subtitles {
+            const val FRIEND_REQUEST_PREFIX = "User "
+            const val FRIEND_REQUEST_SUFFIX = "wants to add you as a friend."
+            const val DISCUSSION_PREFIX = "Invited to join discussion "
+            const val SESSION_PREFIX = "Invited to join session "
+        }
+
+        object Swipe {
+            const val MARK_READ_THRESHOLD = 0.10f
+            const val DELETE_THRESHOLD = 0.40f
+            const val TRIGGERED_SCALE = 1.3f
+            const val DEFAULT_SCALE = 1f
+        }
+
+        object Fallbacks {
+            const val DEFAULT_USER = "User"
+            const val DEFAULT_DISCUSSION = "Discussion"
+            const val DEFAULT_SESSION = "Session"
+            const val FALLBACK_LETTER = '•'
+        }
+    }
+
+    object NotificationSheet {
+        val AVATAR_SIZE: Dp = 52.dp
+
+        object Content {
+            const val CLOSE_ICON_DESCRIPTION = "Close"
+            const val DISCUSSION_KEYWORD = "discussion"
+            const val ABOUT_DISCUSSION = "About this discussion"
+            const val ABOUT_SESSION = "About this session"
+            const val ABOUT_FRIEND = "About"
+            const val NO_DESCRIPTION = "No description provided"
+            const val NO_DESCRIPTION_DISCUSSION = "No description provided."
+            const val HANDLE_PREFIX = "@"
+
+            const val DATE_PATTERN = "dd/MM/yyyy"
+            const val SESSION_DATE_PATTERN = "MMM d"
+            const val SESSION_TIME_PATTERN = "h:mm a"
+
+            const val DISCUSSION_PREVIEW_CHAR_LIMIT = 160
+            const val SESSION_PREVIEW_CHAR_LIMIT = 160
+            const val FRIEND_PREVIEW_CHAR_LIMIT = 150
+
+            fun sessionDescription(gameName: String, time: String, locationName: String) =
+                "Play $gameName at $time at $locationName."
+
+            fun participantsMeta(participants: Int, dateLabel: String) =
+                "$participants participants • $dateLabel"
+        }
+
+        object Buttons {
+            const val DECLINE_TEXT = "Decline"
+            const val ACCEPT_TEXT = "Accept"
+        }
+    }
+
+    object ExpandableText {
+        const val DEFAULT_PREVIEW_CHAR_LIMIT = 160
+        const val MORE_INDICATOR = "…"
+        const val SHOW_MORE = "Show more"
+        const val SHOW_LESS = "Show less"
+    }
+
+    object LetterAvatar {
+        const val SIZE_MULTIPLIER = 0.45f
+    }
+
+    object EmptyState {
+        object Messages {
+            const val ALL = "You have no notifications yet."
+            const val UNREAD = "You're all caught up! No unread notifications."
+            const val FRIEND_REQUESTS = "No incoming friend requests."
+            const val DISCUSSIONS = "No discussion invitations."
+            const val SESSIONS = "No session invitations."
+        }
+    }
 }
 
 /* ---------------------------------------------------------
    EXTENSIONS + HELPERS
 --------------------------------------------------------- */
 
+/**
+ * Helper to manage dates and time
+ */
 fun Notification.sentAtLocalDateTime(): LocalDateTime =
     sentAt.toDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime()
 
+/**
+ * Helper for modular composable
+ */
 fun NotificationType.label(): String =
     when (this) {
-      NotificationType.FRIEND_REQUEST -> "Incoming friend request"
-      NotificationType.JOIN_DISCUSSION -> "Discussion invite"
-      NotificationType.JOIN_SESSION -> "Session invite"
+        NotificationType.FRIEND_REQUEST ->
+            NotificationsTabUi.NotificationLabels.FRIEND_REQUEST
+        NotificationType.JOIN_DISCUSSION ->
+            NotificationsTabUi.NotificationLabels.JOIN_DISCUSSION
+        NotificationType.JOIN_SESSION ->
+            NotificationsTabUi.NotificationLabels.JOIN_SESSION
     }
 
+/**
+ * Helper for organisation of the notifications by date
+ */
 data class NotificationSection(val header: String, val items: List<Notification>)
 
+/**
+ * Groups notifications together with respect to the time they were sent at
+ */
 fun groupNotifications(list: List<Notification>): List<NotificationSection> {
-  val today = LocalDate.now()
-  val yesterday = today.minusDays(1)
+    val today = LocalDate.now()
+    val yesterday = today.minusDays(NotificationsTabUi.DateSections.DAYS_BEFORE_YESTERDAY)
 
-  val todayItems = list.filter { it.sentAtLocalDateTime().toLocalDate() == today }
-  val yesterdayItems = list.filter { it.sentAtLocalDateTime().toLocalDate() == yesterday }
-  val earlierItems =
-      list.filter {
-        val d = it.sentAtLocalDateTime().toLocalDate()
-        d != today && d != yesterday
-      }
+    val todayItems = list.filter { it.sentAtLocalDateTime().toLocalDate() == today }
+    val yesterdayItems = list.filter { it.sentAtLocalDateTime().toLocalDate() == yesterday }
+    val earlierItems =
+        list.filter {
+            val d = it.sentAtLocalDateTime().toLocalDate()
+            d != today && d != yesterday
+        }
 
-  val sections = mutableListOf<NotificationSection>()
-  if (todayItems.isNotEmpty()) sections.add(NotificationSection("Today", todayItems))
-  if (yesterdayItems.isNotEmpty()) sections.add(NotificationSection("Yesterday", yesterdayItems))
-  if (earlierItems.isNotEmpty()) sections.add(NotificationSection("Earlier", earlierItems))
+    val sections = mutableListOf<NotificationSection>()
+    if (todayItems.isNotEmpty()) {
+        sections.add(
+            NotificationSection(
+                NotificationsTabUi.DateSections.TODAY,
+                todayItems
+            )
+        )
+    }
+    if (yesterdayItems.isNotEmpty()) {
+        sections.add(
+            NotificationSection(
+                NotificationsTabUi.DateSections.YESTERDAY,
+                yesterdayItems
+            )
+        )
+    }
+    if (earlierItems.isNotEmpty()) {
+        sections.add(
+            NotificationSection(
+                NotificationsTabUi.DateSections.EARLIER,
+                earlierItems
+            )
+        )
+    }
 
-  return sections
+    return sections
 }
 
+/**
+ * Data classes for modular popup composables
+ */
 sealed class NotificationPopupData {
-  data class Discussion(
-      val title: String,
-      val participants: Int,
-      val dateLabel: String,
-      val description: String,
-      val icon: ByteArray?
-  ) : NotificationPopupData()
+    data class Discussion(
+        val title: String,
+        val participants: Int,
+        val dateLabel: String,
+        val description: String,
+        val icon: ByteArray?
+    ) : NotificationPopupData()
 
-  data class Session(
-      val title: String,
-      val participants: Int,
-      val dateLabel: String,
-      val description: String,
-      val icon: ByteArray?
-  ) : NotificationPopupData()
+    data class Session(
+        val title: String,
+        val participants: Int,
+        val dateLabel: String,
+        val description: String,
+        val icon: ByteArray?
+    ) : NotificationPopupData()
 
-  data class FriendRequest(
-      val username: String,
-      val handle: String,
-      val bio: String,
-      val avatar: ByteArray?
-  ) : NotificationPopupData()
+    data class FriendRequest(
+        val username: String,
+        val handle: String,
+        val bio: String,
+        val avatar: ByteArray?
+    ) : NotificationPopupData()
 }
 
+/**
+ * Helper for modular composables
+ */
 data class NotificationSheetState(
     val notification: Notification,
     val popupData: NotificationPopupData
 )
 
-// fun Notification.toPopupData(): NotificationPopupData {
-//  val dateLabel = sentAtLocalDateTime().format(DateTimeFormatter.ofPattern("MMM d"))
-//  return when (type) {
-//    NotificationType.FRIEND_REQUEST ->
-//        NotificationPopupData.FriendRequest(
-//            username = "User $senderOrDiscussionId",
-//            handle = senderOrDiscussionId,
-//            bio = "User $senderOrDiscussionId wants to add you as a friend.",
-//            avatar = null)
-//    NotificationType.JOIN_DISCUSSION ->
-//        NotificationPopupData.Discussion(
-//            title = "Discussion invitation",
-//            participants = 0,
-//            dateLabel = dateLabel,
-//            description = "You've been invited to join discussion $senderOrDiscussionId.",
-//            icon = null)
-//    NotificationType.JOIN_SESSION ->
-//        NotificationPopupData.Session(
-//            title = "Session invitation",
-//            participants = 0,
-//            dateLabel = dateLabel,
-//            description = "You've been invited to join session $senderOrDiscussionId.",
-//            icon = null)
-//  }
-// }
-
 /* ---------------------------------------------------------
    MAIN SCREEN
 --------------------------------------------------------- */
 
+/**
+ * Main screen/tab of this file. It shows the user his sorted notifications, filters and
+ * the notifications are interactible
+ * @param account The current user
+ * @param viewModel VM used by this screen
+ * @param onBack callback upon click of the back button
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NotificationsTab(
@@ -205,198 +341,237 @@ fun NotificationsTab(
     viewModel: NotificationsViewModel = viewModel(),
     onBack: () -> Unit
 ) {
-  val scope = rememberCoroutineScope()
+    val scope = rememberCoroutineScope()
 
-  val filters = NotificationFilter.entries
-  var selectedFilter by remember { mutableStateOf(NotificationFilter.ALL) }
+    val filters = NotificationFilter.entries
+    var selectedFilter by remember { mutableStateOf(NotificationFilter.ALL) }
 
-  val notifications: List<Notification> = account.notifications
+    val notifications: List<Notification> = account.notifications
 
-  val filtered =
-      when (selectedFilter) {
-        NotificationFilter.ALL -> notifications
-        NotificationFilter.UNREAD -> notifications.filter { !it.read }
-        NotificationFilter.FRIEND_REQUESTS ->
-            notifications.filter { it.type == NotificationType.FRIEND_REQUEST }
-        NotificationFilter.DISCUSSIONS ->
-            notifications.filter { it.type == NotificationType.JOIN_DISCUSSION }
-        NotificationFilter.SESSIONS ->
-            notifications.filter { it.type == NotificationType.JOIN_SESSION }
-      }.sortedByDescending { n -> n.sentAt }
+    val filtered =
+        when (selectedFilter) {
+            NotificationFilter.ALL -> notifications
+            NotificationFilter.UNREAD -> notifications.filter { !it.read }
+            NotificationFilter.FRIEND_REQUESTS ->
+                notifications.filter { it.type == NotificationType.FRIEND_REQUEST }
+            NotificationFilter.DISCUSSIONS ->
+                notifications.filter { it.type == NotificationType.JOIN_DISCUSSION }
+            NotificationFilter.SESSIONS ->
+                notifications.filter { it.type == NotificationType.JOIN_SESSION }
+        }.sortedByDescending { n -> n.sentAt }
 
-  val grouped = groupNotifications(filtered)
+    val grouped = groupNotifications(filtered)
 
-  var sheetState by remember { mutableStateOf<NotificationSheetState?>(null) }
+    var sheetState by remember { mutableStateOf<NotificationSheetState?>(null) }
 
-  if (sheetState != null) {
-    val current = sheetState!!
-    NotificationSheet(
-        notification = current.notification,
-        data = current.popupData,
-        viewModel = viewModel,
-        onDismiss = { sheetState = null },
-        onAccept = {
-          scope.launch {
-            current.notification.execute()
-            viewModel.readNotification(account, current.notification)
-            sheetState = null
-          }
-        },
-        onDecline = {
-          viewModel.deleteNotification(account, current.notification)
-          sheetState = null
-        })
-  }
-
-  Scaffold(
-      topBar = {
-        CenterAlignedTopAppBar(
-            colors =
-                TopAppBarDefaults.centerAlignedTopAppBarColors(
-                    containerColor = AppColors.primary,
-                    titleContentColor = AppColors.textIcons,
-                    navigationIconContentColor = AppColors.textIcons),
-            title = {
-              Text(
-                  text = "Notifications",
-                  modifier = Modifier.testTag(NotificationsTabTestTags.HEADER_TITLE))
-            },
-            navigationIcon = {
-              IconButton(onClick = onBack) {
-                Icon(
-                    Icons.AutoMirrored.Filled.ArrowBack,
-                    modifier = Modifier.testTag(NavigationTestTags.GO_BACK_BUTTON),
-                    contentDescription = "Back")
-              }
-            })
-      }) { padding ->
-        Column(modifier = Modifier.padding(padding).fillMaxSize()) {
-          FilterRow(
-              filters = filters, selected = selectedFilter, onSelected = { selectedFilter = it })
-
-          if (filtered.isEmpty()) {
-            EmptyNotificationState(filter = selectedFilter)
-          } else {
-            LazyColumn(
-                modifier =
-                    Modifier.fillMaxSize()
-                        .padding(top = 16.dp)
-                        .testTag(NotificationsTabTestTags.NOTIFICATION_LIST)) {
-                  grouped.forEachIndexed { index, section ->
-                    if (index > 0) item { Spacer(Modifier.height(20.dp)) }
-
-                    item {
-                      Text(
-                          text = section.header,
-                          style = MaterialTheme.typography.titleLarge.copy(fontSize = 22.sp),
-                          color = AppColors.textIcons,
-                          modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
-                    }
-
-                    items(section.items, key = { it.uid }) { notif ->
-                      val context = LocalContext.current
-                      NotificationCard(
-                          notif = notif,
-                          viewModel = viewModel,
-                          onClick = {
-                            scope.launch {
-                              viewModel.preparePopupData(notif, context) { popupData ->
-                                sheetState = NotificationSheetState(notif, popupData)
-                              }
-                            }
-                            viewModel.readNotification(account, notif)
-                          },
-                          onMarkRead = { viewModel.readNotification(account, notif) },
-                          onDelete = { viewModel.deleteNotification(account, notif) })
-                    }
-                  }
+    if (sheetState != null) {
+        val current = sheetState!!
+        NotificationSheet(
+            notification = current.notification,
+            data = current.popupData,
+            viewModel = viewModel,
+            onDismiss = { sheetState = null },
+            onAccept = {
+                scope.launch {
+                    current.notification.execute()
+                    viewModel.readNotification(account, current.notification)
+                    sheetState = null
                 }
-          }
+            },
+            onDecline = {
+                viewModel.deleteNotification(account, current.notification)
+                sheetState = null
+            })
+    }
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                colors =
+                    TopAppBarDefaults.centerAlignedTopAppBarColors(
+                        containerColor = AppColors.primary,
+                        titleContentColor = AppColors.textIcons,
+                        navigationIconContentColor = AppColors.textIcons),
+                title = {
+                    Text(
+                        text = NotificationsTabUi.Header.TITLE,
+                        modifier = Modifier.testTag(NotificationsTabTestTags.HEADER_TITLE))
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            modifier = Modifier.testTag(NavigationTestTags.GO_BACK_BUTTON),
+                            contentDescription = NotificationsTabUi.Header.BACK_ICON_DESCRIPTION)
+                    }
+                })
+        }) { padding ->
+        Column(modifier = Modifier.padding(padding).fillMaxSize()) {
+            FilterRow(
+                filters = filters, selected = selectedFilter, onSelected = { selectedFilter = it })
+
+            if (filtered.isEmpty()) {
+                EmptyNotificationState(filter = selectedFilter)
+            } else {
+                LazyColumn(
+                    modifier =
+                        Modifier.fillMaxSize()
+                            .padding(top = Dimensions.Padding.extraLarge)
+                            .testTag(NotificationsTabTestTags.NOTIFICATION_LIST)) {
+                    grouped.forEachIndexed { index, section ->
+                        if (index > 0) {
+                            item { Spacer(Modifier.height(Dimensions.Padding.xLarge)) }
+                        }
+
+                        item {
+                            Text(
+                                text = section.header,
+                                style = MaterialTheme.typography.titleLarge.copy(
+                                    fontSize = Dimensions.TextSize.largeHeading),
+                                color = AppColors.textIcons,
+                                modifier =
+                                    Modifier.padding(
+                                        horizontal = Dimensions.Padding.extraLarge,
+                                        vertical = Dimensions.Padding.medium))
+                        }
+
+                        items(section.items, key = { it.uid }) { notif ->
+                            val context = LocalContext.current
+                            NotificationCard(
+                                notif = notif,
+                                viewModel = viewModel,
+                                onClick = {
+                                    scope.launch {
+                                        viewModel.preparePopupData(notif, context) { popupData ->
+                                            sheetState = NotificationSheetState(notif, popupData)
+                                        }
+                                    }
+                                    viewModel.readNotification(account, notif)
+                                },
+                                onMarkRead = { viewModel.readNotification(account, notif) },
+                                onDelete = { viewModel.deleteNotification(account, notif) })
+                        }
+                    }
+                }
+            }
         }
-      }
+    }
 }
 
 /* ---------------------------------------------------------
    FILTERS
 --------------------------------------------------------- */
 
+/**
+ * Enum for all filters
+ */
 enum class NotificationFilter(val label: String) {
-  ALL("All"),
-  UNREAD("Unread"),
-  FRIEND_REQUESTS("Friend requests"),
-  DISCUSSIONS("Discussions"),
-  SESSIONS("Sessions")
+    ALL("All"),
+    UNREAD("Unread"),
+    FRIEND_REQUESTS("Friend requests"),
+    DISCUSSIONS("Discussions"),
+    SESSIONS("Sessions")
 }
 
+/**
+ * Composable used to display the row of filters
+ * @param filters All available filters
+ * @param selected The selected filter
+ * @param onSelected Callback upon selection of a filter
+ */
 @Composable
 fun FilterRow(
     filters: List<NotificationFilter>,
     selected: NotificationFilter,
     onSelected: (NotificationFilter) -> Unit,
 ) {
-  val scroll = rememberScrollState()
+    val scroll = rememberScrollState()
 
-  val showLeft by remember { derivedStateOf { scroll.value > 0 } }
-  val showRight by remember { derivedStateOf { scroll.value < scroll.maxValue } }
+    val showLeft by remember { derivedStateOf { scroll.value > 0 } }
+    val showRight by remember { derivedStateOf { scroll.value < scroll.maxValue } }
 
-  Column(modifier = Modifier.fillMaxWidth()) {
-    val padLimit = 24
-    val padStart = minOf(scroll.value, padLimit)
-    val padEnd = minOf(scroll.maxValue - scroll.value, padLimit)
+    Column(modifier = Modifier.fillMaxWidth()) {
+        val padLimit = NotificationsTabUi.Filters.PADDING_LIMIT
+        val padStart = minOf(scroll.value, padLimit)
+        val padEnd = minOf(scroll.maxValue - scroll.value, padLimit)
 
-    Box(
-        modifier =
-            Modifier.fillMaxWidth().height(40.dp).padding(start = padStart.dp, end = padEnd.dp)) {
-          Row(modifier = Modifier.horizontalScroll(scroll).padding(horizontal = 12.dp)) {
-            filters.forEach { filter ->
-              FilterChip(
-                  text = filter.label,
-                  selected = filter == selected,
-                  modifier =
-                      Modifier.testTag(NotificationsTabTestTags.FILTER_CHIP_PREFIX + filter.name),
-                  onClick = { onSelected(filter) })
+        Box(
+            modifier =
+                Modifier.fillMaxWidth()
+                    .height(Dimensions.ContainerSize.iconButtonTouch)
+                    .padding(start = padStart.dp, end = padEnd.dp)) {
+            Row(
+                modifier =
+                    Modifier.horizontalScroll(scroll)
+                        .padding(horizontal = Dimensions.Padding.large)) {
+                filters.forEach { filter ->
+                    FilterChip(
+                        text = filter.label,
+                        selected = filter == selected,
+                        modifier =
+                            Modifier.testTag(
+                                NotificationsTabTestTags.FILTER_CHIP_PREFIX + filter.name),
+                        onClick = { onSelected(filter) })
 
-              Spacer(Modifier.width(16.dp))
+                    Spacer(Modifier.width(Dimensions.Padding.extraLarge))
+                }
             }
-          }
 
-          if (showLeft) {
-            Box(
-                Modifier.align(Alignment.CenterStart)
-                    .width(32.dp)
-                    .fillMaxHeight()
-                    .background(
-                        Brush.horizontalGradient(
-                            listOf(
-                                AppColors.primary,
-                                AppColors.primary.copy(alpha = 0.7f),
-                                Color.Transparent))))
-          }
+            if (showLeft) {
+                Box(
+                    Modifier.align(Alignment.CenterStart)
+                        .width(Dimensions.Padding.xxxLarge)
+                        .fillMaxHeight()
+                        .background(
+                            Brush.horizontalGradient(
+                                listOf(
+                                    AppColors.primary,
+                                    AppColors.primary.copy(
+                                        alpha = NotificationsTabUi.Filters.GRADIENT_ALPHA),
+                                    Color.Transparent))))
+            }
 
-          if (showRight) {
-            Box(
-                Modifier.align(Alignment.CenterEnd)
-                    .width(32.dp)
-                    .fillMaxHeight()
-                    .background(
-                        Brush.horizontalGradient(listOf(Color.Transparent, AppColors.primary))))
-          }
+            if (showRight) {
+                Box(
+                    Modifier.align(Alignment.CenterEnd)
+                        .width(Dimensions.Padding.xxxLarge)
+                        .fillMaxHeight()
+                        .background(
+                            Brush.horizontalGradient(
+                                listOf(Color.Transparent, AppColors.primary))))
+            }
         }
 
-    Row(
-        modifier = Modifier.fillMaxWidth().padding(top = 4.dp, start = 12.dp, end = 12.dp),
-        horizontalArrangement = Arrangement.SpaceBetween) {
-          if (showLeft) {
-            Icon(Icons.Default.ChevronLeft, null, tint = AppColors.textIconsFade)
-          } else Spacer(Modifier.size(24.dp))
+        Row(
+            modifier =
+                Modifier.fillMaxWidth()
+                    .padding(
+                        top = Dimensions.Padding.small,
+                        start = Dimensions.Padding.large,
+                        end = Dimensions.Padding.large),
+            horizontalArrangement = Arrangement.SpaceBetween) {
+            if (showLeft) {
+                Icon(Icons.Default.ChevronLeft, null, tint = AppColors.textIconsFade)
+            } else {
+                Spacer(Modifier.size(Dimensions.IconSize.large))
+            }
 
-          if (showRight) {
-            Icon(Icons.Default.ChevronRight, null, tint = AppColors.textIconsFade)
-          } else Spacer(Modifier.size(24.dp))
+            if (showRight) {
+                Icon(Icons.Default.ChevronRight, null, tint = AppColors.textIconsFade)
+            } else {
+                Spacer(Modifier.size(Dimensions.IconSize.large))
+            }
         }
-  }
+    }
 }
 
+/**
+ * Filter chips used for filtering
+ * @param text Text to display in the chip
+ * @param selected Whether the chip is selected or not
+ * @param modifier Modifiers to pass to the chip
+ * @param onClick Callback upon click on the chip
+ */
 @Composable
 fun FilterChip(
     text: String,
@@ -404,23 +579,37 @@ fun FilterChip(
     modifier: Modifier = Modifier,
     onClick: () -> Unit
 ) {
-  val border = if (selected) AppColors.neutral else AppColors.textIconsFade
+    val border = if (selected) AppColors.neutral else AppColors.textIconsFade
 
-  Box(
-      modifier =
-          modifier
-              .clip(RoundedCornerShape(4.dp))
-              .border(if (selected) 2.dp else 1.dp, border, RoundedCornerShape(16.dp))
-              .clickable { onClick() }
-              .padding(horizontal = 16.dp, vertical = 8.dp)) {
+    Box(
+        modifier =
+            modifier
+                .clip(RoundedCornerShape(Dimensions.CornerRadius.small))
+                .border(
+                    if (selected) Dimensions.DividerThickness.medium
+                    else Dimensions.DividerThickness.standard,
+                    border,
+                    RoundedCornerShape(Dimensions.CornerRadius.extraLarge))
+                .clickable { onClick() }
+                .padding(
+                    horizontal = Dimensions.Padding.extraLarge,
+                    vertical = Dimensions.Padding.medium)) {
         Text(text, color = AppColors.textIcons)
-      }
+    }
 }
 
 /* ---------------------------------------------------------
    NOTIFICATION CARD
 --------------------------------------------------------- */
 
+/**
+ * Notification card, handles everything in relation to the card
+ * @param notif Actual notification data
+ * @param viewModel VM used by this screen
+ * @param onClick Callback upon click on the notification
+ * @param onMarkRead Callback upon swiping right
+ * @param onDelete Callback upon swiping left
+ */
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class)
 @Composable
 fun NotificationCard(
@@ -430,195 +619,245 @@ fun NotificationCard(
     onMarkRead: () -> Unit,
     onDelete: () -> Unit
 ) {
-  val dismissState =
-      rememberDismissState(
-          confirmStateChange = { state ->
-            when (state) {
-              DismissValue.DismissedToStart -> {
-                onDelete()
-                false
-              }
-              DismissValue.DismissedToEnd -> {
-                onMarkRead()
-                false
-              }
-              else -> false
-            }
-          })
+    val dismissState =
+        rememberDismissState(
+            confirmStateChange = { state ->
+                when (state) {
+                    DismissValue.DismissedToStart -> {
+                        onDelete()
+                        false
+                    }
+                    DismissValue.DismissedToEnd -> {
+                        onMarkRead()
+                        false
+                    }
+                    else -> false
+                }
+            })
 
-  SwipeToDismiss(
-      state = dismissState,
-      background = { SwipeBackground(dismissState) },
-      dismissContent = { NotificationRowContent(notif, viewModel, onClick) },
-      directions = setOf(DismissDirection.StartToEnd, DismissDirection.EndToStart),
-      dismissThresholds = {
-        when (it) {
-          DismissDirection.StartToEnd -> FractionalThreshold(0.10f)
-          DismissDirection.EndToStart -> FractionalThreshold(0.40f)
-        }
-      })
+    SwipeToDismiss(
+        state = dismissState,
+        background = { SwipeBackground(dismissState) },
+        dismissContent = { NotificationRowContent(notif, viewModel, onClick) },
+        directions = setOf(DismissDirection.StartToEnd, DismissDirection.EndToStart),
+        dismissThresholds = {
+            when (it) {
+                DismissDirection.StartToEnd ->
+                    FractionalThreshold(
+                        NotificationsTabUi.NotificationCard.Swipe.MARK_READ_THRESHOLD)
+                DismissDirection.EndToStart ->
+                    FractionalThreshold(
+                        NotificationsTabUi.NotificationCard.Swipe.DELETE_THRESHOLD)
+            }
+        })
 }
 
+/**
+ * Function used to manage the swiping left/right
+ * @param state whether the card is currently swiped or not
+ */
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 private fun SwipeBackground(state: DismissState) {
-  val dir = state.dismissDirection ?: return
-  val isTriggered = state.targetValue != DismissValue.Default
-  val scale by animateFloatAsState(if (isTriggered) 1.3f else 1f)
+    val dir = state.dismissDirection ?: return
+    val isTriggered = state.targetValue != DismissValue.Default
+    val scale by
+    animateFloatAsState(
+        if (isTriggered)
+            NotificationsTabUi.NotificationCard.Swipe.TRIGGERED_SCALE
+        else NotificationsTabUi.NotificationCard.Swipe.DEFAULT_SCALE)
 
-  val color =
-      when (dir) {
-        DismissDirection.StartToEnd -> AppColors.neutral
-        DismissDirection.EndToStart -> AppColors.negative
-      }
+    val color =
+        when (dir) {
+            DismissDirection.StartToEnd -> AppColors.neutral
+            DismissDirection.EndToStart -> AppColors.negative
+        }
 
-  Box(
-      modifier = Modifier.fillMaxSize().background(color).padding(horizontal = 20.dp),
-      contentAlignment =
-          when (dir) {
-            DismissDirection.StartToEnd -> Alignment.CenterStart
-            DismissDirection.EndToStart -> Alignment.CenterEnd
-          }) {
+    Box(
+        modifier =
+            Modifier.fillMaxSize()
+                .background(color)
+                .padding(horizontal = Dimensions.Padding.xLarge),
+        contentAlignment =
+            when (dir) {
+                DismissDirection.StartToEnd -> Alignment.CenterStart
+                DismissDirection.EndToStart -> Alignment.CenterEnd
+            }) {
         val icon =
             when (dir) {
-              DismissDirection.StartToEnd -> Icons.Default.MarkChatRead
-              DismissDirection.EndToStart -> Icons.Default.Delete
+                DismissDirection.StartToEnd -> Icons.Default.MarkChatRead
+                DismissDirection.EndToStart -> Icons.Default.Delete
             }
 
         Icon(icon, null, tint = Color.White, modifier = Modifier.scale(scale))
-      }
+    }
 }
 
+/**
+ * Actual content of the notification
+ * @param notif Notification data
+ * @param viewModel VM used by this screen
+ * @param onClick Callback upon click
+ */
 @Composable
 private fun NotificationRowContent(
     notif: Notification,
     viewModel: NotificationsViewModel,
     onClick: () -> Unit
 ) {
-  val context = LocalContext.current
+    val context = LocalContext.current
 
-  var avatarBytes by remember(notif.uid) { mutableStateOf<ByteArray?>(null) }
-  var friend by remember { mutableStateOf<Account?>(null) }
-  var discussionName by remember { mutableStateOf<String?>(null) }
-  var sessionName by remember { mutableStateOf<String?>(null) }
+    var avatarBytes by remember(notif.uid) { mutableStateOf<ByteArray?>(null) }
+    var friend by remember { mutableStateOf<Account?>(null) }
+    var discussionName by remember { mutableStateOf<String?>(null) }
+    var sessionName by remember { mutableStateOf<String?>(null) }
 
-  LaunchedEffect(notif.uid) {
-    when (notif.type) {
-      NotificationType.FRIEND_REQUEST -> {
-        viewModel.getOtherAccount(notif.senderOrDiscussionId) { acc ->
-          friend = acc
-          viewModel.loadAccountImage(notif.senderOrDiscussionId, context) { avatarBytes = it }
+    LaunchedEffect(notif.uid) {
+        when (notif.type) {
+            NotificationType.FRIEND_REQUEST -> {
+                viewModel.getOtherAccount(notif.senderOrDiscussionId) { acc ->
+                    friend = acc
+                    viewModel.loadAccountImage(notif.senderOrDiscussionId, context) { avatarBytes = it }
+                }
+            }
+            NotificationType.JOIN_DISCUSSION -> {
+                viewModel.getDiscussion(notif.senderOrDiscussionId) { disc ->
+                    discussionName = disc.name
+                    viewModel.loadDiscussionImage(disc.uid, context) { bytes -> avatarBytes = bytes }
+                }
+            }
+            NotificationType.JOIN_SESSION -> {
+                viewModel.getDiscussion(notif.senderOrDiscussionId) { disc ->
+                    val session = disc.session
+                    sessionName = session?.name ?: disc.name
+                    viewModel.loadDiscussionImage(disc.uid, context) { bytes -> avatarBytes = bytes }
+                }
+            }
         }
-      }
-      NotificationType.JOIN_DISCUSSION -> {
-        viewModel.getDiscussion(notif.senderOrDiscussionId) { disc ->
-          discussionName = disc.name
-          viewModel.loadDiscussionImage(disc.uid, context) { bytes -> avatarBytes = bytes }
-        }
-      }
-      NotificationType.JOIN_SESSION -> {
-        viewModel.getDiscussion(notif.senderOrDiscussionId) { disc ->
-          val session = disc.session
-          sessionName = session?.name ?: disc.name
-          viewModel.loadDiscussionImage(disc.uid, context) { bytes -> avatarBytes = bytes }
-        }
-      }
     }
-  }
 
-  val dateTime = notif.sentAtLocalDateTime()
-  val date = dateTime.toLocalDate()
-  val today = LocalDate.now()
-  val timeText =
-      if (date == today || date == today.minusDays(1))
-          dateTime.format(DateTimeFormatter.ofPattern("h:mm a"))
-      else dateTime.format(DateTimeFormatter.ofPattern("dd/MM/yyyy"))
+    val dateTime = notif.sentAtLocalDateTime()
+    val date = dateTime.toLocalDate()
+    val today = LocalDate.now()
+    val timeText =
+        if (date == today || date == today.minusDays(NotificationsTabUi.DateSections.DAYS_BEFORE_YESTERDAY))
+            dateTime.format(
+                DateTimeFormatter.ofPattern(
+                    NotificationsTabUi.NotificationCard.TimeFormats.TIME_PATTERN))
+        else
+            dateTime.format(
+                DateTimeFormatter.ofPattern(
+                    NotificationsTabUi.NotificationCard.TimeFormats.DATE_PATTERN))
 
-  val displayName =
-      when (notif.type) {
-        NotificationType.FRIEND_REQUEST -> friend?.name ?: "User"
-        NotificationType.JOIN_DISCUSSION -> discussionName ?: "Discussion"
-        NotificationType.JOIN_SESSION -> sessionName ?: "Session"
-      }
-
-  val fallbackLetter = displayName.firstOrNull()?.uppercaseChar() ?: '•'
-
-  Row(
-      modifier =
-          Modifier.fillMaxWidth()
-              .testTag(NotificationsTabTestTags.NOTIFICATION_ITEM_PREFIX + notif.uid)
-              .background(AppColors.primary)
-              .clickable { onClick() }
-              .padding(horizontal = 12.dp, vertical = 10.dp)) {
-        if (!notif.read) {
-          Box(
-              modifier =
-                  Modifier.padding(top = 12.dp)
-                      .size(18.dp)
-                      .clip(RoundedCornerShape(50))
-                      .background(AppColors.negative)
-                      .testTag(NotificationsTabTestTags.UNREAD_DOT_PREFIX + notif.uid))
+    val displayName =
+        when (notif.type) {
+            NotificationType.FRIEND_REQUEST ->
+                friend?.name ?: NotificationsTabUi.NotificationCard.Fallbacks.DEFAULT_USER
+            NotificationType.JOIN_DISCUSSION ->
+                discussionName ?: NotificationsTabUi.NotificationCard.Fallbacks.DEFAULT_DISCUSSION
+            NotificationType.JOIN_SESSION ->
+                sessionName ?: NotificationsTabUi.NotificationCard.Fallbacks.DEFAULT_SESSION
         }
 
-        Spacer(Modifier.width(12.dp))
+    val fallbackLetter =
+        displayName.firstOrNull()
+            ?: NotificationsTabUi.NotificationCard.Fallbacks.FALLBACK_LETTER
+
+    Row(
+        modifier =
+            Modifier.fillMaxWidth()
+                .testTag(NotificationsTabTestTags.NOTIFICATION_ITEM_PREFIX + notif.uid)
+                .background(AppColors.primary)
+                .clickable { onClick() }
+                .padding(
+                    horizontal = Dimensions.Padding.large,
+                    vertical = Dimensions.Padding.extraMedium)) {
+        if (!notif.read) {
+            Box(
+                modifier =
+                    Modifier.padding(top = Dimensions.Padding.large)
+                        .size(NotificationsTabUi.NotificationCard.UNREAD_DOT_SIZE)
+                        .clip(
+                            RoundedCornerShape(
+                                NotificationsTabUi.NotificationCard.UNREAD_DOT_CORNER_RADIUS))
+                        .background(AppColors.negative)
+                        .testTag(NotificationsTabTestTags.UNREAD_DOT_PREFIX + notif.uid))
+        }
+
+        Spacer(Modifier.width(Dimensions.Spacing.large))
 
         LetterAvatar(
             letter = fallbackLetter,
-            size = 44.dp,
-            modifier = Modifier.clip(RoundedCornerShape(22.dp)),
+            size = NotificationsTabUi.NotificationCard.AVATAR_SIZE,
+            modifier = Modifier.clip(RoundedCornerShape(NotificationsTabUi.NotificationCard.AVATAR_CORNER_RADIUS)),
             imageBytes = avatarBytes)
 
-        Spacer(Modifier.width(12.dp))
+        Spacer(Modifier.width(Dimensions.Spacing.large))
 
-        Column(modifier = Modifier.weight(1f)) {
-          Text(
-              text = notif.type.label(),
-              style = MaterialTheme.typography.bodySmall,
-              fontSize = 17.sp,
-              color = AppColors.textIcons)
+        Column(modifier = Modifier.weight(Dimensions.Weight.full)) {
+            Text(
+                text = notif.type.label(),
+                style = MaterialTheme.typography.bodySmall,
+                fontSize = Dimensions.TextSize.title,
+                color = AppColors.textIcons)
 
-          val subtitle =
-              when (notif.type) {
-                NotificationType.FRIEND_REQUEST ->
-                    buildAnnotatedString {
-                      append("User ")
-                      withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append("$displayName ") }
-                      append("wants to add you as a friend.")
-                    }
-                NotificationType.JOIN_DISCUSSION ->
-                    buildAnnotatedString {
-                      append("Invited to join discussion ")
-                      withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append(displayName) }
-                    }
-                NotificationType.JOIN_SESSION ->
-                    buildAnnotatedString {
-                      append("Invited to join session ")
-                      withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append(displayName) }
-                    }
-              }
+            val subtitle =
+                when (notif.type) {
+                    NotificationType.FRIEND_REQUEST ->
+                        buildAnnotatedString {
+                            append(NotificationsTabUi.NotificationCard.Subtitles.FRIEND_REQUEST_PREFIX)
+                            withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
+                                append("$displayName ")
+                            }
+                            append(NotificationsTabUi.NotificationCard.Subtitles.FRIEND_REQUEST_SUFFIX)
+                        }
+                    NotificationType.JOIN_DISCUSSION ->
+                        buildAnnotatedString {
+                            append(NotificationsTabUi.NotificationCard.Subtitles.DISCUSSION_PREFIX)
+                            withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
+                                append(displayName)
+                            }
+                        }
+                    NotificationType.JOIN_SESSION ->
+                        buildAnnotatedString {
+                            append(NotificationsTabUi.NotificationCard.Subtitles.SESSION_PREFIX)
+                            withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
+                                append(displayName)
+                            }
+                        }
+                }
 
-          Text(
-              text = subtitle,
-              style = MaterialTheme.typography.bodySmall,
-              color = AppColors.textIconsFade,
-              modifier = Modifier.padding(top = 2.dp))
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodySmall,
+                color = AppColors.textIconsFade,
+                modifier = Modifier.padding(top = Dimensions.Padding.mediumSmall))
         }
 
-        Spacer(Modifier.width(8.dp))
+        Spacer(Modifier.width(Dimensions.Spacing.small))
 
         Column(horizontalAlignment = Alignment.End) {
-          Text(
-              text = timeText,
-              color = AppColors.textIconsFade,
-              style = MaterialTheme.typography.bodySmall)
+            Text(
+                text = timeText,
+                color = AppColors.textIconsFade,
+                style = MaterialTheme.typography.bodySmall)
         }
-      }
+    }
 }
 
 /* ---------------------------------------------------------
    BOTTOM SHEET
 --------------------------------------------------------- */
 
+/**
+ * Handles the notification popup
+ * @param notification Notification data
+ * @param data Popup data
+ * @param viewModel VM used by this screen
+ * @param onDismiss Callback upon clicking away from the popup
+ * @param onAccept Callback upon executing the notification
+ * @param onDecline Callback upon declining the notification
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NotificationSheet(
@@ -629,167 +868,232 @@ fun NotificationSheet(
     onAccept: () -> Unit,
     onDecline: () -> Unit
 ) {
-  val context = LocalContext.current
+    val context = LocalContext.current
 
-  var avatar by remember { mutableStateOf<ByteArray?>(null) }
-  var icon by remember { mutableStateOf<ByteArray?>(null) }
-  var loadedData by remember { mutableStateOf(data) }
+    var avatar by remember { mutableStateOf<ByteArray?>(null) }
+    var icon by remember { mutableStateOf<ByteArray?>(null) }
+    var loadedData by remember { mutableStateOf(data) }
 
-  LaunchedEffect(notification.uid) {
-    when (notification.type) {
-      NotificationType.FRIEND_REQUEST -> {
-        viewModel.getOtherAccount(notification.senderOrDiscussionId) { acc ->
-          viewModel.loadAccountImage(notification.senderOrDiscussionId, context) { bytes ->
-            avatar = bytes
-          }
+    LaunchedEffect(notification.uid) {
+        when (notification.type) {
+            NotificationType.FRIEND_REQUEST -> {
+                viewModel.getOtherAccount(notification.senderOrDiscussionId) { acc ->
+                    viewModel.loadAccountImage(notification.senderOrDiscussionId, context) { bytes ->
+                        avatar = bytes
+                    }
 
-          loadedData =
-              NotificationPopupData.FriendRequest(
-                  username = acc.name,
-                  handle = acc.handle,
-                  bio =
-                      if (!acc.description.isNullOrBlank()) acc.description!!
-                      else "No description provided",
-                  avatar = avatar)
-        }
-      }
-      NotificationType.JOIN_DISCUSSION -> {
-        viewModel.getDiscussion(notification.senderOrDiscussionId) { disc ->
-          viewModel.loadDiscussionImage(disc.uid, context) { bytes -> icon = bytes }
-
-          loadedData =
-              NotificationPopupData.Discussion(
-                  title = disc.name,
-                  participants = disc.participants.size,
-                  dateLabel =
-                      disc.createdAt
-                          .toDate()
-                          .toInstant()
-                          .atZone(ZoneId.systemDefault())
-                          .toLocalDate()
-                          .format(
-                              DateTimeFormatter.ofPattern(
-                                  "dd/MM/yyyy")), //   val dateLabel =
-                                                  // sentAtLocalDateTime().format(DateTimeFormatter.ofPattern("MMM d"))
-                  description = disc.description.ifBlank { "No description provided." },
-                  icon = icon)
-        }
-      }
-      NotificationType.JOIN_SESSION -> {
-        viewModel.getDiscussion(notification.senderOrDiscussionId) { disc ->
-          viewModel.loadDiscussionImage(disc.uid, context) { bytes -> avatar = bytes }
-
-          val session = disc.session
-          if (session != null) {
-            viewModel.getGame(session.gameId) { game ->
-              val dateTime =
-                  session.date.toDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime()
-
-              loadedData =
-                  NotificationPopupData.Session(
-                      title = session.name,
-                      participants = session.participants.size,
-                      dateLabel = dateTime.format(DateTimeFormatter.ofPattern("MMM d")),
-                      description =
-                          "Play ${game.name} at ${dateTime.format(DateTimeFormatter.ofPattern("h:mm a"))} at ${session.location.name}.",
-                      icon = avatar)
+                    loadedData =
+                        NotificationPopupData.FriendRequest(
+                            username = acc.name,
+                            handle = acc.handle,
+                            bio =
+                                if (!acc.description.isNullOrBlank()) acc.description!!
+                                else NotificationsTabUi.NotificationSheet.Content.NO_DESCRIPTION,
+                            avatar = avatar)
+                }
             }
-          }
-        }
-      }
-    }
-  }
+            NotificationType.JOIN_DISCUSSION -> {
+                viewModel.getDiscussion(notification.senderOrDiscussionId) { disc ->
+                    viewModel.loadDiscussionImage(disc.uid, context) { bytes -> icon = bytes }
 
-  ModalBottomSheet(
-      onDismissRequest = onDismiss,
-      containerColor = AppColors.primary,
-      contentColor = AppColors.textIcons,
-      dragHandle = null) {
-        when (val d = loadedData) {
-          is NotificationPopupData.Discussion -> {
-            NotificationSheetContent(
-                avatarBytes = d.icon,
-                title = d.title,
-                subtitle = null,
-                meta = "${d.participants} participants • ${d.dateLabel}",
-                aboutLabel =
-                    if (d.title.contains("discussion", ignoreCase = true)) "About this discussion"
-                    else "About this session",
-                description = d.description,
-                previewCharLimit = 160,
-                onAccept = onAccept,
-                onDecline = onDecline,
-                onClose = onDismiss)
-          }
-          is NotificationPopupData.Session -> {
-            NotificationSheetContent(
-                avatarBytes = d.icon,
-                title = d.title,
-                subtitle = null,
-                meta = "${d.participants} participants • ${d.dateLabel}",
-                aboutLabel =
-                    if (d.title.contains("discussion", ignoreCase = true)) "About this discussion"
-                    else "About this session",
-                description = d.description,
-                previewCharLimit = 160,
-                onAccept = onAccept,
-                onDecline = onDecline,
-                onClose = onDismiss)
-          }
-          is NotificationPopupData.FriendRequest -> {
-            NotificationSheetContent(
-                avatarBytes = d.avatar,
-                title = d.username,
-                subtitle = "@${d.handle}",
-                meta = null,
-                aboutLabel = "About",
-                description = d.bio,
-                previewCharLimit = 150,
-                onAccept = onAccept,
-                onDecline = onDecline,
-                onClose = onDismiss)
-          }
+                    loadedData =
+                        NotificationPopupData.Discussion(
+                            title = disc.name,
+                            participants = disc.participants.size,
+                            dateLabel =
+                                disc.createdAt
+                                    .toDate()
+                                    .toInstant()
+                                    .atZone(ZoneId.systemDefault())
+                                    .toLocalDate()
+                                    .format(
+                                        DateTimeFormatter.ofPattern(
+                                            NotificationsTabUi.NotificationSheet.Content.DATE_PATTERN)),
+                            description =
+                                disc.description.ifBlank {
+                                    NotificationsTabUi.NotificationSheet.Content
+                                        .NO_DESCRIPTION_DISCUSSION
+                                },
+                            icon = icon)
+                }
+            }
+            NotificationType.JOIN_SESSION -> {
+                viewModel.getDiscussion(notification.senderOrDiscussionId) { disc ->
+                    viewModel.loadDiscussionImage(disc.uid, context) { bytes -> avatar = bytes }
+
+                    val session = disc.session
+                    if (session != null) {
+                        viewModel.getGame(session.gameId) { game ->
+                            val dateTime =
+                                session.date
+                                    .toDate()
+                                    .toInstant()
+                                    .atZone(ZoneId.systemDefault())
+                                    .toLocalDateTime()
+
+                            val dateLabel =
+                                dateTime.format(
+                                    DateTimeFormatter.ofPattern(
+                                        NotificationsTabUi.NotificationSheet.Content.SESSION_DATE_PATTERN))
+                            val timeLabel =
+                                dateTime.format(
+                                    DateTimeFormatter.ofPattern(
+                                        NotificationsTabUi.NotificationSheet.Content.SESSION_TIME_PATTERN))
+
+                            loadedData =
+                                NotificationPopupData.Session(
+                                    title = session.name,
+                                    participants = session.participants.size,
+                                    dateLabel = dateLabel,
+                                    description =
+                                        NotificationsTabUi.NotificationSheet.Content.sessionDescription(
+                                            game.name, timeLabel, session.location.name),
+                                    icon = avatar)
+                        }
+                    }
+                }
+            }
         }
-      }
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        containerColor = AppColors.primary,
+        contentColor = AppColors.textIcons,
+        dragHandle = null) {
+        when (val d = loadedData) {
+            is NotificationPopupData.Discussion -> {
+                NotificationSheetContent(
+                    avatarBytes = d.icon,
+                    title = d.title,
+                    subtitle = null,
+                    meta =
+                        NotificationsTabUi.NotificationSheet.Content.participantsMeta(
+                            d.participants, d.dateLabel),
+                    aboutLabel =
+                        if (
+                            d.title.contains(
+                                NotificationsTabUi.NotificationSheet.Content.DISCUSSION_KEYWORD,
+                                ignoreCase = true))
+                            NotificationsTabUi.NotificationSheet.Content.ABOUT_DISCUSSION
+                        else NotificationsTabUi.NotificationSheet.Content.ABOUT_SESSION,
+                    description = d.description,
+                    previewCharLimit =
+                        NotificationsTabUi.NotificationSheet.Content.DISCUSSION_PREVIEW_CHAR_LIMIT,
+                    onAccept = onAccept,
+                    onDecline = onDecline,
+                    onClose = onDismiss)
+            }
+            is NotificationPopupData.Session -> {
+                NotificationSheetContent(
+                    avatarBytes = d.icon,
+                    title = d.title,
+                    subtitle = null,
+                    meta =
+                        NotificationsTabUi.NotificationSheet.Content.participantsMeta(
+                            d.participants, d.dateLabel),
+                    aboutLabel =
+                        if (
+                            d.title.contains(
+                                NotificationsTabUi.NotificationSheet.Content.DISCUSSION_KEYWORD,
+                                ignoreCase = true))
+                            NotificationsTabUi.NotificationSheet.Content.ABOUT_DISCUSSION
+                        else NotificationsTabUi.NotificationSheet.Content.ABOUT_SESSION,
+                    description = d.description,
+                    previewCharLimit =
+                        NotificationsTabUi.NotificationSheet.Content.SESSION_PREVIEW_CHAR_LIMIT,
+                    onAccept = onAccept,
+                    onDecline = onDecline,
+                    onClose = onDismiss)
+            }
+            is NotificationPopupData.FriendRequest -> {
+                NotificationSheetContent(
+                    avatarBytes = d.avatar,
+                    title = d.username,
+                    subtitle =
+                        NotificationsTabUi.NotificationSheet.Content.HANDLE_PREFIX + d.handle,
+                    meta = null,
+                    aboutLabel = NotificationsTabUi.NotificationSheet.Content.ABOUT_FRIEND,
+                    description = d.bio,
+                    previewCharLimit =
+                        NotificationsTabUi.NotificationSheet.Content.FRIEND_PREVIEW_CHAR_LIMIT,
+                    onAccept = onAccept,
+                    onDecline = onDecline,
+                    onClose = onDismiss)
+            }
+        }
+    }
 }
 
+/**
+ * Buttons at the bottom of the popup sheet. Only reason they're inside their
+ * own composable is to make the above composable easier to read
+ * @param onDecline Callback upon declining the notification
+ * @param onAccept Callback upon executing the notification
+ */
 @Composable
 fun BottomSheetButtons(onDecline: () -> Unit, onAccept: () -> Unit) {
-  Row(
-      modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 20.dp),
-      horizontalArrangement = Arrangement.SpaceBetween) {
+    Row(
+        modifier =
+            Modifier.fillMaxWidth()
+                .padding(
+                    horizontal = Dimensions.Padding.extraLarge,
+                    vertical = Dimensions.Padding.xLarge),
+        horizontalArrangement = Arrangement.SpaceBetween) {
         Button(
             onClick = onDecline,
             colors =
                 ButtonDefaults.buttonColors(
                     containerColor = AppColors.negative, contentColor = AppColors.textIcons),
-            shape = RoundedCornerShape(8.dp),
+            shape = RoundedCornerShape(Dimensions.CornerRadius.medium),
             elevation = ButtonDefaults.buttonElevation(Dimensions.Elevation.medium),
             modifier = Modifier.testTag(NotificationsTabTestTags.SHEET_DECLINE_BUTTON),
-            contentPadding = PaddingValues(horizontal = 20.dp, vertical = 10.dp)) {
-              Row(verticalAlignment = Alignment.CenterVertically) {
+            contentPadding =
+                PaddingValues(
+                    horizontal = Dimensions.Padding.xLarge,
+                    vertical = Dimensions.Padding.extraMedium)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
                 Icon(Icons.Default.Close, null)
-                Text("Decline", modifier = Modifier.padding(4.dp))
-              }
+                Text(
+                    NotificationsTabUi.NotificationSheet.Buttons.DECLINE_TEXT,
+                    modifier = Modifier.padding(Dimensions.Padding.small))
             }
+        }
 
         Button(
             onClick = onAccept,
             colors =
                 ButtonDefaults.buttonColors(
                     containerColor = AppColors.affirmative, contentColor = AppColors.textIcons),
-            shape = RoundedCornerShape(12.dp),
+            shape = RoundedCornerShape(Dimensions.CornerRadius.large),
             elevation = ButtonDefaults.buttonElevation(Dimensions.Elevation.medium),
             modifier = Modifier.testTag(NotificationsTabTestTags.SHEET_ACCEPT_BUTTON),
-            contentPadding = PaddingValues(horizontal = 20.dp, vertical = 10.dp)) {
-              Row(verticalAlignment = Alignment.CenterVertically) {
+            contentPadding =
+                PaddingValues(
+                    horizontal = Dimensions.Padding.xLarge,
+                    vertical = Dimensions.Padding.extraMedium)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
                 Icon(Icons.Default.Check, null)
-                Text("Accept", modifier = Modifier.padding(4.dp))
-              }
+                Text(
+                    NotificationsTabUi.NotificationSheet.Buttons.ACCEPT_TEXT,
+                    modifier = Modifier.padding(Dimensions.Padding.small))
             }
-      }
+        }
+    }
 }
 
+/**
+ * Creates the sheet's content and formats everything.
+ * @param avatarBytes Used to display profile pictures
+ * @param title Title of the sheet
+ * @param subtitle Smaller text under the title
+ * @param meta Used for dates/handles
+ * @param description User/discussion/session description
+ * @param previewCharLimit Limit of how many chars to show
+ * @param onAccept Callback upon accepting the request
+ * @param onDecline Callback upon declining the request
+ * @param onClose Callback upon closing the popup
+ */
 @Composable
 fun NotificationSheetContent(
     avatarBytes: ByteArray?,
@@ -803,83 +1107,108 @@ fun NotificationSheetContent(
     onDecline: () -> Unit,
     onClose: () -> Unit
 ) {
-  Column(modifier = Modifier.padding(20.dp)) {
-    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
-      Icon(
-          Icons.Default.Close,
-          "Close",
-          tint = AppColors.textIcons,
-          modifier = Modifier.clickable { onClose() })
-    }
-
-    Spacer(Modifier.height(4.dp))
-
-    Row(verticalAlignment = Alignment.CenterVertically) {
-      LetterAvatar(letter = title.firstOrNull() ?: '•', size = 52.dp, imageBytes = avatarBytes)
-
-      Spacer(Modifier.width(12.dp))
-
-      Column {
-        Text(
-            title,
-            style = MaterialTheme.typography.titleLarge,
-            color = AppColors.textIcons,
-            modifier = Modifier.testTag(NotificationsTabTestTags.SHEET_TITLE))
-        if (subtitle != null) {
-          Text(subtitle, style = MaterialTheme.typography.bodyMedium, color = AppColors.textIcons)
+    Column(modifier = Modifier.padding(Dimensions.Padding.xLarge)) {
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+            Icon(
+                Icons.Default.Close,
+                NotificationsTabUi.NotificationSheet.Content.CLOSE_ICON_DESCRIPTION,
+                tint = AppColors.textIcons,
+                modifier = Modifier.clickable { onClose() })
         }
-      }
+
+        Spacer(Modifier.height(Dimensions.Spacing.small))
+
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            LetterAvatar(
+                letter =
+                    title.firstOrNull()
+                        ?: NotificationsTabUi.NotificationCard.Fallbacks.FALLBACK_LETTER,
+                size = NotificationsTabUi.NotificationSheet.AVATAR_SIZE,
+                imageBytes = avatarBytes)
+
+            Spacer(Modifier.width(Dimensions.Spacing.large))
+
+            Column {
+                Text(
+                    title,
+                    style = MaterialTheme.typography.titleLarge,
+                    color = AppColors.textIcons,
+                    modifier = Modifier.testTag(NotificationsTabTestTags.SHEET_TITLE))
+                if (subtitle != null) {
+                    Text(
+                        subtitle, style = MaterialTheme.typography.bodyMedium, color = AppColors.textIcons)
+                }
+            }
+        }
+
+        if (meta != null) {
+            Spacer(Modifier.height(Dimensions.Spacing.medium))
+            Text(meta, style = MaterialTheme.typography.bodyMedium, color = AppColors.textIconsFade)
+        }
+
+        Spacer(Modifier.height(Dimensions.Spacing.extraLarge))
+
+        Text(
+            text = aboutLabel,
+            style = MaterialTheme.typography.titleMedium,
+            color = AppColors.textIcons,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.padding(bottom = Dimensions.Padding.mediumSmall))
+
+        ExpandableText(
+            text = description,
+            previewCharLimit = previewCharLimit,
+            modifier = Modifier.testTag(NotificationsTabTestTags.SHEET_DESCRIPTION))
+
+        Spacer(Modifier.height(Dimensions.Spacing.xLarge))
+
+        BottomSheetButtons(onDecline, onAccept)
     }
-
-    if (meta != null) {
-      Spacer(Modifier.height(8.dp))
-      Text(meta, style = MaterialTheme.typography.bodyMedium, color = AppColors.textIconsFade)
-    }
-
-    Spacer(Modifier.height(16.dp))
-
-    Text(
-        text = aboutLabel,
-        style = MaterialTheme.typography.titleMedium,
-        color = AppColors.textIcons,
-        fontWeight = FontWeight.SemiBold,
-        modifier = Modifier.padding(bottom = 6.dp))
-
-    ExpandableText(
-        text = description,
-        previewCharLimit = previewCharLimit,
-        modifier = Modifier.testTag(NotificationsTabTestTags.SHEET_DESCRIPTION))
-
-    Spacer(Modifier.height(20.dp))
-
-    BottomSheetButtons(onDecline, onAccept)
-  }
 }
 
-/* ---------------------------------------------------------
-   EXPANDABLE TEXT / AVATAR / EMPTY STATE
---------------------------------------------------------- */
 
+/**
+ * Composable to manage expandable text
+ * @param text Text that can be too long
+ * @param previewCharLimit Limit to how many characters to display
+ * @param modifier Modifier applied to this composable
+ */
 @Composable
-fun ExpandableText(text: String, previewCharLimit: Int = 160, modifier: Modifier = Modifier) {
-  var expanded by remember { mutableStateOf(false) }
+fun ExpandableText(
+    text: String,
+    previewCharLimit: Int = NotificationsTabUi.ExpandableText.DEFAULT_PREVIEW_CHAR_LIMIT,
+    modifier: Modifier = Modifier
+) {
+    var expanded by remember { mutableStateOf(false) }
 
-  Column(modifier = modifier.semantics(mergeDescendants = true) {}) {
-    Text(
-        if (expanded || text.length <= previewCharLimit) text
-        else text.take(previewCharLimit) + "…",
-        color = AppColors.textIcons)
+    Column(modifier = modifier.semantics(mergeDescendants = true) {}) {
+        Text(
+            if (expanded || text.length <= previewCharLimit) text
+            else text.take(previewCharLimit) + NotificationsTabUi.ExpandableText.MORE_INDICATOR,
+            color = AppColors.textIcons)
 
-    if (text.length > previewCharLimit) {
-      Text(
-          text = if (expanded) "Show less" else "Show more",
-          color = AppColors.textIcons,
-          fontWeight = FontWeight.Bold,
-          modifier = Modifier.padding(top = 4.dp).clickable { expanded = !expanded })
+        if (text.length > previewCharLimit) {
+            Text(
+                text =
+                    if (expanded) NotificationsTabUi.ExpandableText.SHOW_LESS
+                    else NotificationsTabUi.ExpandableText.SHOW_MORE,
+                color = AppColors.textIcons,
+                fontWeight = FontWeight.Bold,
+                modifier =
+                    Modifier.padding(top = Dimensions.Padding.small).clickable {
+                        expanded = !expanded
+                    })
+        }
     }
-  }
 }
 
+/**
+ * Fallback when user/discussion do not have a picture
+ * @param letter Letter to use for the fake avatar
+ * @param size Size of the avatar bubble
+ * @param modifier Modifiers to apply to this screen
+ * @param imageBytes Image to display if available
+ */
 @Composable
 fun LetterAvatar(
     letter: Char,
@@ -887,44 +1216,52 @@ fun LetterAvatar(
     modifier: Modifier = Modifier,
     imageBytes: ByteArray? = null
 ) {
-  if (imageBytes != null) {
-    AsyncImage(
-        model = imageBytes,
-        contentDescription = null,
-        contentScale = ContentScale.Crop,
-        modifier = modifier.size(size).clip(CircleShape))
-  } else {
-    Box(
-        modifier = modifier.size(size).clip(CircleShape).background(AppColors.neutral),
-        contentAlignment = Alignment.Center) {
-          Text(
-              text = letter.uppercase(),
-              color = AppColors.primary,
-              fontSize = (size.value * 0.45).sp,
-              fontWeight = FontWeight.Bold)
+    if (imageBytes != null) {
+        AsyncImage(
+            model = imageBytes,
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = modifier.size(size).clip(CircleShape))
+    } else {
+        Box(
+            modifier = modifier.size(size).clip(CircleShape).background(AppColors.neutral),
+            contentAlignment = Alignment.Center) {
+            Text(
+                text = letter.uppercase(),
+                color = AppColors.primary,
+                fontSize =
+                    (size.value * NotificationsTabUi.LetterAvatar.SIZE_MULTIPLIER).sp,
+                fontWeight = FontWeight.Bold)
         }
-  }
+    }
 }
 
+/**
+ * Handles no notification being available for a filter
+ * @param filter Selected filter
+ * @param modifier Modifiers to apply to this composable
+ */
 @Composable
 fun EmptyNotificationState(filter: NotificationFilter, modifier: Modifier = Modifier) {
-  val message =
-      when (filter) {
-        NotificationFilter.ALL -> "You have no notifications yet."
-        NotificationFilter.UNREAD -> "You're all caught up! No unread notifications."
-        NotificationFilter.FRIEND_REQUESTS -> "No incoming friend requests."
-        NotificationFilter.DISCUSSIONS -> "No discussion invitations."
-        NotificationFilter.SESSIONS -> "No session invitations."
-      }
+    val message =
+        when (filter) {
+            NotificationFilter.ALL -> NotificationsTabUi.EmptyState.Messages.ALL
+            NotificationFilter.UNREAD -> NotificationsTabUi.EmptyState.Messages.UNREAD
+            NotificationFilter.FRIEND_REQUESTS ->
+                NotificationsTabUi.EmptyState.Messages.FRIEND_REQUESTS
+            NotificationFilter.DISCUSSIONS -> NotificationsTabUi.EmptyState.Messages.DISCUSSIONS
+            NotificationFilter.SESSIONS -> NotificationsTabUi.EmptyState.Messages.SESSIONS
+        }
 
-  Column(
-      modifier = modifier.fillMaxSize().padding(32.dp),
-      verticalArrangement = Arrangement.Center,
-      horizontalAlignment = Alignment.CenterHorizontally) {
+    Column(
+        modifier =
+            modifier.fillMaxSize().padding(Dimensions.Padding.xxxLarge),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally) {
         Text(
             text = message,
             color = AppColors.textIconsFade,
             style = MaterialTheme.typography.bodyLarge,
             modifier = Modifier.testTag(NotificationsTabTestTags.EMPTY_STATE_TEXT))
-      }
+    }
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/account/NotificationsTab.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/NotificationsTab.kt
@@ -311,8 +311,6 @@ fun NotificationsTab(
     viewModel: NotificationsViewModel = viewModel(),
     onBack: () -> Unit
 ) {
-  val scope = rememberCoroutineScope()
-
   val filters = NotificationFilter.entries
   var selectedFilter by remember { mutableStateOf(NotificationFilter.ALL) }
 
@@ -1134,8 +1132,8 @@ fun NotificationSheetContent(
 @Composable
 fun ExpandableText(
     text: String,
-    previewCharLimit: Int = NotificationsTabUi.ExpandableText.DEFAULT_PREVIEW_CHAR_LIMIT,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    previewCharLimit: Int = NotificationsTabUi.ExpandableText.DEFAULT_PREVIEW_CHAR_LIMIT
 ) {
   var expanded by remember { mutableStateOf(false) }
 

--- a/app/src/main/java/com/github/meeplemeet/ui/account/NotificationsTab.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/NotificationsTab.kt
@@ -55,7 +55,6 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier

--- a/app/src/main/java/com/github/meeplemeet/ui/account/NotificationsTab.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/NotificationsTab.kt
@@ -1,0 +1,917 @@
+package com.github.meeplemeet.ui.account
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.DismissDirection
+import androidx.compose.material.DismissState
+import androidx.compose.material.DismissValue
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.FractionalThreshold
+import androidx.compose.material.SwipeToDismiss
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.ChevronLeft
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.MarkChatRead
+import androidx.compose.material.rememberDismissState
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.github.meeplemeet.R
+import com.github.meeplemeet.model.account.Account
+import com.github.meeplemeet.model.account.ProfileScreenViewModel
+import com.github.meeplemeet.ui.navigation.NavigationTestTags
+import com.github.meeplemeet.ui.theme.AppColors
+import com.github.meeplemeet.ui.theme.Dimensions
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+/* ---------------------------------------------------------
+   UI Test Tags
+--------------------------------------------------------- */
+
+object NotificationsTabTestTags {
+  const val HEADER_TITLE = "header_title"
+}
+
+/* ---------------------------------------------------------
+   BACKEND-READY MODELS
+--------------------------------------------------------- */
+
+data class Notification(
+    val id: Int,
+    val type: NotificationType,
+    val variableText: String, // The bold part
+    val time: LocalDateTime,
+    val isUnread: Boolean,
+    val icon: Painter // Replace with URL later
+)
+
+enum class NotificationType {
+  FRIEND_REQUEST,
+  DISCUSSION_INVITE,
+  SESSION_INVITE
+}
+
+/* ---------------------------------------------------------
+   MESSAGE BUILDING (prefix + variable + suffix)
+--------------------------------------------------------- */
+
+data class NotificationParts(val prefix: String, val bold: String, val suffix: String)
+
+fun Notification.parts(): NotificationParts {
+  return when (type) {
+    NotificationType.FRIEND_REQUEST ->
+        NotificationParts(
+            prefix = "", bold = variableText, suffix = " wants to add you as a friend!")
+    NotificationType.DISCUSSION_INVITE ->
+        NotificationParts(
+            prefix = "You've been invited to join ", bold = variableText, suffix = "!")
+    NotificationType.SESSION_INVITE ->
+        NotificationParts(
+            prefix = "You've been invited to join ", bold = variableText, suffix = "!")
+  }
+}
+
+/* ---------------------------------------------------------
+   GROUPING: Today / Yesterday / Earlier
+--------------------------------------------------------- */
+
+data class NotificationSection(val header: String, val items: List<Notification>)
+
+fun groupNotifications(list: List<Notification>): List<NotificationSection> {
+  val today = LocalDate.now()
+  val yesterday = today.minusDays(1)
+
+  val todayItems = list.filter { it.time.toLocalDate() == today }
+  val yesterdayItems = list.filter { it.time.toLocalDate() == yesterday }
+  val earlierItems =
+      list.filter {
+        val d = it.time.toLocalDate()
+        d != today && d != yesterday
+      }
+
+  val sections = mutableListOf<NotificationSection>()
+  if (todayItems.isNotEmpty()) sections.add(NotificationSection("Today", todayItems))
+  if (yesterdayItems.isNotEmpty()) sections.add(NotificationSection("Yesterday", yesterdayItems))
+  if (earlierItems.isNotEmpty()) sections.add(NotificationSection("Earlier", earlierItems))
+
+  return sections
+}
+
+sealed class NotificationPopupData {
+  data class Discussion(
+      val title: String,
+      val participants: Int,
+      val dateLabel: String,
+      val description: String,
+      val icon: Painter
+  ) : NotificationPopupData()
+
+  data class Session(
+      val title: String,
+      val participants: Int,
+      val dateLabel: String,
+      val description: String,
+      val icon: Painter
+  ) : NotificationPopupData()
+
+  data class FriendRequest(
+      val username: String,
+      val handle: String,
+      val bio: String,
+      val avatar: Painter
+  ) : NotificationPopupData()
+}
+
+/* ---------------------------------------------------------
+   MAIN SCREEN
+--------------------------------------------------------- */
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NotificationsTab(
+    account: Account,
+    viewModel: ProfileScreenViewModel = viewModel(),
+    onBack: () -> Unit
+) {
+  val filters = NotificationFilter.entries
+  var selectedFilter by remember { mutableStateOf(NotificationFilter.ALL) }
+
+  // Replace with VM later
+  val notifications = rememberDummyNotifications()
+  val grouped = groupNotifications(notifications.value)
+  var sheetData by remember { mutableStateOf<NotificationPopupData?>(null) }
+
+  if (sheetData != null) {
+    NotificationSheet(
+        data = sheetData!!,
+        onDismiss = { sheetData = null },
+        onAccept = { sheetData = null },
+        onDecline = { sheetData = null })
+  }
+
+  Scaffold(
+      topBar = {
+        CenterAlignedTopAppBar(
+            colors =
+                TopAppBarDefaults.centerAlignedTopAppBarColors(
+                    containerColor = AppColors.primary,
+                    titleContentColor = AppColors.textIcons,
+                    navigationIconContentColor = AppColors.textIcons),
+            title = {
+              Text(
+                  text = "Notifications",
+                  modifier = Modifier.testTag(NotificationsTabTestTags.HEADER_TITLE))
+            },
+            navigationIcon = {
+              IconButton(onClick = onBack) {
+                Icon(
+                    Icons.AutoMirrored.Filled.ArrowBack,
+                    modifier = Modifier.testTag(NavigationTestTags.GO_BACK_BUTTON),
+                    contentDescription = "Back")
+              }
+            })
+      }) { padding ->
+        Column(modifier = Modifier.padding(padding).fillMaxSize()) {
+          FilterRow(
+              filters = filters, selected = selectedFilter, onSelected = { selectedFilter = it })
+
+          LazyColumn(modifier = Modifier.fillMaxSize().padding(top = 16.dp)) {
+            grouped.forEachIndexed { index, section ->
+              if (index > 0) {
+                item { Spacer(Modifier.height(20.dp)) }
+              }
+
+              item {
+                Text(
+                    text = section.header,
+                    style = MaterialTheme.typography.titleLarge.copy(fontSize = 22.sp),
+                    color = AppColors.textIcons,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
+              }
+
+              items(section.items, key = { it.id }) { notif ->
+                NotificationListItem(
+                    notif = notif,
+                    onClick = { sheetData = notif.toPopupData() },
+                    onMarkRead = {
+                      val list = notifications.value.toMutableList()
+                      val idx = list.indexOfFirst { it.id == notif.id }
+                      if (idx != -1) {
+                        list[idx] = list[idx].copy(isUnread = false)
+                      }
+                      notifications.value = list
+                    },
+                    onDelete = {
+                      notifications.value = notifications.value.filterNot { it.id == notif.id }
+                    })
+              }
+            }
+          }
+        }
+      }
+}
+
+/* ---------------------------------------------------------
+   FILTER ROW + CHIP
+--------------------------------------------------------- */
+
+@Composable
+fun FilterRow(
+    filters: List<NotificationFilter>,
+    selected: NotificationFilter,
+    onSelected: (NotificationFilter) -> Unit,
+) {
+  val scrollState = rememberScrollState()
+
+  val showLeftFade by remember { derivedStateOf { scrollState.value > 0 } }
+  val showRightFade by remember { derivedStateOf { scrollState.value < scrollState.maxValue } }
+
+  Column(modifier = Modifier.fillMaxWidth()) {
+    val padLimit = 24
+    val dynamicPaddingStart = if (scrollState.value <= padLimit) scrollState.value else padLimit
+    val dynamicPaddingEnd =
+        if (scrollState.maxValue - scrollState.value <= padLimit)
+            (scrollState.maxValue - scrollState.value)
+        else padLimit
+
+    Box(
+        modifier =
+            Modifier.fillMaxWidth()
+                .height(40.dp)
+                .padding(start = dynamicPaddingStart.dp, end = dynamicPaddingEnd.dp)) {
+
+          // === SCROLLABLE CHIP ROW ===
+          Row(modifier = Modifier.horizontalScroll(scrollState).padding(horizontal = 12.dp)) {
+            filters.forEach { filter ->
+              val isSelected = filter == selected
+
+              FilterChip(
+                  text = filter.label, selected = isSelected, onClick = { onSelected(filter) })
+
+              Spacer(Modifier.width(16.dp))
+            }
+          }
+
+          // === LEFT FADE ===
+          if (showLeftFade) {
+            Box(
+                modifier =
+                    Modifier.align(Alignment.CenterStart)
+                        .width(32.dp)
+                        .fillMaxHeight()
+                        .background(
+                            Brush.horizontalGradient(
+                                listOf(
+                                    AppColors.primary,
+                                    AppColors.primary.copy(alpha = 0.7f),
+                                    Color.Transparent))))
+          }
+
+          // === RIGHT FADE ===
+          if (showRightFade) {
+            Box(
+                modifier =
+                    Modifier.align(Alignment.CenterEnd)
+                        .width(32.dp)
+                        .fillMaxHeight()
+                        .background(
+                            Brush.horizontalGradient(listOf(Color.Transparent, AppColors.primary))))
+          }
+        }
+
+    // === ARROWS BELOW CHIPS (visual cue only) ===
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(top = 4.dp, start = 12.dp, end = 12.dp),
+        horizontalArrangement = Arrangement.SpaceBetween) {
+          if (showLeftFade) {
+            Icon(
+                imageVector = Icons.Default.ChevronLeft,
+                contentDescription = null,
+                tint = AppColors.textIconsFade)
+          } else {
+            Spacer(Modifier.size(24.dp))
+          }
+
+          if (showRightFade) {
+            Icon(
+                imageVector = Icons.Default.ChevronRight,
+                contentDescription = null,
+                tint = AppColors.textIconsFade)
+          } else {
+            Spacer(Modifier.size(24.dp))
+          }
+        }
+  }
+}
+
+@Composable
+fun FilterChip(text: String, selected: Boolean, onClick: () -> Unit) {
+  val border = if (selected) AppColors.neutral else AppColors.textIconsFade
+
+  Box(
+      modifier =
+          Modifier.clip(RoundedCornerShape(4.dp))
+              .background(Color.Transparent)
+              .border(if (selected) 2.dp else 1.dp, border, RoundedCornerShape(16.dp))
+              .clickable { onClick() }
+              .padding(horizontal = 16.dp, vertical = 8.dp)) {
+        Text(text = text, color = AppColors.textIcons)
+      }
+}
+
+enum class NotificationFilter(val label: String) {
+  ALL("All"),
+  UNREAD("Unread"),
+  FRIEND_REQUESTS("Friend requests"),
+  DISCUSSIONS("Discussions"),
+  SESSIONS("Sessions")
+}
+
+/* ---------------------------------------------------------
+   LIST ITEM (CARD + DIVIDER)
+--------------------------------------------------------- */
+
+@Composable
+fun NotificationListItem(
+    notif: Notification,
+    onClick: () -> Unit,
+    onMarkRead: () -> Unit,
+    onDelete: () -> Unit
+) {
+  Column(modifier = Modifier.fillMaxWidth().clickable { onClick() }) {
+    NotificationCard(notif = notif, onDelete = onDelete, onMarkRead = onMarkRead)
+    HorizontalDivider(
+        modifier = Modifier.fillMaxWidth().padding(start = 68.dp, end = 16.dp),
+        color = AppColors.textIcons.copy(alpha = 0.4f))
+  }
+}
+
+/* ---------------------------------------------------------
+   SWIPE CARD
+--------------------------------------------------------- */
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class)
+@Composable
+fun NotificationCard(notif: Notification, onDelete: () -> Unit, onMarkRead: () -> Unit) {
+  val dismissState =
+      rememberDismissState(
+          confirmStateChange = { state ->
+            when (state) {
+              DismissValue.DismissedToStart -> {
+                onDelete()
+                false
+              }
+              DismissValue.DismissedToEnd -> {
+                onMarkRead()
+                false
+              }
+              else -> false
+            }
+          })
+
+  SwipeToDismiss(
+      state = dismissState,
+      background = { SwipeBackground(dismissState) },
+      dismissContent = { NotificationContent(notif = notif) },
+      directions = setOf(DismissDirection.StartToEnd, DismissDirection.EndToStart),
+      dismissThresholds = { direction ->
+        when (direction) {
+          DismissDirection.StartToEnd -> FractionalThreshold(0.10f) // mark read
+          DismissDirection.EndToStart -> FractionalThreshold(0.40f) // delete
+        }
+      })
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+private fun SwipeBackground(state: DismissState) {
+  val direction = state.dismissDirection ?: return
+
+  val isTriggered = state.targetValue != DismissValue.Default
+  val scale by animateFloatAsState(if (isTriggered) 1.3f else 1f)
+
+  val color =
+      when (direction) {
+        DismissDirection.StartToEnd -> AppColors.neutral
+        DismissDirection.EndToStart -> AppColors.negative
+      }
+
+  Box(
+      modifier = Modifier.fillMaxSize().background(color).padding(horizontal = 20.dp),
+      contentAlignment =
+          when (direction) {
+            DismissDirection.StartToEnd -> Alignment.CenterStart
+            DismissDirection.EndToStart -> Alignment.CenterEnd
+          }) {
+        val icon =
+            when (direction) {
+              DismissDirection.StartToEnd -> Icons.Default.MarkChatRead
+              DismissDirection.EndToStart -> Icons.Default.Delete
+            }
+
+        Icon(icon, contentDescription = null, tint = Color.White, modifier = Modifier.scale(scale))
+      }
+}
+
+/* ---------------------------------------------------------
+   CARD CONTENT
+--------------------------------------------------------- */
+
+@Composable
+private fun NotificationContent(notif: Notification) {
+
+  val date = notif.time.toLocalDate()
+  val today = LocalDate.now()
+  val yesterday = today.minusDays(1)
+
+  val timeText =
+      when (date) {
+        today,
+        yesterday -> notif.time.format(DateTimeFormatter.ofPattern("h:mm a"))
+        else -> notif.time.format(DateTimeFormatter.ofPattern("dd/MM/yyyy"))
+      }
+
+  val parts = notif.parts()
+
+  Row(
+      modifier =
+          Modifier.background(AppColors.primary)
+              .fillMaxWidth()
+              .padding(horizontal = 12.dp, vertical = 10.dp)) {
+        Icon(
+            painter = notif.icon,
+            contentDescription = null,
+            modifier = Modifier.width(44.dp).clip(RoundedCornerShape(22.dp)))
+
+        Spacer(Modifier.width(12.dp))
+
+        Column(modifier = Modifier.weight(1f)) {
+          Text(
+              text = notif.type.label(),
+              style = MaterialTheme.typography.bodySmall,
+              fontSize = 17.sp,
+              color = AppColors.textIcons)
+
+          Text(
+              text =
+                  buildAnnotatedString {
+                    append(parts.prefix)
+                    withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append(parts.bold) }
+                    append(parts.suffix)
+                  },
+              style = MaterialTheme.typography.bodySmall,
+              color = AppColors.textIconsFade,
+              modifier = Modifier.padding(top = 2.dp))
+        }
+
+        Spacer(Modifier.width(8.dp))
+
+        Column(horizontalAlignment = Alignment.End) {
+          Text(
+              text = timeText,
+              style = MaterialTheme.typography.bodySmall,
+              color = AppColors.textIconsFade)
+
+          if (notif.isUnread) {
+            Box(
+                modifier =
+                    Modifier.padding(top = 6.dp)
+                        .size(10.dp)
+                        .clip(RoundedCornerShape(50))
+                        .background(AppColors.negative))
+          }
+        }
+      }
+}
+
+/* ---------------------------------------------------------
+   EXTENSION FOR DISPLAY NAME
+--------------------------------------------------------- */
+
+fun NotificationType.label(): String {
+  return when (this) {
+    NotificationType.FRIEND_REQUEST -> "Incoming friend request"
+    NotificationType.DISCUSSION_INVITE -> "Incoming discussion invite"
+    NotificationType.SESSION_INVITE -> "Incoming session invite"
+  }
+}
+
+@Composable
+fun ExpandableText(text: String, previewCharLimit: Int = 160, modifier: Modifier = Modifier) {
+  var expanded by remember { mutableStateOf(false) }
+
+  Column(modifier = modifier) {
+    Text(
+        text =
+            if (expanded || text.length <= previewCharLimit) text
+            else text.take(previewCharLimit) + "…",
+        color = AppColors.textIcons)
+
+    if (text.length > previewCharLimit) {
+      Text(
+          text = if (expanded) "Show less" else "Show more",
+          color = AppColors.textIcons,
+          fontWeight = FontWeight.Bold,
+          modifier = Modifier.padding(top = 4.dp).clickable { expanded = !expanded })
+    }
+  }
+}
+
+@Composable
+fun ExpandableAnnotatedBio(username: String, fullBio: String, previewCharLimit: Int = 150) {
+  var expanded by remember { mutableStateOf(false) }
+
+  fun annotate(text: String): AnnotatedString {
+    return buildAnnotatedString {
+      withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append(username) }
+      append(text.removePrefix(username))
+    }
+  }
+
+  if (fullBio.length <= previewCharLimit) {
+    Text(annotate(fullBio))
+  } else {
+    Column {
+      val preview = fullBio.take(previewCharLimit) + "…"
+      Text(annotate(if (expanded) fullBio else preview))
+
+      Text(
+          text = if (expanded) "Show less" else "Show more",
+          color = MaterialTheme.colorScheme.primary,
+          fontWeight = FontWeight.Bold,
+          modifier = Modifier.padding(top = 4.dp).clickable { expanded = !expanded })
+    }
+  }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NotificationSheet(
+    data: NotificationPopupData,
+    onDismiss: () -> Unit,
+    onAccept: () -> Unit,
+    onDecline: () -> Unit
+) {
+  ModalBottomSheet(
+      onDismissRequest = onDismiss,
+      containerColor = AppColors.primary,
+      contentColor = AppColors.textIcons,
+      dragHandle = null) {
+        when (data) {
+          is NotificationPopupData.Discussion ->
+              DiscussionSessionSheetContent(
+                  title = data.title,
+                  participants = data.participants,
+                  dateLabel = data.dateLabel,
+                  description = data.description,
+                  icon = data.icon,
+                  onAccept = onAccept,
+                  onDecline = onDecline,
+                  onClose = onDismiss)
+          is NotificationPopupData.Session ->
+              DiscussionSessionSheetContent(
+                  title = data.title,
+                  participants = data.participants,
+                  dateLabel = data.dateLabel,
+                  description = data.description,
+                  icon = data.icon,
+                  onAccept = onAccept,
+                  onDecline = onDecline,
+                  onClose = onDismiss)
+          is NotificationPopupData.FriendRequest ->
+              FriendRequestSheetContent(
+                  username = data.username,
+                  handle = data.handle,
+                  bio = data.bio,
+                  avatar = data.avatar,
+                  onAccept = onAccept,
+                  onDecline = onDecline,
+                  onClose = onDismiss)
+        }
+      }
+}
+
+@Composable
+fun BottomSheetButtons(onDecline: () -> Unit, onAccept: () -> Unit) {
+  Row(
+      modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 20.dp),
+      horizontalArrangement = Arrangement.SpaceBetween) {
+        Button(
+            onClick = onDecline,
+            colors =
+                ButtonDefaults.buttonColors(
+                    containerColor = AppColors.negative, contentColor = AppColors.textIcons),
+            shape = RoundedCornerShape(8.dp),
+            elevation = ButtonDefaults.buttonElevation(Dimensions.Elevation.medium),
+            contentPadding = PaddingValues(horizontal = 20.dp, vertical = 10.dp)) {
+              Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(imageVector = Icons.Default.Close, contentDescription = null)
+                Text(text = "Decline", modifier = Modifier.padding(4.dp))
+              }
+            }
+
+        Button(
+            onClick = onAccept,
+            colors =
+                ButtonDefaults.buttonColors(
+                    containerColor = AppColors.affirmative, contentColor = AppColors.textIcons),
+            shape = RoundedCornerShape(12.dp),
+            elevation = ButtonDefaults.buttonElevation(Dimensions.Elevation.medium),
+            contentPadding = PaddingValues(horizontal = 20.dp, vertical = 10.dp)) {
+              Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(imageVector = Icons.Default.Check, contentDescription = null)
+                Text(text = "Accept", modifier = Modifier.padding(4.dp))
+              }
+            }
+      }
+}
+
+@Composable
+fun DiscussionSessionSheetContent(
+    title: String,
+    participants: Int,
+    dateLabel: String,
+    description: String,
+    icon: Painter,
+    onAccept: () -> Unit,
+    onDecline: () -> Unit,
+    onClose: () -> Unit
+) {
+  Column(modifier = Modifier.padding(20.dp)) {
+
+    // Close button
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+      Icon(
+          imageVector = Icons.Default.Close,
+          contentDescription = "Close",
+          tint = AppColors.textIcons,
+          modifier = Modifier.clickable { onClose() })
+    }
+
+    Spacer(Modifier.height(4.dp))
+
+    // Title area
+    Row(verticalAlignment = Alignment.CenterVertically) {
+      Icon(
+          painter = icon,
+          contentDescription = null,
+          modifier = Modifier.size(48.dp).clip(RoundedCornerShape(12.dp)))
+      Spacer(Modifier.width(12.dp))
+      Text(
+          text = title,
+          style = MaterialTheme.typography.titleLarge,
+          color = AppColors.textIconsFade)
+    }
+
+    Spacer(Modifier.height(8.dp))
+
+    Text(
+        text = "$participants participants • $dateLabel",
+        style = MaterialTheme.typography.bodyMedium,
+        color = AppColors.textIconsFade)
+
+    Spacer(Modifier.height(16.dp))
+
+    // Header for description
+    Text(
+        text =
+            if (title.contains("discussion", ignoreCase = true)) "About this discussion"
+            else "About this session",
+        style = MaterialTheme.typography.titleMedium,
+        color = AppColors.textIcons,
+        fontWeight = FontWeight.SemiBold,
+        modifier = Modifier.padding(bottom = 6.dp))
+
+    // Expandable long description
+    ExpandableText(text = description, previewCharLimit = 160)
+
+    Spacer(Modifier.height(20.dp))
+
+    BottomSheetButtons(onDecline = onDecline, onAccept = onAccept)
+  }
+}
+
+@Composable
+fun FriendRequestSheetContent(
+    username: String,
+    handle: String,
+    bio: String,
+    avatar: Painter,
+    onAccept: () -> Unit,
+    onDecline: () -> Unit,
+    onClose: () -> Unit
+) {
+  Column(modifier = Modifier.padding(20.dp)) {
+
+    // Close button
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+      Icon(
+          imageVector = Icons.Default.Close,
+          contentDescription = "Close",
+          tint = AppColors.textIcons,
+          modifier = Modifier.clickable { onClose() })
+    }
+
+    Spacer(Modifier.height(4.dp))
+
+    // Title area
+    Row(verticalAlignment = Alignment.CenterVertically) {
+      Icon(
+          painter = avatar,
+          contentDescription = null,
+          modifier = Modifier.size(52.dp).clip(RoundedCornerShape(26.dp)))
+
+      Spacer(Modifier.width(12.dp))
+
+      Column {
+        Text(
+            text = username,
+            style = MaterialTheme.typography.titleLarge,
+            color = AppColors.textIcons)
+        Text(
+            text = "@$handle",
+            style = MaterialTheme.typography.bodyMedium,
+            color = AppColors.textIcons)
+      }
+    }
+
+    Spacer(Modifier.height(16.dp))
+
+    // BIO header
+    Text(
+        text = "About",
+        style = MaterialTheme.typography.titleMedium,
+        color = AppColors.textIcons,
+        fontWeight = FontWeight.SemiBold,
+        modifier = Modifier.padding(bottom = 6.dp))
+
+    // Bold-username bio with expandable text
+    ExpandableAnnotatedBio(username = username, fullBio = bio, previewCharLimit = 150)
+
+    Spacer(Modifier.height(20.dp))
+
+    BottomSheetButtons(onDecline = onDecline, onAccept = onAccept)
+  }
+}
+
+/* ---------------------------------------------------------
+   EVERYTHING BELOW THIS LINE IS *ONLY BEFORE BACKEND*
+   Dummy notifications + icon loading for previews
+--------------------------------------------------------- */
+
+fun Notification.toPopupData(): NotificationPopupData {
+  return when (type) {
+    NotificationType.DISCUSSION_INVITE ->
+        NotificationPopupData.Discussion(
+            title = "Discussion Invite",
+            participants = 12, // placeholder, replace when backend provides value
+            dateLabel = time.format(DateTimeFormatter.ofPattern("MMM d")),
+            description = "You've been invited to join $variableText.",
+            icon = icon)
+    NotificationType.SESSION_INVITE ->
+        NotificationPopupData.Session(
+            title = "Session Invite",
+            participants = 8, // placeholder
+            dateLabel = time.format(DateTimeFormatter.ofPattern("MMM d")),
+            description = "You've been invited to join $variableText.",
+            icon = icon)
+    NotificationType.FRIEND_REQUEST ->
+        NotificationPopupData.FriendRequest(
+            username = variableText,
+            handle = variableText.lowercase(), // placeholder until backend
+            bio = "$variableText wants to add you as a friend!",
+            avatar = icon)
+  }
+}
+
+@Composable
+fun rememberDummyNotifications(): MutableState<List<Notification>> {
+  val icon = painterResource(R.drawable.google_logo)
+
+  return remember {
+    mutableStateOf(
+        listOf(
+            Notification(
+                id = 1,
+                type = NotificationType.FRIEND_REQUEST,
+                variableText = "raging monkey",
+                time = LocalDateTime.now().minusHours(1),
+                isUnread = true,
+                icon = icon),
+            Notification(
+                id = 2,
+                type = NotificationType.DISCUSSION_INVITE,
+                variableText = "Monopoly's bazaar",
+                time = LocalDateTime.now().minusHours(3),
+                isUnread = false,
+                icon = icon),
+            Notification(
+                id = 3,
+                type = NotificationType.SESSION_INVITE,
+                variableText = "Monopoly this Friday",
+                time = LocalDateTime.now().minusHours(5),
+                isUnread = true,
+                icon = icon),
+            Notification(
+                id = 4,
+                type = NotificationType.FRIEND_REQUEST,
+                variableText = "Tobey Maguire",
+                time = LocalDateTime.now().minusDays(1).minusHours(2),
+                isUnread = false,
+                icon = icon),
+            Notification(
+                id = 5,
+                type = NotificationType.DISCUSSION_INVITE,
+                variableText = "Catan strategies",
+                time = LocalDateTime.now().minusDays(1).minusHours(4),
+                isUnread = true,
+                icon = icon),
+            Notification(
+                id = 6,
+                type = NotificationType.SESSION_INVITE,
+                variableText = "Catan this weekend",
+                time = LocalDateTime.now().minusDays(1).minusHours(6),
+                isUnread = false,
+                icon = icon),
+            Notification(
+                id = 7,
+                type = NotificationType.FRIEND_REQUEST,
+                variableText = "boardgame_fox",
+                time = LocalDateTime.now().minusDays(2),
+                isUnread = false,
+                icon = icon),
+            Notification(
+                id = 8,
+                type = NotificationType.SESSION_INVITE,
+                variableText = "Ticket to Ride",
+                time = LocalDateTime.now().minusDays(3),
+                isUnread = true,
+                icon = icon),
+            Notification(
+                id = 9,
+                type = NotificationType.DISCUSSION_INVITE,
+                variableText = "House Rules Meetup",
+                time = LocalDateTime.now().minusDays(4),
+                isUnread = false,
+                icon = icon)))
+  }
+}

--- a/app/src/main/java/com/github/meeplemeet/ui/account/NotificationsTab.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/NotificationsTab.kt
@@ -90,234 +90,204 @@ import java.time.format.DateTimeFormatter
 import kotlinx.coroutines.launch
 
 object NotificationsTabTestTags {
-    const val HEADER_TITLE = "header_title"
-    const val FILTER_CHIP_PREFIX = "filter_chip_"
-    const val EMPTY_STATE_TEXT = "empty_state_text"
-    const val NOTIFICATION_LIST = "notification_list"
-    const val NOTIFICATION_ITEM_PREFIX = "notification_item_"
-    const val SHEET_TITLE = "sheet_title"
-    const val SHEET_DESCRIPTION = "sheet_description"
-    const val SHEET_ACCEPT_BUTTON = "sheet_accept_button"
-    const val SHEET_DECLINE_BUTTON = "sheet_decline_button"
-    const val UNREAD_DOT_PREFIX = "unread_dot_"
+  const val HEADER_TITLE = "header_title"
+  const val FILTER_CHIP_PREFIX = "filter_chip_"
+  const val EMPTY_STATE_TEXT = "empty_state_text"
+  const val NOTIFICATION_LIST = "notification_list"
+  const val NOTIFICATION_ITEM_PREFIX = "notification_item_"
+  const val SHEET_TITLE = "sheet_title"
+  const val SHEET_DESCRIPTION = "sheet_description"
+  const val SHEET_ACCEPT_BUTTON = "sheet_accept_button"
+  const val SHEET_DECLINE_BUTTON = "sheet_decline_button"
+  const val UNREAD_DOT_PREFIX = "unread_dot_"
 }
 
 object NotificationsTabUi {
-    object Header {
-        const val TITLE = "Notifications"
-        const val BACK_ICON_DESCRIPTION = "Back"
+  object Header {
+    const val TITLE = "Notifications"
+    const val BACK_ICON_DESCRIPTION = "Back"
+  }
+
+  object NotificationLabels {
+    const val FRIEND_REQUEST = "Incoming friend request"
+    const val JOIN_DISCUSSION = "Discussion invite"
+    const val JOIN_SESSION = "Session invite"
+  }
+
+  object DateSections {
+    const val TODAY = "Today"
+    const val YESTERDAY = "Yesterday"
+    const val EARLIER = "Earlier"
+    const val DAYS_BEFORE_YESTERDAY = 1L
+  }
+
+  object Filters {
+    const val PADDING_LIMIT = 24
+    const val GRADIENT_ALPHA = 0.7f
+  }
+
+  object NotificationCard {
+    const val UNREAD_DOT_CORNER_RADIUS = 50
+    val AVATAR_CORNER_RADIUS: Dp = 22.dp
+    val UNREAD_DOT_SIZE: Dp = 18.dp
+    val AVATAR_SIZE: Dp = 44.dp
+
+    object TimeFormats {
+      const val TIME_PATTERN = "h:mm a"
+      const val DATE_PATTERN = "dd/MM/yyyy"
     }
 
-    object NotificationLabels {
-        const val FRIEND_REQUEST = "Incoming friend request"
-        const val JOIN_DISCUSSION = "Discussion invite"
-        const val JOIN_SESSION = "Session invite"
+    object Subtitles {
+      const val FRIEND_REQUEST_PREFIX = "User "
+      const val FRIEND_REQUEST_SUFFIX = "wants to add you as a friend."
+      const val DISCUSSION_PREFIX = "Invited to join discussion "
+      const val SESSION_PREFIX = "Invited to join session "
     }
 
-    object DateSections {
-        const val TODAY = "Today"
-        const val YESTERDAY = "Yesterday"
-        const val EARLIER = "Earlier"
-        const val DAYS_BEFORE_YESTERDAY = 1L
+    object Swipe {
+      const val MARK_READ_THRESHOLD = 0.10f
+      const val DELETE_THRESHOLD = 0.40f
+      const val TRIGGERED_SCALE = 1.3f
+      const val DEFAULT_SCALE = 1f
     }
 
-    object Filters {
-        const val PADDING_LIMIT = 24
-        const val GRADIENT_ALPHA = 0.7f
+    object Fallbacks {
+      const val DEFAULT_USER = "User"
+      const val DEFAULT_DISCUSSION = "Discussion"
+      const val DEFAULT_SESSION = "Session"
+      const val FALLBACK_LETTER = '•'
+    }
+  }
+
+  object NotificationSheet {
+    val AVATAR_SIZE: Dp = 52.dp
+
+    object Content {
+      const val CLOSE_ICON_DESCRIPTION = "Close"
+      const val DISCUSSION_KEYWORD = "discussion"
+      const val ABOUT_DISCUSSION = "About this discussion"
+      const val ABOUT_SESSION = "About this session"
+      const val ABOUT_FRIEND = "About"
+      const val NO_DESCRIPTION = "No description provided"
+      const val NO_DESCRIPTION_DISCUSSION = "No description provided."
+      const val HANDLE_PREFIX = "@"
+
+      const val DATE_PATTERN = "dd/MM/yyyy"
+      const val SESSION_DATE_PATTERN = "MMM d"
+      const val SESSION_TIME_PATTERN = "h:mm a"
+
+      const val DISCUSSION_PREVIEW_CHAR_LIMIT = 160
+      const val SESSION_PREVIEW_CHAR_LIMIT = 160
+      const val FRIEND_PREVIEW_CHAR_LIMIT = 150
+
+      fun sessionDescription(gameName: String, time: String, locationName: String) =
+          "Play $gameName at $time at $locationName."
+
+      fun participantsMeta(participants: Int, dateLabel: String) =
+          "$participants participants • $dateLabel"
     }
 
-    object NotificationCard {
-        const val UNREAD_DOT_CORNER_RADIUS = 50
-        val AVATAR_CORNER_RADIUS: Dp = 22.dp
-        val UNREAD_DOT_SIZE: Dp = 18.dp
-        val AVATAR_SIZE: Dp = 44.dp
-
-        object TimeFormats {
-            const val TIME_PATTERN = "h:mm a"
-            const val DATE_PATTERN = "dd/MM/yyyy"
-        }
-
-        object Subtitles {
-            const val FRIEND_REQUEST_PREFIX = "User "
-            const val FRIEND_REQUEST_SUFFIX = "wants to add you as a friend."
-            const val DISCUSSION_PREFIX = "Invited to join discussion "
-            const val SESSION_PREFIX = "Invited to join session "
-        }
-
-        object Swipe {
-            const val MARK_READ_THRESHOLD = 0.10f
-            const val DELETE_THRESHOLD = 0.40f
-            const val TRIGGERED_SCALE = 1.3f
-            const val DEFAULT_SCALE = 1f
-        }
-
-        object Fallbacks {
-            const val DEFAULT_USER = "User"
-            const val DEFAULT_DISCUSSION = "Discussion"
-            const val DEFAULT_SESSION = "Session"
-            const val FALLBACK_LETTER = '•'
-        }
+    object Buttons {
+      const val DECLINE_TEXT = "Decline"
+      const val ACCEPT_TEXT = "Accept"
     }
+  }
 
-    object NotificationSheet {
-        val AVATAR_SIZE: Dp = 52.dp
+  object ExpandableText {
+    const val DEFAULT_PREVIEW_CHAR_LIMIT = 160
+    const val MORE_INDICATOR = "…"
+    const val SHOW_MORE = "Show more"
+    const val SHOW_LESS = "Show less"
+  }
 
-        object Content {
-            const val CLOSE_ICON_DESCRIPTION = "Close"
-            const val DISCUSSION_KEYWORD = "discussion"
-            const val ABOUT_DISCUSSION = "About this discussion"
-            const val ABOUT_SESSION = "About this session"
-            const val ABOUT_FRIEND = "About"
-            const val NO_DESCRIPTION = "No description provided"
-            const val NO_DESCRIPTION_DISCUSSION = "No description provided."
-            const val HANDLE_PREFIX = "@"
+  object LetterAvatar {
+    const val SIZE_MULTIPLIER = 0.45f
+  }
 
-            const val DATE_PATTERN = "dd/MM/yyyy"
-            const val SESSION_DATE_PATTERN = "MMM d"
-            const val SESSION_TIME_PATTERN = "h:mm a"
-
-            const val DISCUSSION_PREVIEW_CHAR_LIMIT = 160
-            const val SESSION_PREVIEW_CHAR_LIMIT = 160
-            const val FRIEND_PREVIEW_CHAR_LIMIT = 150
-
-            fun sessionDescription(gameName: String, time: String, locationName: String) =
-                "Play $gameName at $time at $locationName."
-
-            fun participantsMeta(participants: Int, dateLabel: String) =
-                "$participants participants • $dateLabel"
-        }
-
-        object Buttons {
-            const val DECLINE_TEXT = "Decline"
-            const val ACCEPT_TEXT = "Accept"
-        }
+  object EmptyState {
+    object Messages {
+      const val ALL = "You have no notifications yet."
+      const val UNREAD = "You're all caught up! No unread notifications."
+      const val FRIEND_REQUESTS = "No incoming friend requests."
+      const val DISCUSSIONS = "No discussion invitations."
+      const val SESSIONS = "No session invitations."
     }
-
-    object ExpandableText {
-        const val DEFAULT_PREVIEW_CHAR_LIMIT = 160
-        const val MORE_INDICATOR = "…"
-        const val SHOW_MORE = "Show more"
-        const val SHOW_LESS = "Show less"
-    }
-
-    object LetterAvatar {
-        const val SIZE_MULTIPLIER = 0.45f
-    }
-
-    object EmptyState {
-        object Messages {
-            const val ALL = "You have no notifications yet."
-            const val UNREAD = "You're all caught up! No unread notifications."
-            const val FRIEND_REQUESTS = "No incoming friend requests."
-            const val DISCUSSIONS = "No discussion invitations."
-            const val SESSIONS = "No session invitations."
-        }
-    }
+  }
 }
 
 /* ---------------------------------------------------------
    EXTENSIONS + HELPERS
 --------------------------------------------------------- */
 
-/**
- * Helper to manage dates and time
- */
+/** Helper to manage dates and time */
 fun Notification.sentAtLocalDateTime(): LocalDateTime =
     sentAt.toDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime()
 
-/**
- * Helper for modular composable
- */
+/** Helper for modular composable */
 fun NotificationType.label(): String =
     when (this) {
-        NotificationType.FRIEND_REQUEST ->
-            NotificationsTabUi.NotificationLabels.FRIEND_REQUEST
-        NotificationType.JOIN_DISCUSSION ->
-            NotificationsTabUi.NotificationLabels.JOIN_DISCUSSION
-        NotificationType.JOIN_SESSION ->
-            NotificationsTabUi.NotificationLabels.JOIN_SESSION
+      NotificationType.FRIEND_REQUEST -> NotificationsTabUi.NotificationLabels.FRIEND_REQUEST
+      NotificationType.JOIN_DISCUSSION -> NotificationsTabUi.NotificationLabels.JOIN_DISCUSSION
+      NotificationType.JOIN_SESSION -> NotificationsTabUi.NotificationLabels.JOIN_SESSION
     }
 
-/**
- * Helper for organisation of the notifications by date
- */
+/** Helper for organisation of the notifications by date */
 data class NotificationSection(val header: String, val items: List<Notification>)
 
-/**
- * Groups notifications together with respect to the time they were sent at
- */
+/** Groups notifications together with respect to the time they were sent at */
 fun groupNotifications(list: List<Notification>): List<NotificationSection> {
-    val today = LocalDate.now()
-    val yesterday = today.minusDays(NotificationsTabUi.DateSections.DAYS_BEFORE_YESTERDAY)
+  val today = LocalDate.now()
+  val yesterday = today.minusDays(NotificationsTabUi.DateSections.DAYS_BEFORE_YESTERDAY)
 
-    val todayItems = list.filter { it.sentAtLocalDateTime().toLocalDate() == today }
-    val yesterdayItems = list.filter { it.sentAtLocalDateTime().toLocalDate() == yesterday }
-    val earlierItems =
-        list.filter {
-            val d = it.sentAtLocalDateTime().toLocalDate()
-            d != today && d != yesterday
-        }
+  val todayItems = list.filter { it.sentAtLocalDateTime().toLocalDate() == today }
+  val yesterdayItems = list.filter { it.sentAtLocalDateTime().toLocalDate() == yesterday }
+  val earlierItems =
+      list.filter {
+        val d = it.sentAtLocalDateTime().toLocalDate()
+        d != today && d != yesterday
+      }
 
-    val sections = mutableListOf<NotificationSection>()
-    if (todayItems.isNotEmpty()) {
-        sections.add(
-            NotificationSection(
-                NotificationsTabUi.DateSections.TODAY,
-                todayItems
-            )
-        )
-    }
-    if (yesterdayItems.isNotEmpty()) {
-        sections.add(
-            NotificationSection(
-                NotificationsTabUi.DateSections.YESTERDAY,
-                yesterdayItems
-            )
-        )
-    }
-    if (earlierItems.isNotEmpty()) {
-        sections.add(
-            NotificationSection(
-                NotificationsTabUi.DateSections.EARLIER,
-                earlierItems
-            )
-        )
-    }
+  val sections = mutableListOf<NotificationSection>()
+  if (todayItems.isNotEmpty()) {
+    sections.add(NotificationSection(NotificationsTabUi.DateSections.TODAY, todayItems))
+  }
+  if (yesterdayItems.isNotEmpty()) {
+    sections.add(NotificationSection(NotificationsTabUi.DateSections.YESTERDAY, yesterdayItems))
+  }
+  if (earlierItems.isNotEmpty()) {
+    sections.add(NotificationSection(NotificationsTabUi.DateSections.EARLIER, earlierItems))
+  }
 
-    return sections
+  return sections
 }
 
-/**
- * Data classes for modular popup composables
- */
+/** Data classes for modular popup composables */
 sealed class NotificationPopupData {
-    data class Discussion(
-        val title: String,
-        val participants: Int,
-        val dateLabel: String,
-        val description: String,
-        val icon: ByteArray?
-    ) : NotificationPopupData()
+  data class Discussion(
+      val title: String,
+      val participants: Int,
+      val dateLabel: String,
+      val description: String,
+      val icon: ByteArray?
+  ) : NotificationPopupData()
 
-    data class Session(
-        val title: String,
-        val participants: Int,
-        val dateLabel: String,
-        val description: String,
-        val icon: ByteArray?
-    ) : NotificationPopupData()
+  data class Session(
+      val title: String,
+      val participants: Int,
+      val dateLabel: String,
+      val description: String,
+      val icon: ByteArray?
+  ) : NotificationPopupData()
 
-    data class FriendRequest(
-        val username: String,
-        val handle: String,
-        val bio: String,
-        val avatar: ByteArray?
-    ) : NotificationPopupData()
+  data class FriendRequest(
+      val username: String,
+      val handle: String,
+      val bio: String,
+      val avatar: ByteArray?
+  ) : NotificationPopupData()
 }
 
-/**
- * Helper for modular composables
- */
+/** Helper for modular composables */
 data class NotificationSheetState(
     val notification: Notification,
     val popupData: NotificationPopupData
@@ -328,8 +298,9 @@ data class NotificationSheetState(
 --------------------------------------------------------- */
 
 /**
- * Main screen/tab of this file. It shows the user his sorted notifications, filters and
- * the notifications are interactible
+ * Main screen/tab of this file. It shows the user his sorted notifications, filters and the
+ * notifications are interactible
+ *
  * @param account The current user
  * @param viewModel VM used by this screen
  * @param onBack callback upon click of the back button
@@ -341,140 +312,140 @@ fun NotificationsTab(
     viewModel: NotificationsViewModel = viewModel(),
     onBack: () -> Unit
 ) {
-    val scope = rememberCoroutineScope()
+  val scope = rememberCoroutineScope()
 
-    val filters = NotificationFilter.entries
-    var selectedFilter by remember { mutableStateOf(NotificationFilter.ALL) }
+  val filters = NotificationFilter.entries
+  var selectedFilter by remember { mutableStateOf(NotificationFilter.ALL) }
 
-    val notifications: List<Notification> = account.notifications
+  val notifications: List<Notification> = account.notifications
 
-    val filtered =
-        when (selectedFilter) {
-            NotificationFilter.ALL -> notifications
-            NotificationFilter.UNREAD -> notifications.filter { !it.read }
-            NotificationFilter.FRIEND_REQUESTS ->
-                notifications.filter { it.type == NotificationType.FRIEND_REQUEST }
-            NotificationFilter.DISCUSSIONS ->
-                notifications.filter { it.type == NotificationType.JOIN_DISCUSSION }
-            NotificationFilter.SESSIONS ->
-                notifications.filter { it.type == NotificationType.JOIN_SESSION }
-        }.sortedByDescending { n -> n.sentAt }
+  val filtered =
+      when (selectedFilter) {
+        NotificationFilter.ALL -> notifications
+        NotificationFilter.UNREAD -> notifications.filter { !it.read }
+        NotificationFilter.FRIEND_REQUESTS ->
+            notifications.filter { it.type == NotificationType.FRIEND_REQUEST }
+        NotificationFilter.DISCUSSIONS ->
+            notifications.filter { it.type == NotificationType.JOIN_DISCUSSION }
+        NotificationFilter.SESSIONS ->
+            notifications.filter { it.type == NotificationType.JOIN_SESSION }
+      }.sortedByDescending { n -> n.sentAt }
 
-    val grouped = groupNotifications(filtered)
+  val grouped = groupNotifications(filtered)
 
-    var sheetState by remember { mutableStateOf<NotificationSheetState?>(null) }
+  var sheetState by remember { mutableStateOf<NotificationSheetState?>(null) }
 
-    if (sheetState != null) {
-        val current = sheetState!!
-        NotificationSheet(
-            notification = current.notification,
-            data = current.popupData,
-            viewModel = viewModel,
-            onDismiss = { sheetState = null },
-            onAccept = {
-                scope.launch {
-                    current.notification.execute()
-                    viewModel.readNotification(account, current.notification)
-                    sheetState = null
-                }
+  if (sheetState != null) {
+    val current = sheetState!!
+    NotificationSheet(
+        notification = current.notification,
+        data = current.popupData,
+        viewModel = viewModel,
+        onDismiss = { sheetState = null },
+        onAccept = {
+          scope.launch {
+            current.notification.execute()
+            viewModel.readNotification(account, current.notification)
+            sheetState = null
+          }
+        },
+        onDecline = {
+          viewModel.deleteNotification(account, current.notification)
+          sheetState = null
+        })
+  }
+
+  Scaffold(
+      topBar = {
+        CenterAlignedTopAppBar(
+            colors =
+                TopAppBarDefaults.centerAlignedTopAppBarColors(
+                    containerColor = AppColors.primary,
+                    titleContentColor = AppColors.textIcons,
+                    navigationIconContentColor = AppColors.textIcons),
+            title = {
+              Text(
+                  text = NotificationsTabUi.Header.TITLE,
+                  modifier = Modifier.testTag(NotificationsTabTestTags.HEADER_TITLE))
             },
-            onDecline = {
-                viewModel.deleteNotification(account, current.notification)
-                sheetState = null
+            navigationIcon = {
+              IconButton(onClick = onBack) {
+                Icon(
+                    Icons.AutoMirrored.Filled.ArrowBack,
+                    modifier = Modifier.testTag(NavigationTestTags.GO_BACK_BUTTON),
+                    contentDescription = NotificationsTabUi.Header.BACK_ICON_DESCRIPTION)
+              }
             })
-    }
-
-    Scaffold(
-        topBar = {
-            CenterAlignedTopAppBar(
-                colors =
-                    TopAppBarDefaults.centerAlignedTopAppBarColors(
-                        containerColor = AppColors.primary,
-                        titleContentColor = AppColors.textIcons,
-                        navigationIconContentColor = AppColors.textIcons),
-                title = {
-                    Text(
-                        text = NotificationsTabUi.Header.TITLE,
-                        modifier = Modifier.testTag(NotificationsTabTestTags.HEADER_TITLE))
-                },
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(
-                            Icons.AutoMirrored.Filled.ArrowBack,
-                            modifier = Modifier.testTag(NavigationTestTags.GO_BACK_BUTTON),
-                            contentDescription = NotificationsTabUi.Header.BACK_ICON_DESCRIPTION)
-                    }
-                })
-        }) { padding ->
+      }) { padding ->
         Column(modifier = Modifier.padding(padding).fillMaxSize()) {
-            FilterRow(
-                filters = filters, selected = selectedFilter, onSelected = { selectedFilter = it })
+          FilterRow(
+              filters = filters, selected = selectedFilter, onSelected = { selectedFilter = it })
 
-            if (filtered.isEmpty()) {
-                EmptyNotificationState(filter = selectedFilter)
-            } else {
-                LazyColumn(
-                    modifier =
-                        Modifier.fillMaxSize()
-                            .padding(top = Dimensions.Padding.extraLarge)
-                            .testTag(NotificationsTabTestTags.NOTIFICATION_LIST)) {
-                    grouped.forEachIndexed { index, section ->
-                        if (index > 0) {
-                            item { Spacer(Modifier.height(Dimensions.Padding.xLarge)) }
-                        }
-
-                        item {
-                            Text(
-                                text = section.header,
-                                style = MaterialTheme.typography.titleLarge.copy(
-                                    fontSize = Dimensions.TextSize.largeHeading),
-                                color = AppColors.textIcons,
-                                modifier =
-                                    Modifier.padding(
-                                        horizontal = Dimensions.Padding.extraLarge,
-                                        vertical = Dimensions.Padding.medium))
-                        }
-
-                        items(section.items, key = { it.uid }) { notif ->
-                            val context = LocalContext.current
-                            NotificationCard(
-                                notif = notif,
-                                viewModel = viewModel,
-                                onClick = {
-                                    scope.launch {
-                                        viewModel.preparePopupData(notif, context) { popupData ->
-                                            sheetState = NotificationSheetState(notif, popupData)
-                                        }
-                                    }
-                                    viewModel.readNotification(account, notif)
-                                },
-                                onMarkRead = { viewModel.readNotification(account, notif) },
-                                onDelete = { viewModel.deleteNotification(account, notif) })
-                        }
+          if (filtered.isEmpty()) {
+            EmptyNotificationState(filter = selectedFilter)
+          } else {
+            LazyColumn(
+                modifier =
+                    Modifier.fillMaxSize()
+                        .padding(top = Dimensions.Padding.extraLarge)
+                        .testTag(NotificationsTabTestTags.NOTIFICATION_LIST)) {
+                  grouped.forEachIndexed { index, section ->
+                    if (index > 0) {
+                      item { Spacer(Modifier.height(Dimensions.Padding.xLarge)) }
                     }
+
+                    item {
+                      Text(
+                          text = section.header,
+                          style =
+                              MaterialTheme.typography.titleLarge.copy(
+                                  fontSize = Dimensions.TextSize.largeHeading),
+                          color = AppColors.textIcons,
+                          modifier =
+                              Modifier.padding(
+                                  horizontal = Dimensions.Padding.extraLarge,
+                                  vertical = Dimensions.Padding.medium))
+                    }
+
+                    items(section.items, key = { it.uid }) { notif ->
+                      val context = LocalContext.current
+                      NotificationCard(
+                          notif = notif,
+                          viewModel = viewModel,
+                          onClick = {
+                            scope.launch {
+                              viewModel.preparePopupData(notif, context) { popupData ->
+                                sheetState = NotificationSheetState(notif, popupData)
+                              }
+                            }
+                            viewModel.readNotification(account, notif)
+                          },
+                          onMarkRead = { viewModel.readNotification(account, notif) },
+                          onDelete = { viewModel.deleteNotification(account, notif) })
+                    }
+                  }
                 }
-            }
+          }
         }
-    }
+      }
 }
 
 /* ---------------------------------------------------------
    FILTERS
 --------------------------------------------------------- */
 
-/**
- * Enum for all filters
- */
+/** Enum for all filters */
 enum class NotificationFilter(val label: String) {
-    ALL("All"),
-    UNREAD("Unread"),
-    FRIEND_REQUESTS("Friend requests"),
-    DISCUSSIONS("Discussions"),
-    SESSIONS("Sessions")
+  ALL("All"),
+  UNREAD("Unread"),
+  FRIEND_REQUESTS("Friend requests"),
+  DISCUSSIONS("Discussions"),
+  SESSIONS("Sessions")
 }
 
 /**
  * Composable used to display the row of filters
+ *
  * @param filters All available filters
  * @param selected The selected filter
  * @param onSelected Callback upon selection of a filter
@@ -485,88 +456,88 @@ fun FilterRow(
     selected: NotificationFilter,
     onSelected: (NotificationFilter) -> Unit,
 ) {
-    val scroll = rememberScrollState()
+  val scroll = rememberScrollState()
 
-    val showLeft by remember { derivedStateOf { scroll.value > 0 } }
-    val showRight by remember { derivedStateOf { scroll.value < scroll.maxValue } }
+  val showLeft by remember { derivedStateOf { scroll.value > 0 } }
+  val showRight by remember { derivedStateOf { scroll.value < scroll.maxValue } }
 
-    Column(modifier = Modifier.fillMaxWidth()) {
-        val padLimit = NotificationsTabUi.Filters.PADDING_LIMIT
-        val padStart = minOf(scroll.value, padLimit)
-        val padEnd = minOf(scroll.maxValue - scroll.value, padLimit)
+  Column(modifier = Modifier.fillMaxWidth()) {
+    val padLimit = NotificationsTabUi.Filters.PADDING_LIMIT
+    val padStart = minOf(scroll.value, padLimit)
+    val padEnd = minOf(scroll.maxValue - scroll.value, padLimit)
 
-        Box(
-            modifier =
-                Modifier.fillMaxWidth()
-                    .height(Dimensions.ContainerSize.iconButtonTouch)
-                    .padding(start = padStart.dp, end = padEnd.dp)) {
-            Row(
-                modifier =
-                    Modifier.horizontalScroll(scroll)
-                        .padding(horizontal = Dimensions.Padding.large)) {
+    Box(
+        modifier =
+            Modifier.fillMaxWidth()
+                .height(Dimensions.ContainerSize.iconButtonTouch)
+                .padding(start = padStart.dp, end = padEnd.dp)) {
+          Row(
+              modifier =
+                  Modifier.horizontalScroll(scroll)
+                      .padding(horizontal = Dimensions.Padding.large)) {
                 filters.forEach { filter ->
-                    FilterChip(
-                        text = filter.label,
-                        selected = filter == selected,
-                        modifier =
-                            Modifier.testTag(
-                                NotificationsTabTestTags.FILTER_CHIP_PREFIX + filter.name),
-                        onClick = { onSelected(filter) })
+                  FilterChip(
+                      text = filter.label,
+                      selected = filter == selected,
+                      modifier =
+                          Modifier.testTag(
+                              NotificationsTabTestTags.FILTER_CHIP_PREFIX + filter.name),
+                      onClick = { onSelected(filter) })
 
-                    Spacer(Modifier.width(Dimensions.Padding.extraLarge))
+                  Spacer(Modifier.width(Dimensions.Padding.extraLarge))
                 }
-            }
+              }
 
-            if (showLeft) {
-                Box(
-                    Modifier.align(Alignment.CenterStart)
-                        .width(Dimensions.Padding.xxxLarge)
-                        .fillMaxHeight()
-                        .background(
-                            Brush.horizontalGradient(
-                                listOf(
-                                    AppColors.primary,
-                                    AppColors.primary.copy(
-                                        alpha = NotificationsTabUi.Filters.GRADIENT_ALPHA),
-                                    Color.Transparent))))
-            }
+          if (showLeft) {
+            Box(
+                Modifier.align(Alignment.CenterStart)
+                    .width(Dimensions.Padding.xxxLarge)
+                    .fillMaxHeight()
+                    .background(
+                        Brush.horizontalGradient(
+                            listOf(
+                                AppColors.primary,
+                                AppColors.primary.copy(
+                                    alpha = NotificationsTabUi.Filters.GRADIENT_ALPHA),
+                                Color.Transparent))))
+          }
 
-            if (showRight) {
-                Box(
-                    Modifier.align(Alignment.CenterEnd)
-                        .width(Dimensions.Padding.xxxLarge)
-                        .fillMaxHeight()
-                        .background(
-                            Brush.horizontalGradient(
-                                listOf(Color.Transparent, AppColors.primary))))
-            }
+          if (showRight) {
+            Box(
+                Modifier.align(Alignment.CenterEnd)
+                    .width(Dimensions.Padding.xxxLarge)
+                    .fillMaxHeight()
+                    .background(
+                        Brush.horizontalGradient(listOf(Color.Transparent, AppColors.primary))))
+          }
         }
 
-        Row(
-            modifier =
-                Modifier.fillMaxWidth()
-                    .padding(
-                        top = Dimensions.Padding.small,
-                        start = Dimensions.Padding.large,
-                        end = Dimensions.Padding.large),
-            horizontalArrangement = Arrangement.SpaceBetween) {
-            if (showLeft) {
-                Icon(Icons.Default.ChevronLeft, null, tint = AppColors.textIconsFade)
-            } else {
-                Spacer(Modifier.size(Dimensions.IconSize.large))
-            }
+    Row(
+        modifier =
+            Modifier.fillMaxWidth()
+                .padding(
+                    top = Dimensions.Padding.small,
+                    start = Dimensions.Padding.large,
+                    end = Dimensions.Padding.large),
+        horizontalArrangement = Arrangement.SpaceBetween) {
+          if (showLeft) {
+            Icon(Icons.Default.ChevronLeft, null, tint = AppColors.textIconsFade)
+          } else {
+            Spacer(Modifier.size(Dimensions.IconSize.large))
+          }
 
-            if (showRight) {
-                Icon(Icons.Default.ChevronRight, null, tint = AppColors.textIconsFade)
-            } else {
-                Spacer(Modifier.size(Dimensions.IconSize.large))
-            }
+          if (showRight) {
+            Icon(Icons.Default.ChevronRight, null, tint = AppColors.textIconsFade)
+          } else {
+            Spacer(Modifier.size(Dimensions.IconSize.large))
+          }
         }
-    }
+  }
 }
 
 /**
  * Filter chips used for filtering
+ *
  * @param text Text to display in the chip
  * @param selected Whether the chip is selected or not
  * @param modifier Modifiers to pass to the chip
@@ -579,23 +550,23 @@ fun FilterChip(
     modifier: Modifier = Modifier,
     onClick: () -> Unit
 ) {
-    val border = if (selected) AppColors.neutral else AppColors.textIconsFade
+  val border = if (selected) AppColors.neutral else AppColors.textIconsFade
 
-    Box(
-        modifier =
-            modifier
-                .clip(RoundedCornerShape(Dimensions.CornerRadius.small))
-                .border(
-                    if (selected) Dimensions.DividerThickness.medium
-                    else Dimensions.DividerThickness.standard,
-                    border,
-                    RoundedCornerShape(Dimensions.CornerRadius.extraLarge))
-                .clickable { onClick() }
-                .padding(
-                    horizontal = Dimensions.Padding.extraLarge,
-                    vertical = Dimensions.Padding.medium)) {
+  Box(
+      modifier =
+          modifier
+              .clip(RoundedCornerShape(Dimensions.CornerRadius.small))
+              .border(
+                  if (selected) Dimensions.DividerThickness.medium
+                  else Dimensions.DividerThickness.standard,
+                  border,
+                  RoundedCornerShape(Dimensions.CornerRadius.extraLarge))
+              .clickable { onClick() }
+              .padding(
+                  horizontal = Dimensions.Padding.extraLarge,
+                  vertical = Dimensions.Padding.medium)) {
         Text(text, color = AppColors.textIcons)
-    }
+      }
 }
 
 /* ---------------------------------------------------------
@@ -604,6 +575,7 @@ fun FilterChip(
 
 /**
  * Notification card, handles everything in relation to the card
+ *
  * @param notif Actual notification data
  * @param viewModel VM used by this screen
  * @param onClick Callback upon click on the notification
@@ -619,82 +591,79 @@ fun NotificationCard(
     onMarkRead: () -> Unit,
     onDelete: () -> Unit
 ) {
-    val dismissState =
-        rememberDismissState(
-            confirmStateChange = { state ->
-                when (state) {
-                    DismissValue.DismissedToStart -> {
-                        onDelete()
-                        false
-                    }
-                    DismissValue.DismissedToEnd -> {
-                        onMarkRead()
-                        false
-                    }
-                    else -> false
-                }
-            })
-
-    SwipeToDismiss(
-        state = dismissState,
-        background = { SwipeBackground(dismissState) },
-        dismissContent = { NotificationRowContent(notif, viewModel, onClick) },
-        directions = setOf(DismissDirection.StartToEnd, DismissDirection.EndToStart),
-        dismissThresholds = {
-            when (it) {
-                DismissDirection.StartToEnd ->
-                    FractionalThreshold(
-                        NotificationsTabUi.NotificationCard.Swipe.MARK_READ_THRESHOLD)
-                DismissDirection.EndToStart ->
-                    FractionalThreshold(
-                        NotificationsTabUi.NotificationCard.Swipe.DELETE_THRESHOLD)
+  val dismissState =
+      rememberDismissState(
+          confirmStateChange = { state ->
+            when (state) {
+              DismissValue.DismissedToStart -> {
+                onDelete()
+                false
+              }
+              DismissValue.DismissedToEnd -> {
+                onMarkRead()
+                false
+              }
+              else -> false
             }
-        })
+          })
+
+  SwipeToDismiss(
+      state = dismissState,
+      background = { SwipeBackground(dismissState) },
+      dismissContent = { NotificationRowContent(notif, viewModel, onClick) },
+      directions = setOf(DismissDirection.StartToEnd, DismissDirection.EndToStart),
+      dismissThresholds = {
+        when (it) {
+          DismissDirection.StartToEnd ->
+              FractionalThreshold(NotificationsTabUi.NotificationCard.Swipe.MARK_READ_THRESHOLD)
+          DismissDirection.EndToStart ->
+              FractionalThreshold(NotificationsTabUi.NotificationCard.Swipe.DELETE_THRESHOLD)
+        }
+      })
 }
 
 /**
  * Function used to manage the swiping left/right
+ *
  * @param state whether the card is currently swiped or not
  */
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 private fun SwipeBackground(state: DismissState) {
-    val dir = state.dismissDirection ?: return
-    val isTriggered = state.targetValue != DismissValue.Default
-    val scale by
-    animateFloatAsState(
-        if (isTriggered)
-            NotificationsTabUi.NotificationCard.Swipe.TRIGGERED_SCALE
-        else NotificationsTabUi.NotificationCard.Swipe.DEFAULT_SCALE)
+  val dir = state.dismissDirection ?: return
+  val isTriggered = state.targetValue != DismissValue.Default
+  val scale by
+      animateFloatAsState(
+          if (isTriggered) NotificationsTabUi.NotificationCard.Swipe.TRIGGERED_SCALE
+          else NotificationsTabUi.NotificationCard.Swipe.DEFAULT_SCALE)
 
-    val color =
-        when (dir) {
-            DismissDirection.StartToEnd -> AppColors.neutral
-            DismissDirection.EndToStart -> AppColors.negative
-        }
+  val color =
+      when (dir) {
+        DismissDirection.StartToEnd -> AppColors.neutral
+        DismissDirection.EndToStart -> AppColors.negative
+      }
 
-    Box(
-        modifier =
-            Modifier.fillMaxSize()
-                .background(color)
-                .padding(horizontal = Dimensions.Padding.xLarge),
-        contentAlignment =
-            when (dir) {
-                DismissDirection.StartToEnd -> Alignment.CenterStart
-                DismissDirection.EndToStart -> Alignment.CenterEnd
-            }) {
+  Box(
+      modifier =
+          Modifier.fillMaxSize().background(color).padding(horizontal = Dimensions.Padding.xLarge),
+      contentAlignment =
+          when (dir) {
+            DismissDirection.StartToEnd -> Alignment.CenterStart
+            DismissDirection.EndToStart -> Alignment.CenterEnd
+          }) {
         val icon =
             when (dir) {
-                DismissDirection.StartToEnd -> Icons.Default.MarkChatRead
-                DismissDirection.EndToStart -> Icons.Default.Delete
+              DismissDirection.StartToEnd -> Icons.Default.MarkChatRead
+              DismissDirection.EndToStart -> Icons.Default.Delete
             }
 
         Icon(icon, null, tint = Color.White, modifier = Modifier.scale(scale))
-    }
+      }
 }
 
 /**
  * Actual content of the notification
+ *
  * @param notif Notification data
  * @param viewModel VM used by this screen
  * @param onClick Callback upon click
@@ -705,83 +674,83 @@ private fun NotificationRowContent(
     viewModel: NotificationsViewModel,
     onClick: () -> Unit
 ) {
-    val context = LocalContext.current
+  val context = LocalContext.current
 
-    var avatarBytes by remember(notif.uid) { mutableStateOf<ByteArray?>(null) }
-    var friend by remember { mutableStateOf<Account?>(null) }
-    var discussionName by remember { mutableStateOf<String?>(null) }
-    var sessionName by remember { mutableStateOf<String?>(null) }
+  var avatarBytes by remember(notif.uid) { mutableStateOf<ByteArray?>(null) }
+  var friend by remember { mutableStateOf<Account?>(null) }
+  var discussionName by remember { mutableStateOf<String?>(null) }
+  var sessionName by remember { mutableStateOf<String?>(null) }
 
-    LaunchedEffect(notif.uid) {
-        when (notif.type) {
-            NotificationType.FRIEND_REQUEST -> {
-                viewModel.getOtherAccount(notif.senderOrDiscussionId) { acc ->
-                    friend = acc
-                    viewModel.loadAccountImage(notif.senderOrDiscussionId, context) { avatarBytes = it }
-                }
-            }
-            NotificationType.JOIN_DISCUSSION -> {
-                viewModel.getDiscussion(notif.senderOrDiscussionId) { disc ->
-                    discussionName = disc.name
-                    viewModel.loadDiscussionImage(disc.uid, context) { bytes -> avatarBytes = bytes }
-                }
-            }
-            NotificationType.JOIN_SESSION -> {
-                viewModel.getDiscussion(notif.senderOrDiscussionId) { disc ->
-                    val session = disc.session
-                    sessionName = session?.name ?: disc.name
-                    viewModel.loadDiscussionImage(disc.uid, context) { bytes -> avatarBytes = bytes }
-                }
-            }
+  LaunchedEffect(notif.uid) {
+    when (notif.type) {
+      NotificationType.FRIEND_REQUEST -> {
+        viewModel.getOtherAccount(notif.senderOrDiscussionId) { acc ->
+          friend = acc
+          viewModel.loadAccountImage(notif.senderOrDiscussionId, context) { avatarBytes = it }
         }
+      }
+      NotificationType.JOIN_DISCUSSION -> {
+        viewModel.getDiscussion(notif.senderOrDiscussionId) { disc ->
+          discussionName = disc.name
+          viewModel.loadDiscussionImage(disc.uid, context) { bytes -> avatarBytes = bytes }
+        }
+      }
+      NotificationType.JOIN_SESSION -> {
+        viewModel.getDiscussion(notif.senderOrDiscussionId) { disc ->
+          val session = disc.session
+          sessionName = session?.name ?: disc.name
+          viewModel.loadDiscussionImage(disc.uid, context) { bytes -> avatarBytes = bytes }
+        }
+      }
     }
+  }
 
-    val dateTime = notif.sentAtLocalDateTime()
-    val date = dateTime.toLocalDate()
-    val today = LocalDate.now()
-    val timeText =
-        if (date == today || date == today.minusDays(NotificationsTabUi.DateSections.DAYS_BEFORE_YESTERDAY))
-            dateTime.format(
-                DateTimeFormatter.ofPattern(
-                    NotificationsTabUi.NotificationCard.TimeFormats.TIME_PATTERN))
-        else
-            dateTime.format(
-                DateTimeFormatter.ofPattern(
-                    NotificationsTabUi.NotificationCard.TimeFormats.DATE_PATTERN))
+  val dateTime = notif.sentAtLocalDateTime()
+  val date = dateTime.toLocalDate()
+  val today = LocalDate.now()
+  val timeText =
+      if (date == today ||
+          date == today.minusDays(NotificationsTabUi.DateSections.DAYS_BEFORE_YESTERDAY))
+          dateTime.format(
+              DateTimeFormatter.ofPattern(
+                  NotificationsTabUi.NotificationCard.TimeFormats.TIME_PATTERN))
+      else
+          dateTime.format(
+              DateTimeFormatter.ofPattern(
+                  NotificationsTabUi.NotificationCard.TimeFormats.DATE_PATTERN))
 
-    val displayName =
-        when (notif.type) {
-            NotificationType.FRIEND_REQUEST ->
-                friend?.name ?: NotificationsTabUi.NotificationCard.Fallbacks.DEFAULT_USER
-            NotificationType.JOIN_DISCUSSION ->
-                discussionName ?: NotificationsTabUi.NotificationCard.Fallbacks.DEFAULT_DISCUSSION
-            NotificationType.JOIN_SESSION ->
-                sessionName ?: NotificationsTabUi.NotificationCard.Fallbacks.DEFAULT_SESSION
-        }
+  val displayName =
+      when (notif.type) {
+        NotificationType.FRIEND_REQUEST ->
+            friend?.name ?: NotificationsTabUi.NotificationCard.Fallbacks.DEFAULT_USER
+        NotificationType.JOIN_DISCUSSION ->
+            discussionName ?: NotificationsTabUi.NotificationCard.Fallbacks.DEFAULT_DISCUSSION
+        NotificationType.JOIN_SESSION ->
+            sessionName ?: NotificationsTabUi.NotificationCard.Fallbacks.DEFAULT_SESSION
+      }
 
-    val fallbackLetter =
-        displayName.firstOrNull()
-            ?: NotificationsTabUi.NotificationCard.Fallbacks.FALLBACK_LETTER
+  val fallbackLetter =
+      displayName.firstOrNull() ?: NotificationsTabUi.NotificationCard.Fallbacks.FALLBACK_LETTER
 
-    Row(
-        modifier =
-            Modifier.fillMaxWidth()
-                .testTag(NotificationsTabTestTags.NOTIFICATION_ITEM_PREFIX + notif.uid)
-                .background(AppColors.primary)
-                .clickable { onClick() }
-                .padding(
-                    horizontal = Dimensions.Padding.large,
-                    vertical = Dimensions.Padding.extraMedium)) {
+  Row(
+      modifier =
+          Modifier.fillMaxWidth()
+              .testTag(NotificationsTabTestTags.NOTIFICATION_ITEM_PREFIX + notif.uid)
+              .background(AppColors.primary)
+              .clickable { onClick() }
+              .padding(
+                  horizontal = Dimensions.Padding.large,
+                  vertical = Dimensions.Padding.extraMedium)) {
         if (!notif.read) {
-            Box(
-                modifier =
-                    Modifier.padding(top = Dimensions.Padding.large)
-                        .size(NotificationsTabUi.NotificationCard.UNREAD_DOT_SIZE)
-                        .clip(
-                            RoundedCornerShape(
-                                NotificationsTabUi.NotificationCard.UNREAD_DOT_CORNER_RADIUS))
-                        .background(AppColors.negative)
-                        .testTag(NotificationsTabTestTags.UNREAD_DOT_PREFIX + notif.uid))
+          Box(
+              modifier =
+                  Modifier.padding(top = Dimensions.Padding.large)
+                      .size(NotificationsTabUi.NotificationCard.UNREAD_DOT_SIZE)
+                      .clip(
+                          RoundedCornerShape(
+                              NotificationsTabUi.NotificationCard.UNREAD_DOT_CORNER_RADIUS))
+                      .background(AppColors.negative)
+                      .testTag(NotificationsTabTestTags.UNREAD_DOT_PREFIX + notif.uid))
         }
 
         Spacer(Modifier.width(Dimensions.Spacing.large))
@@ -789,60 +758,56 @@ private fun NotificationRowContent(
         LetterAvatar(
             letter = fallbackLetter,
             size = NotificationsTabUi.NotificationCard.AVATAR_SIZE,
-            modifier = Modifier.clip(RoundedCornerShape(NotificationsTabUi.NotificationCard.AVATAR_CORNER_RADIUS)),
+            modifier =
+                Modifier.clip(
+                    RoundedCornerShape(NotificationsTabUi.NotificationCard.AVATAR_CORNER_RADIUS)),
             imageBytes = avatarBytes)
 
         Spacer(Modifier.width(Dimensions.Spacing.large))
 
         Column(modifier = Modifier.weight(Dimensions.Weight.full)) {
-            Text(
-                text = notif.type.label(),
-                style = MaterialTheme.typography.bodySmall,
-                fontSize = Dimensions.TextSize.title,
-                color = AppColors.textIcons)
+          Text(
+              text = notif.type.label(),
+              style = MaterialTheme.typography.bodySmall,
+              fontSize = Dimensions.TextSize.title,
+              color = AppColors.textIcons)
 
-            val subtitle =
-                when (notif.type) {
-                    NotificationType.FRIEND_REQUEST ->
-                        buildAnnotatedString {
-                            append(NotificationsTabUi.NotificationCard.Subtitles.FRIEND_REQUEST_PREFIX)
-                            withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
-                                append("$displayName ")
-                            }
-                            append(NotificationsTabUi.NotificationCard.Subtitles.FRIEND_REQUEST_SUFFIX)
-                        }
-                    NotificationType.JOIN_DISCUSSION ->
-                        buildAnnotatedString {
-                            append(NotificationsTabUi.NotificationCard.Subtitles.DISCUSSION_PREFIX)
-                            withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
-                                append(displayName)
-                            }
-                        }
-                    NotificationType.JOIN_SESSION ->
-                        buildAnnotatedString {
-                            append(NotificationsTabUi.NotificationCard.Subtitles.SESSION_PREFIX)
-                            withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
-                                append(displayName)
-                            }
-                        }
-                }
+          val subtitle =
+              when (notif.type) {
+                NotificationType.FRIEND_REQUEST ->
+                    buildAnnotatedString {
+                      append(NotificationsTabUi.NotificationCard.Subtitles.FRIEND_REQUEST_PREFIX)
+                      withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append("$displayName ") }
+                      append(NotificationsTabUi.NotificationCard.Subtitles.FRIEND_REQUEST_SUFFIX)
+                    }
+                NotificationType.JOIN_DISCUSSION ->
+                    buildAnnotatedString {
+                      append(NotificationsTabUi.NotificationCard.Subtitles.DISCUSSION_PREFIX)
+                      withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append(displayName) }
+                    }
+                NotificationType.JOIN_SESSION ->
+                    buildAnnotatedString {
+                      append(NotificationsTabUi.NotificationCard.Subtitles.SESSION_PREFIX)
+                      withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append(displayName) }
+                    }
+              }
 
-            Text(
-                text = subtitle,
-                style = MaterialTheme.typography.bodySmall,
-                color = AppColors.textIconsFade,
-                modifier = Modifier.padding(top = Dimensions.Padding.mediumSmall))
+          Text(
+              text = subtitle,
+              style = MaterialTheme.typography.bodySmall,
+              color = AppColors.textIconsFade,
+              modifier = Modifier.padding(top = Dimensions.Padding.mediumSmall))
         }
 
         Spacer(Modifier.width(Dimensions.Spacing.small))
 
         Column(horizontalAlignment = Alignment.End) {
-            Text(
-                text = timeText,
-                color = AppColors.textIconsFade,
-                style = MaterialTheme.typography.bodySmall)
+          Text(
+              text = timeText,
+              color = AppColors.textIconsFade,
+              style = MaterialTheme.typography.bodySmall)
         }
-    }
+      }
 }
 
 /* ---------------------------------------------------------
@@ -851,6 +816,7 @@ private fun NotificationRowContent(
 
 /**
  * Handles the notification popup
+ *
  * @param notification Notification data
  * @param data Popup data
  * @param viewModel VM used by this screen
@@ -868,178 +834,170 @@ fun NotificationSheet(
     onAccept: () -> Unit,
     onDecline: () -> Unit
 ) {
-    val context = LocalContext.current
+  val context = LocalContext.current
 
-    var avatar by remember { mutableStateOf<ByteArray?>(null) }
-    var icon by remember { mutableStateOf<ByteArray?>(null) }
-    var loadedData by remember { mutableStateOf(data) }
+  var avatar by remember { mutableStateOf<ByteArray?>(null) }
+  var icon by remember { mutableStateOf<ByteArray?>(null) }
+  var loadedData by remember { mutableStateOf(data) }
 
-    LaunchedEffect(notification.uid) {
-        when (notification.type) {
-            NotificationType.FRIEND_REQUEST -> {
-                viewModel.getOtherAccount(notification.senderOrDiscussionId) { acc ->
-                    viewModel.loadAccountImage(notification.senderOrDiscussionId, context) { bytes ->
-                        avatar = bytes
-                    }
+  LaunchedEffect(notification.uid) {
+    when (notification.type) {
+      NotificationType.FRIEND_REQUEST -> {
+        viewModel.getOtherAccount(notification.senderOrDiscussionId) { acc ->
+          viewModel.loadAccountImage(notification.senderOrDiscussionId, context) { bytes ->
+            avatar = bytes
+          }
 
-                    loadedData =
-                        NotificationPopupData.FriendRequest(
-                            username = acc.name,
-                            handle = acc.handle,
-                            bio =
-                                if (!acc.description.isNullOrBlank()) acc.description!!
-                                else NotificationsTabUi.NotificationSheet.Content.NO_DESCRIPTION,
-                            avatar = avatar)
-                }
-            }
-            NotificationType.JOIN_DISCUSSION -> {
-                viewModel.getDiscussion(notification.senderOrDiscussionId) { disc ->
-                    viewModel.loadDiscussionImage(disc.uid, context) { bytes -> icon = bytes }
-
-                    loadedData =
-                        NotificationPopupData.Discussion(
-                            title = disc.name,
-                            participants = disc.participants.size,
-                            dateLabel =
-                                disc.createdAt
-                                    .toDate()
-                                    .toInstant()
-                                    .atZone(ZoneId.systemDefault())
-                                    .toLocalDate()
-                                    .format(
-                                        DateTimeFormatter.ofPattern(
-                                            NotificationsTabUi.NotificationSheet.Content.DATE_PATTERN)),
-                            description =
-                                disc.description.ifBlank {
-                                    NotificationsTabUi.NotificationSheet.Content
-                                        .NO_DESCRIPTION_DISCUSSION
-                                },
-                            icon = icon)
-                }
-            }
-            NotificationType.JOIN_SESSION -> {
-                viewModel.getDiscussion(notification.senderOrDiscussionId) { disc ->
-                    viewModel.loadDiscussionImage(disc.uid, context) { bytes -> avatar = bytes }
-
-                    val session = disc.session
-                    if (session != null) {
-                        viewModel.getGame(session.gameId) { game ->
-                            val dateTime =
-                                session.date
-                                    .toDate()
-                                    .toInstant()
-                                    .atZone(ZoneId.systemDefault())
-                                    .toLocalDateTime()
-
-                            val dateLabel =
-                                dateTime.format(
-                                    DateTimeFormatter.ofPattern(
-                                        NotificationsTabUi.NotificationSheet.Content.SESSION_DATE_PATTERN))
-                            val timeLabel =
-                                dateTime.format(
-                                    DateTimeFormatter.ofPattern(
-                                        NotificationsTabUi.NotificationSheet.Content.SESSION_TIME_PATTERN))
-
-                            loadedData =
-                                NotificationPopupData.Session(
-                                    title = session.name,
-                                    participants = session.participants.size,
-                                    dateLabel = dateLabel,
-                                    description =
-                                        NotificationsTabUi.NotificationSheet.Content.sessionDescription(
-                                            game.name, timeLabel, session.location.name),
-                                    icon = avatar)
-                        }
-                    }
-                }
-            }
+          loadedData =
+              NotificationPopupData.FriendRequest(
+                  username = acc.name,
+                  handle = acc.handle,
+                  bio =
+                      if (!acc.description.isNullOrBlank()) acc.description!!
+                      else NotificationsTabUi.NotificationSheet.Content.NO_DESCRIPTION,
+                  avatar = avatar)
         }
-    }
+      }
+      NotificationType.JOIN_DISCUSSION -> {
+        viewModel.getDiscussion(notification.senderOrDiscussionId) { disc ->
+          viewModel.loadDiscussionImage(disc.uid, context) { bytes -> icon = bytes }
 
-    ModalBottomSheet(
-        onDismissRequest = onDismiss,
-        containerColor = AppColors.primary,
-        contentColor = AppColors.textIcons,
-        dragHandle = null) {
+          loadedData =
+              NotificationPopupData.Discussion(
+                  title = disc.name,
+                  participants = disc.participants.size,
+                  dateLabel =
+                      disc.createdAt
+                          .toDate()
+                          .toInstant()
+                          .atZone(ZoneId.systemDefault())
+                          .toLocalDate()
+                          .format(
+                              DateTimeFormatter.ofPattern(
+                                  NotificationsTabUi.NotificationSheet.Content.DATE_PATTERN)),
+                  description =
+                      disc.description.ifBlank {
+                        NotificationsTabUi.NotificationSheet.Content.NO_DESCRIPTION_DISCUSSION
+                      },
+                  icon = icon)
+        }
+      }
+      NotificationType.JOIN_SESSION -> {
+        viewModel.getDiscussion(notification.senderOrDiscussionId) { disc ->
+          viewModel.loadDiscussionImage(disc.uid, context) { bytes -> avatar = bytes }
+
+          val session = disc.session
+          if (session != null) {
+            viewModel.getGame(session.gameId) { game ->
+              val dateTime =
+                  session.date.toDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime()
+
+              val dateLabel =
+                  dateTime.format(
+                      DateTimeFormatter.ofPattern(
+                          NotificationsTabUi.NotificationSheet.Content.SESSION_DATE_PATTERN))
+              val timeLabel =
+                  dateTime.format(
+                      DateTimeFormatter.ofPattern(
+                          NotificationsTabUi.NotificationSheet.Content.SESSION_TIME_PATTERN))
+
+              loadedData =
+                  NotificationPopupData.Session(
+                      title = session.name,
+                      participants = session.participants.size,
+                      dateLabel = dateLabel,
+                      description =
+                          NotificationsTabUi.NotificationSheet.Content.sessionDescription(
+                              game.name, timeLabel, session.location.name),
+                      icon = avatar)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  ModalBottomSheet(
+      onDismissRequest = onDismiss,
+      containerColor = AppColors.primary,
+      contentColor = AppColors.textIcons,
+      dragHandle = null) {
         when (val d = loadedData) {
-            is NotificationPopupData.Discussion -> {
-                NotificationSheetContent(
-                    avatarBytes = d.icon,
-                    title = d.title,
-                    subtitle = null,
-                    meta =
-                        NotificationsTabUi.NotificationSheet.Content.participantsMeta(
-                            d.participants, d.dateLabel),
-                    aboutLabel =
-                        if (
-                            d.title.contains(
-                                NotificationsTabUi.NotificationSheet.Content.DISCUSSION_KEYWORD,
-                                ignoreCase = true))
-                            NotificationsTabUi.NotificationSheet.Content.ABOUT_DISCUSSION
-                        else NotificationsTabUi.NotificationSheet.Content.ABOUT_SESSION,
-                    description = d.description,
-                    previewCharLimit =
-                        NotificationsTabUi.NotificationSheet.Content.DISCUSSION_PREVIEW_CHAR_LIMIT,
-                    onAccept = onAccept,
-                    onDecline = onDecline,
-                    onClose = onDismiss)
-            }
-            is NotificationPopupData.Session -> {
-                NotificationSheetContent(
-                    avatarBytes = d.icon,
-                    title = d.title,
-                    subtitle = null,
-                    meta =
-                        NotificationsTabUi.NotificationSheet.Content.participantsMeta(
-                            d.participants, d.dateLabel),
-                    aboutLabel =
-                        if (
-                            d.title.contains(
-                                NotificationsTabUi.NotificationSheet.Content.DISCUSSION_KEYWORD,
-                                ignoreCase = true))
-                            NotificationsTabUi.NotificationSheet.Content.ABOUT_DISCUSSION
-                        else NotificationsTabUi.NotificationSheet.Content.ABOUT_SESSION,
-                    description = d.description,
-                    previewCharLimit =
-                        NotificationsTabUi.NotificationSheet.Content.SESSION_PREVIEW_CHAR_LIMIT,
-                    onAccept = onAccept,
-                    onDecline = onDecline,
-                    onClose = onDismiss)
-            }
-            is NotificationPopupData.FriendRequest -> {
-                NotificationSheetContent(
-                    avatarBytes = d.avatar,
-                    title = d.username,
-                    subtitle =
-                        NotificationsTabUi.NotificationSheet.Content.HANDLE_PREFIX + d.handle,
-                    meta = null,
-                    aboutLabel = NotificationsTabUi.NotificationSheet.Content.ABOUT_FRIEND,
-                    description = d.bio,
-                    previewCharLimit =
-                        NotificationsTabUi.NotificationSheet.Content.FRIEND_PREVIEW_CHAR_LIMIT,
-                    onAccept = onAccept,
-                    onDecline = onDecline,
-                    onClose = onDismiss)
-            }
+          is NotificationPopupData.Discussion -> {
+            NotificationSheetContent(
+                avatarBytes = d.icon,
+                title = d.title,
+                subtitle = null,
+                meta =
+                    NotificationsTabUi.NotificationSheet.Content.participantsMeta(
+                        d.participants, d.dateLabel),
+                aboutLabel =
+                    if (d.title.contains(
+                        NotificationsTabUi.NotificationSheet.Content.DISCUSSION_KEYWORD,
+                        ignoreCase = true))
+                        NotificationsTabUi.NotificationSheet.Content.ABOUT_DISCUSSION
+                    else NotificationsTabUi.NotificationSheet.Content.ABOUT_SESSION,
+                description = d.description,
+                previewCharLimit =
+                    NotificationsTabUi.NotificationSheet.Content.DISCUSSION_PREVIEW_CHAR_LIMIT,
+                onAccept = onAccept,
+                onDecline = onDecline,
+                onClose = onDismiss)
+          }
+          is NotificationPopupData.Session -> {
+            NotificationSheetContent(
+                avatarBytes = d.icon,
+                title = d.title,
+                subtitle = null,
+                meta =
+                    NotificationsTabUi.NotificationSheet.Content.participantsMeta(
+                        d.participants, d.dateLabel),
+                aboutLabel =
+                    if (d.title.contains(
+                        NotificationsTabUi.NotificationSheet.Content.DISCUSSION_KEYWORD,
+                        ignoreCase = true))
+                        NotificationsTabUi.NotificationSheet.Content.ABOUT_DISCUSSION
+                    else NotificationsTabUi.NotificationSheet.Content.ABOUT_SESSION,
+                description = d.description,
+                previewCharLimit =
+                    NotificationsTabUi.NotificationSheet.Content.SESSION_PREVIEW_CHAR_LIMIT,
+                onAccept = onAccept,
+                onDecline = onDecline,
+                onClose = onDismiss)
+          }
+          is NotificationPopupData.FriendRequest -> {
+            NotificationSheetContent(
+                avatarBytes = d.avatar,
+                title = d.username,
+                subtitle = NotificationsTabUi.NotificationSheet.Content.HANDLE_PREFIX + d.handle,
+                meta = null,
+                aboutLabel = NotificationsTabUi.NotificationSheet.Content.ABOUT_FRIEND,
+                description = d.bio,
+                previewCharLimit =
+                    NotificationsTabUi.NotificationSheet.Content.FRIEND_PREVIEW_CHAR_LIMIT,
+                onAccept = onAccept,
+                onDecline = onDecline,
+                onClose = onDismiss)
+          }
         }
-    }
+      }
 }
 
 /**
- * Buttons at the bottom of the popup sheet. Only reason they're inside their
- * own composable is to make the above composable easier to read
+ * Buttons at the bottom of the popup sheet. Only reason they're inside their own composable is to
+ * make the above composable easier to read
+ *
  * @param onDecline Callback upon declining the notification
  * @param onAccept Callback upon executing the notification
  */
 @Composable
 fun BottomSheetButtons(onDecline: () -> Unit, onAccept: () -> Unit) {
-    Row(
-        modifier =
-            Modifier.fillMaxWidth()
-                .padding(
-                    horizontal = Dimensions.Padding.extraLarge,
-                    vertical = Dimensions.Padding.xLarge),
-        horizontalArrangement = Arrangement.SpaceBetween) {
+  Row(
+      modifier =
+          Modifier.fillMaxWidth()
+              .padding(
+                  horizontal = Dimensions.Padding.extraLarge, vertical = Dimensions.Padding.xLarge),
+      horizontalArrangement = Arrangement.SpaceBetween) {
         Button(
             onClick = onDecline,
             colors =
@@ -1052,13 +1010,13 @@ fun BottomSheetButtons(onDecline: () -> Unit, onAccept: () -> Unit) {
                 PaddingValues(
                     horizontal = Dimensions.Padding.xLarge,
                     vertical = Dimensions.Padding.extraMedium)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
+              Row(verticalAlignment = Alignment.CenterVertically) {
                 Icon(Icons.Default.Close, null)
                 Text(
                     NotificationsTabUi.NotificationSheet.Buttons.DECLINE_TEXT,
                     modifier = Modifier.padding(Dimensions.Padding.small))
+              }
             }
-        }
 
         Button(
             onClick = onAccept,
@@ -1072,18 +1030,19 @@ fun BottomSheetButtons(onDecline: () -> Unit, onAccept: () -> Unit) {
                 PaddingValues(
                     horizontal = Dimensions.Padding.xLarge,
                     vertical = Dimensions.Padding.extraMedium)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
+              Row(verticalAlignment = Alignment.CenterVertically) {
                 Icon(Icons.Default.Check, null)
                 Text(
                     NotificationsTabUi.NotificationSheet.Buttons.ACCEPT_TEXT,
                     modifier = Modifier.padding(Dimensions.Padding.small))
+              }
             }
-        }
-    }
+      }
 }
 
 /**
  * Creates the sheet's content and formats everything.
+ *
  * @param avatarBytes Used to display profile pictures
  * @param title Title of the sheet
  * @param subtitle Smaller text under the title
@@ -1107,68 +1066,66 @@ fun NotificationSheetContent(
     onDecline: () -> Unit,
     onClose: () -> Unit
 ) {
-    Column(modifier = Modifier.padding(Dimensions.Padding.xLarge)) {
-        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
-            Icon(
-                Icons.Default.Close,
-                NotificationsTabUi.NotificationSheet.Content.CLOSE_ICON_DESCRIPTION,
-                tint = AppColors.textIcons,
-                modifier = Modifier.clickable { onClose() })
-        }
-
-        Spacer(Modifier.height(Dimensions.Spacing.small))
-
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            LetterAvatar(
-                letter =
-                    title.firstOrNull()
-                        ?: NotificationsTabUi.NotificationCard.Fallbacks.FALLBACK_LETTER,
-                size = NotificationsTabUi.NotificationSheet.AVATAR_SIZE,
-                imageBytes = avatarBytes)
-
-            Spacer(Modifier.width(Dimensions.Spacing.large))
-
-            Column {
-                Text(
-                    title,
-                    style = MaterialTheme.typography.titleLarge,
-                    color = AppColors.textIcons,
-                    modifier = Modifier.testTag(NotificationsTabTestTags.SHEET_TITLE))
-                if (subtitle != null) {
-                    Text(
-                        subtitle, style = MaterialTheme.typography.bodyMedium, color = AppColors.textIcons)
-                }
-            }
-        }
-
-        if (meta != null) {
-            Spacer(Modifier.height(Dimensions.Spacing.medium))
-            Text(meta, style = MaterialTheme.typography.bodyMedium, color = AppColors.textIconsFade)
-        }
-
-        Spacer(Modifier.height(Dimensions.Spacing.extraLarge))
-
-        Text(
-            text = aboutLabel,
-            style = MaterialTheme.typography.titleMedium,
-            color = AppColors.textIcons,
-            fontWeight = FontWeight.SemiBold,
-            modifier = Modifier.padding(bottom = Dimensions.Padding.mediumSmall))
-
-        ExpandableText(
-            text = description,
-            previewCharLimit = previewCharLimit,
-            modifier = Modifier.testTag(NotificationsTabTestTags.SHEET_DESCRIPTION))
-
-        Spacer(Modifier.height(Dimensions.Spacing.xLarge))
-
-        BottomSheetButtons(onDecline, onAccept)
+  Column(modifier = Modifier.padding(Dimensions.Padding.xLarge)) {
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+      Icon(
+          Icons.Default.Close,
+          NotificationsTabUi.NotificationSheet.Content.CLOSE_ICON_DESCRIPTION,
+          tint = AppColors.textIcons,
+          modifier = Modifier.clickable { onClose() })
     }
-}
 
+    Spacer(Modifier.height(Dimensions.Spacing.small))
+
+    Row(verticalAlignment = Alignment.CenterVertically) {
+      LetterAvatar(
+          letter =
+              title.firstOrNull() ?: NotificationsTabUi.NotificationCard.Fallbacks.FALLBACK_LETTER,
+          size = NotificationsTabUi.NotificationSheet.AVATAR_SIZE,
+          imageBytes = avatarBytes)
+
+      Spacer(Modifier.width(Dimensions.Spacing.large))
+
+      Column {
+        Text(
+            title,
+            style = MaterialTheme.typography.titleLarge,
+            color = AppColors.textIcons,
+            modifier = Modifier.testTag(NotificationsTabTestTags.SHEET_TITLE))
+        if (subtitle != null) {
+          Text(subtitle, style = MaterialTheme.typography.bodyMedium, color = AppColors.textIcons)
+        }
+      }
+    }
+
+    if (meta != null) {
+      Spacer(Modifier.height(Dimensions.Spacing.medium))
+      Text(meta, style = MaterialTheme.typography.bodyMedium, color = AppColors.textIconsFade)
+    }
+
+    Spacer(Modifier.height(Dimensions.Spacing.extraLarge))
+
+    Text(
+        text = aboutLabel,
+        style = MaterialTheme.typography.titleMedium,
+        color = AppColors.textIcons,
+        fontWeight = FontWeight.SemiBold,
+        modifier = Modifier.padding(bottom = Dimensions.Padding.mediumSmall))
+
+    ExpandableText(
+        text = description,
+        previewCharLimit = previewCharLimit,
+        modifier = Modifier.testTag(NotificationsTabTestTags.SHEET_DESCRIPTION))
+
+    Spacer(Modifier.height(Dimensions.Spacing.xLarge))
+
+    BottomSheetButtons(onDecline, onAccept)
+  }
+}
 
 /**
  * Composable to manage expandable text
+ *
  * @param text Text that can be too long
  * @param previewCharLimit Limit to how many characters to display
  * @param modifier Modifier applied to this composable
@@ -1179,31 +1136,30 @@ fun ExpandableText(
     previewCharLimit: Int = NotificationsTabUi.ExpandableText.DEFAULT_PREVIEW_CHAR_LIMIT,
     modifier: Modifier = Modifier
 ) {
-    var expanded by remember { mutableStateOf(false) }
+  var expanded by remember { mutableStateOf(false) }
 
-    Column(modifier = modifier.semantics(mergeDescendants = true) {}) {
-        Text(
-            if (expanded || text.length <= previewCharLimit) text
-            else text.take(previewCharLimit) + NotificationsTabUi.ExpandableText.MORE_INDICATOR,
-            color = AppColors.textIcons)
+  Column(modifier = modifier.semantics(mergeDescendants = true) {}) {
+    Text(
+        if (expanded || text.length <= previewCharLimit) text
+        else text.take(previewCharLimit) + NotificationsTabUi.ExpandableText.MORE_INDICATOR,
+        color = AppColors.textIcons)
 
-        if (text.length > previewCharLimit) {
-            Text(
-                text =
-                    if (expanded) NotificationsTabUi.ExpandableText.SHOW_LESS
-                    else NotificationsTabUi.ExpandableText.SHOW_MORE,
-                color = AppColors.textIcons,
-                fontWeight = FontWeight.Bold,
-                modifier =
-                    Modifier.padding(top = Dimensions.Padding.small).clickable {
-                        expanded = !expanded
-                    })
-        }
+    if (text.length > previewCharLimit) {
+      Text(
+          text =
+              if (expanded) NotificationsTabUi.ExpandableText.SHOW_LESS
+              else NotificationsTabUi.ExpandableText.SHOW_MORE,
+          color = AppColors.textIcons,
+          fontWeight = FontWeight.Bold,
+          modifier =
+              Modifier.padding(top = Dimensions.Padding.small).clickable { expanded = !expanded })
     }
+  }
 }
 
 /**
  * Fallback when user/discussion do not have a picture
+ *
  * @param letter Letter to use for the fake avatar
  * @param size Size of the avatar bubble
  * @param modifier Modifiers to apply to this screen
@@ -1216,52 +1172,50 @@ fun LetterAvatar(
     modifier: Modifier = Modifier,
     imageBytes: ByteArray? = null
 ) {
-    if (imageBytes != null) {
-        AsyncImage(
-            model = imageBytes,
-            contentDescription = null,
-            contentScale = ContentScale.Crop,
-            modifier = modifier.size(size).clip(CircleShape))
-    } else {
-        Box(
-            modifier = modifier.size(size).clip(CircleShape).background(AppColors.neutral),
-            contentAlignment = Alignment.Center) {
-            Text(
-                text = letter.uppercase(),
-                color = AppColors.primary,
-                fontSize =
-                    (size.value * NotificationsTabUi.LetterAvatar.SIZE_MULTIPLIER).sp,
-                fontWeight = FontWeight.Bold)
+  if (imageBytes != null) {
+    AsyncImage(
+        model = imageBytes,
+        contentDescription = null,
+        contentScale = ContentScale.Crop,
+        modifier = modifier.size(size).clip(CircleShape))
+  } else {
+    Box(
+        modifier = modifier.size(size).clip(CircleShape).background(AppColors.neutral),
+        contentAlignment = Alignment.Center) {
+          Text(
+              text = letter.uppercase(),
+              color = AppColors.primary,
+              fontSize = (size.value * NotificationsTabUi.LetterAvatar.SIZE_MULTIPLIER).sp,
+              fontWeight = FontWeight.Bold)
         }
-    }
+  }
 }
 
 /**
  * Handles no notification being available for a filter
+ *
  * @param filter Selected filter
  * @param modifier Modifiers to apply to this composable
  */
 @Composable
 fun EmptyNotificationState(filter: NotificationFilter, modifier: Modifier = Modifier) {
-    val message =
-        when (filter) {
-            NotificationFilter.ALL -> NotificationsTabUi.EmptyState.Messages.ALL
-            NotificationFilter.UNREAD -> NotificationsTabUi.EmptyState.Messages.UNREAD
-            NotificationFilter.FRIEND_REQUESTS ->
-                NotificationsTabUi.EmptyState.Messages.FRIEND_REQUESTS
-            NotificationFilter.DISCUSSIONS -> NotificationsTabUi.EmptyState.Messages.DISCUSSIONS
-            NotificationFilter.SESSIONS -> NotificationsTabUi.EmptyState.Messages.SESSIONS
-        }
+  val message =
+      when (filter) {
+        NotificationFilter.ALL -> NotificationsTabUi.EmptyState.Messages.ALL
+        NotificationFilter.UNREAD -> NotificationsTabUi.EmptyState.Messages.UNREAD
+        NotificationFilter.FRIEND_REQUESTS -> NotificationsTabUi.EmptyState.Messages.FRIEND_REQUESTS
+        NotificationFilter.DISCUSSIONS -> NotificationsTabUi.EmptyState.Messages.DISCUSSIONS
+        NotificationFilter.SESSIONS -> NotificationsTabUi.EmptyState.Messages.SESSIONS
+      }
 
-    Column(
-        modifier =
-            modifier.fillMaxSize().padding(Dimensions.Padding.xxxLarge),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally) {
+  Column(
+      modifier = modifier.fillMaxSize().padding(Dimensions.Padding.xxxLarge),
+      verticalArrangement = Arrangement.Center,
+      horizontalAlignment = Alignment.CenterHorizontally) {
         Text(
             text = message,
             color = AppColors.textIconsFade,
             style = MaterialTheme.typography.bodyLarge,
             modifier = Modifier.testTag(NotificationsTabTestTags.EMPTY_STATE_TEXT))
-    }
+      }
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/account/ProfileScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/ProfileScreen.kt
@@ -43,6 +43,7 @@ fun ProfileScreen(
     navigation: NavigationActions,
     viewModel: ProfileScreenViewModel = viewModel(),
     account: Account,
+    onClickNotifications: () -> Unit,
     onSignOutOrDel: () -> Unit,
     onDelete: () -> Unit
 ) {
@@ -64,7 +65,7 @@ fun ProfileScreen(
                   viewModel = viewModel,
                   account = account,
                   onFriendsClick = {}, // define when implemented
-                  onNotificationClick = {}, // define when implemented
+                  onNotificationClick = onClickNotifications,
                   onSignOutOrDel = onSignOutOrDel,
                   onDelete = onDelete)
             }

--- a/app/src/main/java/com/github/meeplemeet/ui/navigation/NavigationSystem.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/navigation/NavigationSystem.kt
@@ -149,6 +149,7 @@ enum class MeepleMeetScreen(
   CreateSpaceRenter("Create Space Renter"),
   SpaceDetails("Space Renter Details"),
   EditSpaceRenter("Edit Space Renter"),
+  NotificationsTab("Notifications tab"),
   Friends("Friends"),
 }
 


### PR DESCRIPTION
## Overview
This PR implements the notifications tab of the profile screen. It is one of the 3 screens/tabs for the Profile Screen. It exposes to the user all of notifications/actions, allowing him to connect with other users through friend requests, discussion and session invites.
This includes the following:

### Filters
- User can filter his notifications by type (friends requests, discussion invites, session invites) and status (marked as read/all).
- Unread notifications appear with a blue-ish background and a red eye-catching dot. Display is the same no matter the filter.

### Section Ordering
- Notifications are placed in one of 3 sections, depending on the time they were sent at. Currently the 3 sections are "Today", "Yesterday" and "Earlier".
- Notifications are ordered in descending order within each section.

### Notification Interactability
- Swipe left to delete the notification.
- Swipe right to mark the notification as read.
- Click on the notification to take action relating to it's type:
  In all 3 cases, the user can either ignore (close the popup), deny the request (which does the same as ignoring) or accept the friend request/join the discussion/session. All 3 actions will mark as read the notification.
  - Upon clicking on a friend request, user can view information relating to the user who sent the friend request.
  - Upon clicking on a discussion, user can view information relating to the discussion that he's being invited to.
  - Upon clicking on a session, user cna view information relating to the discussion that he's being invited to.
  
#### Known limitations
As this is a part of the ProfileScreen, it is not easy to test through the app for friend request/discussion/session notifications. User flow will become much easier once all 3 tabs/screens are merged together.
	
Demo link (incomplete demo): 
<img src="https://github.com/user-attachments/assets/ac87a34b-d9bd-4b4c-a255-5c58332680f2" width="500" height="1000"/>