### PR TITLE
Fix session creation using correct repository method

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/integration/FirestoreSessionTests.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/FirestoreSessionTests.kt
@@ -186,14 +186,7 @@ class FirestoreSessionTests : FirestoreTests() {
   fun canRemoveUserFromSession() = runTest {
     // First create a session with two participants
     viewModel.createSession(
-        account1,
-        baseDiscussion,
-        "Catan Night",
-        "game123",
-        testTimestamp,
-        testLocation,
-        account1,
-        account2)
+        account1, baseDiscussion, "Catan Night", "game123", testTimestamp, testLocation, account2)
     advanceUntilIdle()
 
     val discussionWithSession = discussionRepository.getDiscussion(baseDiscussion.uid)
@@ -329,7 +322,7 @@ class FirestoreSessionTests : FirestoreTests() {
   @Test
   fun creatingSessionUpdatesDiscussionState() = runTest {
     viewModel.createSession(
-        account1, baseDiscussion, "Catan Night", "game123", testTimestamp, testLocation, account1)
+        account1, baseDiscussion, "Catan Night", "game123", testTimestamp, testLocation)
     advanceUntilIdle()
 
     val result = discussionRepository.getDiscussion(baseDiscussion.uid)
@@ -408,7 +401,6 @@ class FirestoreSessionTests : FirestoreTests() {
         "game123",
         testTimestamp,
         testLocation,
-        account1,
         account3) // account3 not in discussion
     advanceUntilIdle()
 
@@ -803,14 +795,7 @@ class FirestoreSessionTests : FirestoreTests() {
   fun nonAdminCanLeaveSession() = runTest {
     // First create a session with two participants
     viewModel.createSession(
-        account1,
-        baseDiscussion,
-        "Catan Night",
-        "game123",
-        testTimestamp,
-        testLocation,
-        account1,
-        account2)
+        account1, baseDiscussion, "Catan Night", "game123", testTimestamp, testLocation, account2)
     advanceUntilIdle()
 
     val discussionWithSession = discussionRepository.getDiscussion(baseDiscussion.uid)

--- a/app/src/main/java/com/github/meeplemeet/model/sessions/CreateSessionViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/sessions/CreateSessionViewModel.kt
@@ -76,13 +76,14 @@ open class CreateSessionViewModel(
                     requester.relationships[account.uid] == RelationshipStatus.FRIEND
           }
 
-      sessionRepository.updateSession(
+      sessionRepository.createSession(
           discussion.uid,
           name,
           gameId,
           date,
           location,
-          participantsToAdd.map { it.uid }.toSet().toList())
+          requester.uid,
+          *participantsToAdd.map { it.uid }.toTypedArray())
 
       // Send a join request to the rest
       participants

--- a/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionScreen.kt
@@ -292,14 +292,16 @@ fun DiscussionScreen(
                         }
                   },
                   actions = {
+                    val isAdmin =
+                        discussion.admins.contains(account.uid) ||
+                            discussion.creatorId == account.uid
+                    val hasSession = discussion.session != null
+                    val inSession =
+                        hasSession && discussion.session!!.participants.contains(account.uid)
                     val icon =
                         when {
-                          discussion.session != null &&
-                              discussion.session.participants.contains(account.uid) ->
-                              Icons.Default.Games
-                          discussion.participants.size > 1 &&
-                              (discussion.admins.contains(account.uid) ||
-                                  discussion.creatorId == account.uid) -> Icons.Default.LibraryAdd
+                          !hasSession && isAdmin -> Icons.Default.LibraryAdd
+                          inSession -> Icons.Default.Games
                           else -> null
                         }
 


### PR DESCRIPTION
This PR fixes a bug where session creation was incorrectly using updateSession() instead of createSession(). The changes include:

  - Updated CreateSessionViewModel to call createSession() with the proper method signature
  - Changed participant handling to use varargs format instead of a list
  - Added creator UID as a required parameter for session creation
  - Refined the action icon logic in DiscussionScreen to properly show the "Add Session" icon only for admins when no session exists, and the "Games" icon for users already in a session

  ---
  🤖 Generated with https://claude.com/claude-code