### PR TITLE
211 bug app crashing when refusing location permission

### DIFF
--- a/app/src/main/java/com/github/meeplemeet/ui/MapScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/MapScreen.kt
@@ -472,7 +472,8 @@ fun MapScreen(
                       .testTag(MapScreenTestTags.GOOGLE_MAP_SCREEN),
               cameraPositionState = cameraPositionState,
               properties =
-                  MapProperties(mapStyleOptions = mapStyleOptions, isMyLocationEnabled = true)) {
+                  MapProperties(
+                      mapStyleOptions = mapStyleOptions, isMyLocationEnabled = permissionGranted)) {
                 val clusters = viewModel.getClusters()
 
                 clusters


### PR DESCRIPTION
**Fix app crashing when refusing to give location permission.**

Related to #211

The crash occurred because `isMyLocationEnabled` was always set to true, which triggered a `SecurityException `when location permission was denied. 
This fix conditions `isMyLocationEnabled `on `permissionGranted`, ensuring the map loads gracefully without crashing.