### PR TITLE
Prevent creating sessions in the past with inline validation

### DIFF
--- a/app/src/main/java/com/github/meeplemeet/ui/components/SessionComponents.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/SessionComponents.kt
@@ -45,6 +45,7 @@ import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.RangeSlider
+import androidx.compose.material3.SelectableDates
 import androidx.compose.material3.SliderColors
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Surface
@@ -550,7 +551,21 @@ fun AppDatePickerDialog(
     onDateSelected: (LocalDate) -> Unit,
     zoneId: ZoneId = ZoneId.systemDefault()
 ) {
-  val state = rememberDatePickerState(initialDisplayMode = DisplayMode.Picker)
+  // Create a SelectableDates object that only allows dates from today onwards
+  val selectableDates = remember {
+    object : SelectableDates {
+      override fun isSelectableDate(utcTimeMillis: Long): Boolean {
+        val selectedDate =
+            Instant.ofEpochMilli(utcTimeMillis).atZone(ZoneId.of("UTC")).toLocalDate()
+        val today = LocalDate.now(zoneId)
+        return !selectedDate.isBefore(today)
+      }
+    }
+  }
+
+  val state =
+      rememberDatePickerState(
+          initialDisplayMode = DisplayMode.Picker, selectableDates = selectableDates)
 
   DatePickerDialog(
       onDismissRequest = onDismiss,

--- a/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionDetailsScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionDetailsScreen.kt
@@ -233,7 +233,8 @@ fun SessionDetailsScreen(
             text = SESSION_DETAILS_TITLE,
             onReturn = {
               // Only admins/owners can persist changes to the session on back navigation.
-              if (isCurrUserAdmin) {
+              // If validation fails, navigate back without saving changes.
+              if (isCurrUserAdmin && !isDateTimeInPast(form.date, form.time)) {
                 viewModel.updateSession(
                     requester = account,
                     discussion = discussion,
@@ -654,12 +655,24 @@ fun OrganizationSection(
         Spacer(Modifier.height(Dimensions.Spacing.extraMedium))
 
         // Time field using the new TimeField composable
-        Box(Modifier.onFocusChanged { onFocusChanged(it.isFocused) }) {
-          TimeField(
-              value = form.time.toString(),
-              onValueChange = { onFormChange(form.copy(time = it)) },
-              editable = editable,
-              modifier = Modifier.fillMaxWidth())
+        Column {
+          Box(Modifier.onFocusChanged { onFocusChanged(it.isFocused) }) {
+            TimeField(
+                value = form.time.toString(),
+                onValueChange = { onFormChange(form.copy(time = it)) },
+                editable = editable,
+                modifier = Modifier.fillMaxWidth())
+          }
+
+          // Show error if date/time is in the past (only for admins who can edit)
+          if (editable && isDateTimeInPast(form.date, form.time)) {
+            Spacer(Modifier.height(Dimensions.Spacing.extraSmall))
+            Text(
+                text = "Cannot update session to a time in the past",
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.padding(start = Dimensions.Padding.medium))
+          }
         }
         Spacer(Modifier.height(Dimensions.Spacing.extraMedium))
 


### PR DESCRIPTION
  This PR adds validation to prevent users from creating or updating sessions with dates/times in the past. The changes include:

  - Added SelectableDates to the date picker dialog to disable selection of past dates
  - Created isDateTimeInPast() helper function to validate date/time combinations
  - Disabled the "Create" button when selected date/time is in the past
  - Display error messages when users attempt to select past date/times
  - Prevent admins from updating sessions to past date/times on the Session Details screen

  The validation respects the user's timezone and provides clear error messaging to guide users toward selecting valid future dates.

  ---
  🤖 Generated with https://claude.com/claude-code