### PR TITLE
feat(ui): make messages editable and removable

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/ui/PostScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/PostScreenTest.kt
@@ -185,7 +185,13 @@ class PostScreenTest : FirestoreTests() {
     checkpoint("tags_display_correctly") {
       // Switch to Alex's post (has tags ["boardgames", "lausanne"])
       postIdState.value = postByAlex.id
-      compose.waitForIdle()
+
+      compose.waitUntil(timeoutMillis = 5_000) {
+        compose
+            .onAllNodesWithTag(PostTags.POST_BODY, useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .isNotEmpty()
+      }
 
       val screenNodes =
           compose.onAllNodesWithTag(PostTags.SCREEN, useUnmergedTree = true).fetchSemanticsNodes()

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/PostScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/PostScreenTest.kt
@@ -4,7 +4,10 @@ package com.github.meeplemeet.ui
 
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -18,6 +21,7 @@ import com.github.meeplemeet.model.posts.Comment
 import com.github.meeplemeet.model.posts.Post
 import com.github.meeplemeet.model.posts.PostRepository
 import com.github.meeplemeet.model.posts.PostViewModel
+import com.github.meeplemeet.model.posts.toNoUid
 import com.github.meeplemeet.ui.posts.COMMENT_TEXT_ZONE_PLACEHOLDER
 import com.github.meeplemeet.ui.posts.PostScreen
 import com.github.meeplemeet.ui.posts.PostTags
@@ -26,6 +30,8 @@ import com.github.meeplemeet.utils.Checkpoint
 import com.github.meeplemeet.utils.FirestoreTests
 import com.google.firebase.Timestamp
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.tasks.await
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -44,7 +50,8 @@ class PostScreenTest : FirestoreTests() {
       Account(uid = "u_alex", handle = "alex", name = "Alex", email = "alex@meeple.ch")
   private val dany =
       Account(uid = "u_dany", handle = "dany", name = "Dany", email = "dany@meeple.ch")
-  private val ts = Timestamp(1_725_000_000, 0)
+
+  private val ts = Timestamp.now()
 
   private fun testComment(id: String, text: String, author: Account, vararg children: Comment) =
       Comment(
@@ -57,29 +64,46 @@ class PostScreenTest : FirestoreTests() {
   private lateinit var postByAlex: Post
   private lateinit var postByMarco: Post
 
-  /* Fake AccountViewModel */
+  /* Fake AccountViewModel that never hits Firestore */
   private inner class FakeAccountViewModel : ViewModel(), AccountViewModel {
     override val scope: CoroutineScope
       get() = viewModelScope
 
     private val accounts = mutableMapOf(marco.uid to marco, alex.uid to alex, dany.uid to dany)
 
-    override fun getOtherAccount(uid: String, onResult: (Account) -> Unit) {
-      if (uid.isBlank()) return
-      accounts[uid]?.let { onResult(it) }
+    override fun getOtherAccount(id: String, onResult: (Account) -> Unit) {
+      if (id.isBlank()) return
+      accounts[id]?.let { onResult(it) }
+    }
+
+    override fun getAccounts(uids: List<String>, onResult: (List<Account>) -> Unit) {
+      onResult(uids.mapNotNull { accounts[it] })
     }
   }
 
   /* ViewModels */
-  private lateinit var postRepo: PostRepository
   private lateinit var postVM: PostViewModel
   private lateinit var accountVM: FakeAccountViewModel
+
+  private val postRepo: PostRepository
+    get() = postRepository
 
   /* Query helpers */
   private fun findNodeByTag(tag: String) = compose.onNodeWithTag(tag, useUnmergedTree = true)
 
   private fun findNodeByText() =
       compose.onNodeWithText(COMMENT_TEXT_ZONE_PLACEHOLDER, useUnmergedTree = true)
+
+  private fun seedPostInFirestore(post: Post) {
+    runBlocking {
+      val (postNoUid, commentDocs) = toNoUid(post)
+      val docRef = postRepo.collection.document(post.id)
+      docRef.set(postNoUid).await()
+
+      val commentsCol = docRef.collection("comments")
+      commentDocs.forEach { comment -> commentsCol.document(comment.id).set(comment).await() }
+    }
+  }
 
   @Before
   fun setup() {
@@ -91,23 +115,28 @@ class PostScreenTest : FirestoreTests() {
 
     postByAlex =
         Post(
-            id = "p1",
+            id = "p_alex",
             title = "Friday Root Night",
             body = "Who wants to play Root or Ark Nova?",
             timestamp = ts,
             authorId = alex.uid,
             tags = listOf("boardgames", "lausanne"),
             comments = listOf(c1, c2))
-    postByMarco = postByAlex.copy(id = "p2", authorId = marco.uid)
 
-    postRepo = PostRepository()
+    // Same content but owned by Marco (this is the editable one)
+    postByMarco = postByAlex.copy(id = "p_marco", authorId = marco.uid)
+
     postVM = PostViewModel(postRepo)
     accountVM = FakeAccountViewModel()
+
+    seedPostInFirestore(postByAlex)
+    seedPostInFirestore(postByMarco)
   }
 
   @Test
   fun all_post_screen_tests() {
     var backCount = 0
+    // Start with a non-existent post to test loading state
     val postIdState = mutableStateOf("p_nonexistent")
 
     compose.setContent {
@@ -142,8 +171,8 @@ class PostScreenTest : FirestoreTests() {
     }
 
     checkpoint("composer_bar_exists_and_interactions") {
-      // Switch to a different post ID
-      postIdState.value = "p_test"
+      // Switch to Marco's own post (exists and is editable)
+      postIdState.value = postByMarco.id
       compose.waitForIdle()
 
       findNodeByTag(PostTags.COMPOSER_BAR).assertExists()
@@ -154,12 +183,36 @@ class PostScreenTest : FirestoreTests() {
     }
 
     checkpoint("tags_display_correctly") {
-      postIdState.value = "p_tags"
+      // Switch to Alex's post (has tags ["boardgames", "lausanne"])
+      postIdState.value = postByAlex.id
       compose.waitForIdle()
+
+      val screenNodes =
+          compose.onAllNodesWithTag(PostTags.SCREEN, useUnmergedTree = true).fetchSemanticsNodes()
+      assert(screenNodes.isNotEmpty())
+
+      val bodyNodes =
+          compose
+              .onAllNodesWithTag(PostTags.POST_BODY, useUnmergedTree = true)
+              .fetchSemanticsNodes()
+      assert(bodyNodes.isNotEmpty())
+
+      compose.waitUntil(timeoutMillis = 5_000) {
+        compose
+            .onAllNodesWithText("boardgames", useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .isNotEmpty()
+      }
+      compose.waitUntil(timeoutMillis = 5_000) {
+        compose
+            .onAllNodesWithText("lausanne", useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .isNotEmpty()
+      }
     }
 
     checkpoint("character_counter_not_visible_initially") {
-      postIdState.value = "p_test"
+      postIdState.value = postByMarco.id
       compose.waitForIdle()
 
       // Counter should not be visible initially
@@ -167,15 +220,15 @@ class PostScreenTest : FirestoreTests() {
     }
 
     checkpoint("character_counter_appears_when_approaching_limit") {
-      // Type text to get close to limit (2048 - 100 = 1948 chars to trigger counter)
+      // Type text to get close to limit
       val longText = "a".repeat(1950)
       findNodeByTag(PostTags.COMPOSER_INPUT).performTextReplacement(longText)
       compose.waitForIdle()
 
       // Counter should now be visible
       findNodeByTag(PostTags.COMPOSER_CHAR_COUNTER).assertExists()
-      // Should show remaining chars (2048 - 1950 = 98)
-      compose.onNodeWithText("98").assertExists()
+      // Should show remaining chars
+      compose.onNodeWithText("98", useUnmergedTree = true).assertExists()
     }
 
     checkpoint("character_counter_shows_warning_when_low") {
@@ -186,7 +239,7 @@ class PostScreenTest : FirestoreTests() {
 
       // Counter should be visible showing 18 chars remaining
       findNodeByTag(PostTags.COMPOSER_CHAR_COUNTER).assertExists()
-      compose.onNodeWithText("18").assertExists()
+      compose.onNodeWithText("18", useUnmergedTree = true).assertExists()
     }
 
     checkpoint("character_limit_enforced") {
@@ -197,14 +250,127 @@ class PostScreenTest : FirestoreTests() {
 
       // Counter should show 0 chars remaining
       findNodeByTag(PostTags.COMPOSER_CHAR_COUNTER).assertExists()
-      compose.onNodeWithText("0").assertExists()
+      compose.onNodeWithText("0", useUnmergedTree = true).assertExists()
 
       // Verify we can't type more - text input should still be exactly 2048 chars
       findNodeByTag(PostTags.COMPOSER_INPUT).performTextInput("b")
       compose.waitForIdle()
 
       // Counter should still show 0 (input rejected)
-      compose.onNodeWithText("0").assertExists()
+      compose.onNodeWithText("0", useUnmergedTree = true).assertExists()
+    }
+
+    checkpoint("edit_buttons_visible_only_for_own_post") {
+      // First show Alex's post (Marco is NOT the author) -> no edit buttons
+      postIdState.value = postByAlex.id
+      compose.waitForIdle()
+
+      findNodeByTag(PostTags.POST_BODY).assertExists()
+
+      compose.onNodeWithTag(PostTags.POST_EDIT_BTN, useUnmergedTree = true).assertDoesNotExist()
+      compose
+          .onNodeWithTag(PostTags.POST_BODY_EDIT_BTN, useUnmergedTree = true)
+          .assertDoesNotExist()
+
+      // Now show Marco's post -> edit buttons should be visible
+      postIdState.value = postByMarco.id
+      compose.waitForIdle()
+
+      findNodeByTag(PostTags.POST_BODY).assertExists()
+
+      compose.onNodeWithTag(PostTags.POST_EDIT_BTN, useUnmergedTree = true).assertExists()
+      compose.onNodeWithTag(PostTags.POST_BODY_EDIT_BTN, useUnmergedTree = true).assertExists()
+    }
+
+    checkpoint("edit_post_body_prefillsComposerAndUpdatesBody") {
+      postIdState.value = postByMarco.id
+      compose.waitForIdle()
+
+      // Wait for body text to be present
+      findNodeByTag(PostTags.POST_BODY).assertExists()
+
+      // Tap the body edit button
+      compose
+          .onNodeWithTag(PostTags.POST_BODY_EDIT_BTN, useUnmergedTree = true)
+          .assertExists()
+          .assertHasClickAction()
+          .performClick()
+      compose.waitForIdle()
+
+      // Composer should be prefilled with the original body
+      compose
+          .onNodeWithTag(PostTags.COMPOSER_INPUT, useUnmergedTree = true)
+          .assertExists()
+          .assertTextEquals(postByMarco.body)
+
+      // Replace with new body text
+      val updatedBody = "Updated body from test about Root and Ark Nova."
+      compose
+          .onNodeWithTag(PostTags.COMPOSER_INPUT, useUnmergedTree = true)
+          .performTextReplacement(updatedBody)
+
+      // Send edit
+      compose
+          .onNodeWithTag(PostTags.COMPOSER_SEND, useUnmergedTree = true)
+          .assertHasClickAction()
+          .performClick()
+      compose.waitForIdle()
+
+      // Composer should be cleared after sending
+      compose.onNodeWithTag(PostTags.COMPOSER_INPUT, useUnmergedTree = true).assertTextEquals("")
+
+      // Wait until the updated body appears in the UI
+      compose.waitUntil(timeoutMillis = 5_000) {
+        compose
+            .onAllNodesWithText(updatedBody, useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .isNotEmpty()
+      }
+    }
+
+    checkpoint("edit_post_title_prefillsComposerAndUpdatesTitle") {
+      postIdState.value = postByMarco.id
+      compose.waitForIdle()
+
+      // Wait for title
+      findNodeByTag(PostTags.POST_TITLE).assertExists()
+
+      // Tap the title edit button
+      compose
+          .onNodeWithTag(PostTags.POST_EDIT_BTN, useUnmergedTree = true)
+          .assertExists()
+          .assertHasClickAction()
+          .performClick()
+      compose.waitForIdle()
+
+      // Composer should be prefilled with the current title
+      compose
+          .onNodeWithTag(PostTags.COMPOSER_INPUT, useUnmergedTree = true)
+          .assertExists()
+          .assertTextEquals(postByMarco.title)
+
+      val updatedTitle = "Updated Friday Root Night"
+      compose
+          .onNodeWithTag(PostTags.COMPOSER_INPUT, useUnmergedTree = true)
+          .performTextReplacement(updatedTitle)
+
+      // Send edit
+      compose
+          .onNodeWithTag(PostTags.COMPOSER_SEND, useUnmergedTree = true)
+          .assertHasClickAction()
+          .performClick()
+      compose.waitForIdle()
+
+      // Composer cleared
+      compose.onNodeWithTag(PostTags.COMPOSER_INPUT, useUnmergedTree = true).assertTextEquals("")
+
+      // Wait until updated title appears in UI
+      compose.waitUntil(timeoutMillis = 5_000) {
+        compose
+            .onAllNodesWithText(updatedTitle, useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .isNotEmpty()
+      }
     }
   }
 }

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/PostScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/PostScreenTest.kt
@@ -23,13 +23,14 @@ import com.github.meeplemeet.ui.posts.PostScreen
 import com.github.meeplemeet.ui.posts.PostTags
 import com.github.meeplemeet.ui.theme.AppTheme
 import com.github.meeplemeet.utils.Checkpoint
+import com.github.meeplemeet.utils.FirestoreTests
 import com.google.firebase.Timestamp
 import kotlinx.coroutines.CoroutineScope
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
-class PostScreenTest {
+class PostScreenTest : FirestoreTests() {
 
   @get:Rule val compose = createComposeRule()
   @get:Rule val ck = Checkpoint.Rule()
@@ -67,10 +68,6 @@ class PostScreenTest {
       if (uid.isBlank()) return
       accounts[uid]?.let { onResult(it) }
     }
-
-    fun addAccount(account: Account) {
-      accounts[account.uid] = account
-    }
   }
 
   /* ViewModels */
@@ -83,24 +80,6 @@ class PostScreenTest {
 
   private fun findNodeByText() =
       compose.onNodeWithText(COMMENT_TEXT_ZONE_PLACEHOLDER, useUnmergedTree = true)
-
-  private fun settleAnimations() {
-    compose.mainClock.advanceTimeBy(700)
-    compose.waitForIdle()
-  }
-
-  private fun setContent(account: Account = marco, postId: String = "p1", onBack: () -> Unit = {}) {
-    compose.setContent {
-      AppTheme {
-        PostScreen(
-            account = account,
-            postId = postId,
-            postViewModel = postVM,
-            accountViewModel = accountVM,
-            onBack = onBack)
-      }
-    }
-  }
 
   @Before
   fun setup() {

--- a/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionScreen.kt
@@ -470,9 +470,8 @@ fun DiscussionScreen(
                         }
 
                     // Selected message overlay
-                    if (hasSelection) {
-                      val overlayAnchor = anchor!!
-                      val relativeOffsetY = overlayAnchor.top - messagesContainerTopPx
+                    if (actionMessage != null && anchor != null) {
+                      val relativeOffsetY = anchor.top - messagesContainerTopPx
 
                       Box(modifier = Modifier.fillMaxSize().clipToBounds()) {
                         // Scrim
@@ -488,51 +487,56 @@ fun DiscussionScreen(
                                         interactionSource =
                                             remember { MutableInteractionSource() }) {})
 
-                        val message = actionMessage!!
-                        val isMineOverlay = message.senderId == account.uid
+                        val isMineOverlay = actionMessage.senderId == account.uid
                         val senderOverlay =
-                            if (!isMineOverlay) userCache[message.senderId]?.name ?: "Unknown"
+                            if (!isMineOverlay) userCache[actionMessage.senderId]?.name ?: "Unknown"
                             else DiscussionCommons.YOU_SENDER_NAME
 
-                        val msgIndex = messages.indexOfFirst { it.uid == message.uid }
+                        val msgIndex = messages.indexOfFirst { it.uid == actionMessage.uid }
                         if (msgIndex >= 0) {
                           val prevMessageOverlay = messages.getOrNull(msgIndex - 1)
                           val nextMessageOverlay = messages.getOrNull(msgIndex + 1)
                           val showDateHeaderOverlay =
                               shouldShowDateHeader(
-                                  current = message.createdAt.toDate(),
+                                  current = actionMessage.createdAt.toDate(),
                                   previous = prevMessageOverlay?.createdAt?.toDate())
                           val isLastFromSenderOverlay =
-                              nextMessageOverlay?.senderId != message.senderId
+                              nextMessageOverlay?.senderId != actionMessage.senderId
                           val isFirstFromSenderOverlay =
-                              prevMessageOverlay?.senderId != message.senderId ||
+                              prevMessageOverlay?.senderId != actionMessage.senderId ||
                                   showDateHeaderOverlay
 
                           Box(
                               modifier =
                                   Modifier.offset { IntOffset(x = 0, y = relativeOffsetY) }) {
                                 when {
-                                  message.poll != null -> {
+                                  actionMessage.poll != null -> {
                                     PollBubble(
                                         msgIndex = msgIndex,
-                                        poll = message.poll,
+                                        poll = actionMessage.poll,
                                         authorName = senderOverlay,
                                         currentUserId = account.uid,
                                         onVote = { optionIndex, isRemoving ->
                                           if (isRemoving) {
                                             viewModel.removeVoteFromPollAsync(
-                                                discussion.uid, message.uid, account, optionIndex)
+                                                discussion.uid,
+                                                actionMessage.uid,
+                                                account,
+                                                optionIndex)
                                           } else {
                                             viewModel.voteOnPollAsync(
-                                                discussion.uid, message.uid, account, optionIndex)
+                                                discussion.uid,
+                                                actionMessage.uid,
+                                                account,
+                                                optionIndex)
                                           }
                                         },
-                                        createdAt = message.createdAt.toDate(),
+                                        createdAt = actionMessage.createdAt.toDate(),
                                         showProfilePicture = isLastFromSenderOverlay)
                                   }
-                                  message.photoUrl != null -> {
+                                  actionMessage.photoUrl != null -> {
                                     PhotoBubble(
-                                        message = message,
+                                        message = actionMessage,
                                         isMine = isMineOverlay,
                                         senderName = senderOverlay,
                                         showProfilePicture = isLastFromSenderOverlay,
@@ -543,7 +547,7 @@ fun DiscussionScreen(
                                   }
                                   else -> {
                                     ChatBubble(
-                                        message = message,
+                                        message = actionMessage,
                                         isMine = isMineOverlay,
                                         senderName = senderOverlay,
                                         showProfilePicture = isLastFromSenderOverlay,

--- a/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionScreen.kt
@@ -39,7 +39,6 @@ import androidx.compose.runtime.*
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.CornerRadius
@@ -379,95 +378,87 @@ fun DiscussionScreen(
                     val hasSelection = actionMessage != null && anchor != null
 
                     // Messages list
-                    LazyColumn(
-                        state = listState,
-                        modifier =
-                            Modifier.fillMaxSize().let { base ->
-                              if (hasSelection) base.blur(Dimensions.Blurring.tiny) else base
-                            }) {
-                          itemsIndexed(items = messages, key = { _, msg -> msg.uid }) {
-                              index,
-                              message ->
-                            val isMine = message.senderId == account.uid
-                            val sender =
-                                if (!isMine) userCache[message.senderId]?.name ?: "Unknown"
-                                else DiscussionCommons.YOU_SENDER_NAME
+                    LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
+                      itemsIndexed(items = messages, key = { _, msg -> msg.uid }) { index, message
+                        ->
+                        val isMine = message.senderId == account.uid
+                        val sender =
+                            if (!isMine) userCache[message.senderId]?.name ?: "Unknown"
+                            else DiscussionCommons.YOU_SENDER_NAME
 
-                            val showDateHeader =
-                                shouldShowDateHeader(
-                                    current = message.createdAt.toDate(),
-                                    previous = messages.getOrNull(index - 1)?.createdAt?.toDate())
-                            if (showDateHeader) {
-                              Spacer(Modifier.height(Dimensions.Spacing.extraSmall))
-                              DateSeparator(date = message.createdAt.toDate())
-                              Spacer(Modifier.height(Dimensions.Spacing.extraSmall))
+                        val showDateHeader =
+                            shouldShowDateHeader(
+                                current = message.createdAt.toDate(),
+                                previous = messages.getOrNull(index - 1)?.createdAt?.toDate())
+                        if (showDateHeader) {
+                          Spacer(Modifier.height(Dimensions.Spacing.extraSmall))
+                          DateSeparator(date = message.createdAt.toDate())
+                          Spacer(Modifier.height(Dimensions.Spacing.extraSmall))
+                        }
+
+                        val nextMessage = messages.getOrNull(index + 1)
+                        val isLastFromSender = nextMessage?.senderId != message.senderId
+
+                        val prevMessage = messages.getOrNull(index - 1)
+                        val isFirstFromSender =
+                            prevMessage?.senderId != message.senderId || showDateHeader
+
+                        SelectableMessageContainer(
+                            message = message,
+                            isMine = isMine,
+                            onAnchorChanged = { id, anchorPos -> messageAnchors[id] = anchorPos },
+                            onLongPress = { msg ->
+                              selectedMessageForActions = msg
+                              selectedMessageAnchor = messageAnchors[msg.uid]
+                            },
+                        ) {
+                          when {
+                            message.poll != null -> {
+                              PollBubble(
+                                  msgIndex = index,
+                                  poll = message.poll,
+                                  authorName = sender,
+                                  currentUserId = account.uid,
+                                  onVote = { optionIndex, isRemoving ->
+                                    if (isRemoving) {
+                                      viewModel.removeVoteFromPollAsync(
+                                          discussion.uid, message.uid, account, optionIndex)
+                                    } else {
+                                      viewModel.voteOnPollAsync(
+                                          discussion.uid, message.uid, account, optionIndex)
+                                    }
+                                  },
+                                  createdAt = message.createdAt.toDate(),
+                                  showProfilePicture = isLastFromSender)
                             }
-
-                            val nextMessage = messages.getOrNull(index + 1)
-                            val isLastFromSender = nextMessage?.senderId != message.senderId
-
-                            val prevMessage = messages.getOrNull(index - 1)
-                            val isFirstFromSender =
-                                prevMessage?.senderId != message.senderId || showDateHeader
-
-                            SelectableMessageContainer(
-                                message = message,
-                                isMine = isMine,
-                                onAnchorChanged = { id, anchorPos ->
-                                  messageAnchors[id] = anchorPos
-                                },
-                                onLongPress = { msg ->
-                                  selectedMessageForActions = msg
-                                  selectedMessageAnchor = messageAnchors[msg.uid]
-                                },
-                            ) {
-                              when {
-                                message.poll != null -> {
-                                  PollBubble(
-                                      msgIndex = index,
-                                      poll = message.poll,
-                                      authorName = sender,
-                                      currentUserId = account.uid,
-                                      onVote = { optionIndex, isRemoving ->
-                                        if (isRemoving) {
-                                          viewModel.removeVoteFromPollAsync(
-                                              discussion.uid, message.uid, account, optionIndex)
-                                        } else {
-                                          viewModel.voteOnPollAsync(
-                                              discussion.uid, message.uid, account, optionIndex)
-                                        }
-                                      },
-                                      createdAt = message.createdAt.toDate(),
-                                      showProfilePicture = isLastFromSender)
-                                }
-                                message.photoUrl != null -> {
-                                  PhotoBubble(
-                                      message = message,
-                                      isMine = isMine,
-                                      senderName = sender,
-                                      showProfilePicture = isLastFromSender,
-                                      showSenderName = isFirstFromSender,
-                                      allMessages = messages,
-                                      userCache = userCache,
-                                      currentUserId = account.uid)
-                                }
-                                else -> {
-                                  ChatBubble(
-                                      message = message,
-                                      isMine = isMine,
-                                      senderName = sender,
-                                      showProfilePicture = isLastFromSender,
-                                      showSenderName = isFirstFromSender)
-                                }
-                              }
+                            message.photoUrl != null -> {
+                              PhotoBubble(
+                                  message = message,
+                                  isMine = isMine,
+                                  senderName = sender,
+                                  showProfilePicture = isLastFromSender,
+                                  showSenderName = isFirstFromSender,
+                                  allMessages = messages,
+                                  userCache = userCache,
+                                  currentUserId = account.uid)
                             }
-
-                            Spacer(
-                                Modifier.height(
-                                    if (isLastFromSender) Dimensions.Spacing.small
-                                    else Dimensions.Spacing.extraSmall))
+                            else -> {
+                              ChatBubble(
+                                  message = message,
+                                  isMine = isMine,
+                                  senderName = sender,
+                                  showProfilePicture = isLastFromSender,
+                                  showSenderName = isFirstFromSender)
+                            }
                           }
                         }
+
+                        Spacer(
+                            Modifier.height(
+                                if (isLastFromSender) Dimensions.Spacing.small
+                                else Dimensions.Spacing.extraSmall))
+                      }
+                    }
 
                     // Selected message overlay
                     if (hasSelection) {

--- a/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionScreen.kt
@@ -70,7 +70,7 @@ import coil.compose.AsyncImage
 import com.github.meeplemeet.model.account.Account
 import com.github.meeplemeet.model.discussions.Discussion
 import com.github.meeplemeet.model.discussions.DiscussionViewModel
-import com.github.meeplemeet.model.discussions.EDIT_MESSAGE_MAX_THRESHOLD
+import com.github.meeplemeet.model.discussions.EDIT_MAX_THRESHOLD
 import com.github.meeplemeet.model.discussions.Message
 import com.github.meeplemeet.model.discussions.Poll
 import com.github.meeplemeet.model.images.ImageFileUtils
@@ -466,7 +466,7 @@ fun DiscussionScreen(
                       actionMessage.senderId == account.uid &&
                           actionMessage.poll == null &&
                           actionMessage.photoUrl == null &&
-                          nowMs <= messageMs + EDIT_MESSAGE_MAX_THRESHOLD
+                          nowMs <= messageMs + EDIT_MAX_THRESHOLD
 
                   MessageOptionsPopup(
                       isEditable = isEditable,

--- a/app/src/main/java/com/github/meeplemeet/ui/posts/PostScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/posts/PostScreen.kt
@@ -304,13 +304,13 @@ fun PostScreen(
               sendEnabled = !isSending && topComment.isNotBlank() && post != null,
               onSend = {
                 val p = post ?: return@ComposerBar
-                val target = editTarget
-                val editing = target != null
 
                 scope.launch {
                   isSending = true
+                  val target = editTarget
+
                   try {
-                    if (editing && target != null) {
+                    if (target != null) {
                       val value = topComment.trim()
                       when (target) {
                         PostEditTarget.TITLE ->
@@ -323,11 +323,12 @@ fun PostScreen(
                       postViewModel.addComment(
                           author = account, post = p, parentId = p.id, text = topComment.trim())
                     }
+
                     topComment = ""
                     focusManager.clearFocus(force = true)
                   } catch (_: Throwable) {
                     snackbarHostState.showSnackbar(
-                        if (editing) ERROR_NOT_EDITED_POST else ERROR_NOT_SENT_COMMENT)
+                        if (target != null) ERROR_NOT_EDITED_POST else ERROR_NOT_SENT_COMMENT)
                   } finally {
                     isSending = false
                   }

--- a/app/src/main/java/com/github/meeplemeet/ui/posts/PostScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/posts/PostScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.material.icons.filled.ArrowDownward
 import androidx.compose.material.icons.filled.ArrowUpward
 import androidx.compose.material.icons.filled.AttachFile
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.outlined.ChatBubbleOutline
 import androidx.compose.material3.*
 import androidx.compose.material3.HorizontalDivider
@@ -59,6 +60,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.meeplemeet.model.account.Account
 import com.github.meeplemeet.model.account.AccountViewModel
+import com.github.meeplemeet.model.discussions.EDIT_MAX_THRESHOLD
 import com.github.meeplemeet.model.posts.Comment
 import com.github.meeplemeet.model.posts.Post
 import com.github.meeplemeet.model.posts.PostViewModel
@@ -76,6 +78,7 @@ const val ERROR_NOT_SENT_COMMENT: String = "Couldn't send comment. Please try ag
 const val ERROR_NOT_DELETED_POST: String = "Couldn't delete post. Please try again."
 const val ERROR_SEND_REPLY: String = "Couldn't send reply. Please try again."
 const val ERROR_NOT_DELETED_COMMENT: String = "Couldn't delete comment. Please try again."
+const val ERROR_NOT_EDITED_POST: String = "Couldn't edit post. Please try again."
 
 const val TOPBAR_TITLE: String = "Post"
 const val COMMENT_TEXT_ZONE_PLACEHOLDER: String = "Share your thoughts..."
@@ -87,7 +90,7 @@ const val HIDE_REPLIES_TEXT: String = "Hide replies"
 const val MAX_COMMENT_LENGTH: Int = 2048
 
 /* ================================================================
- * Setups
+ * Setups and Helpers
  * ================================================================ */
 
 private typealias ResolveUser = (String) -> Account?
@@ -97,6 +100,11 @@ private object ThreadStyle {
   val GapAfter: Dp = Dimensions.Spacing.small
   val Stroke: Dp = Dimensions.Elevation.medium
   val VerticalInset: Dp = Dimensions.Spacing.small
+}
+
+private enum class PostEditTarget {
+  TITLE,
+  BODY
 }
 
 object PostTags {
@@ -127,6 +135,8 @@ object PostTags {
   fun tagChip(tag: String) = "post_tag_chip:$tag"
 
   const val POST_DELETE_BTN = "post_delete_btn"
+  const val POST_EDIT_BTN = "post_edit_btn"
+  const val POST_BODY_EDIT_BTN = "post_body_edit_btn"
 
   fun threadCard(id: String) = "post_thread_card:$id"
 
@@ -151,6 +161,41 @@ object PostTags {
   fun commentReplySend(id: String) = "post_comment_reply_send:$id"
 }
 
+/**
+ * Composable function to display a row of tags associated with a post.
+ *
+ * @param tags List of tags to display.
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun PostTagsRow(tags: List<String>) {
+  if (tags.isEmpty()) return
+
+  FlowRow(
+      modifier = Modifier.testTag(PostTags.POST_TAGS_ROW),
+      horizontalArrangement = Arrangement.spacedBy(Dimensions.Spacing.extraSmall),
+      verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.extraSmall)) {
+        tags.forEach { tag ->
+          Surface(
+              shape = RoundedCornerShape(Dimensions.CornerRadius.small),
+              color = MessagingColors.redditBlueBg,
+              modifier = Modifier.testTag(PostTags.tagChip(tag))) {
+                Text(
+                    text = tag,
+                    style = MaterialTheme.typography.labelSmall,
+                    fontSize = Dimensions.TextSize.tiny,
+                    fontWeight = FontWeight.Bold,
+                    color = MessagingColors.redditBlue,
+                    modifier =
+                        Modifier.padding(
+                            horizontal = Dimensions.Spacing.medium,
+                            vertical = Dimensions.Spacing.small))
+              }
+        }
+      }
+  Spacer(Modifier.height(Dimensions.Spacing.medium))
+}
+
 /* ================================================================
  * Main screen
  * ================================================================ */
@@ -173,8 +218,7 @@ fun PostScreen(
     accountViewModel: AccountViewModel = postViewModel,
     onBack: () -> Unit = {}
 ) {
-  val viewModel = postViewModel
-  val post: Post? by viewModel.postFlow(postId).collectAsState()
+  val post: Post? by postViewModel.postFlow(postId).collectAsState()
 
   val userCache = remember { mutableStateMapOf<String, Account>() }
   val scope = rememberCoroutineScope()
@@ -184,6 +228,7 @@ fun PostScreen(
   var topComment by rememberSaveable { mutableStateOf("") }
   var isSending by remember { mutableStateOf(false) }
   var isReplyingToComment by remember { mutableStateOf(false) }
+  var editTarget by remember { mutableStateOf<PostEditTarget?>(null) }
 
   // Track if post was ever loaded to distinguish between loading and deleted states
   var postEverLoaded by remember { mutableStateOf(false) }
@@ -259,15 +304,30 @@ fun PostScreen(
               sendEnabled = !isSending && topComment.isNotBlank() && post != null,
               onSend = {
                 val p = post ?: return@ComposerBar
+                val target = editTarget
+                val editing = target != null
+
                 scope.launch {
                   isSending = true
                   try {
-                    viewModel.addComment(
-                        author = account, post = p, parentId = p.id, text = topComment.trim())
+                    if (editing && target != null) {
+                      val value = topComment.trim()
+                      when (target) {
+                        PostEditTarget.TITLE ->
+                            postViewModel.editPost(author = account, post = p, newTitle = value)
+                        PostEditTarget.BODY ->
+                            postViewModel.editPost(author = account, post = p, newBody = value)
+                      }
+                      editTarget = null
+                    } else {
+                      postViewModel.addComment(
+                          author = account, post = p, parentId = p.id, text = topComment.trim())
+                    }
                     topComment = ""
                     focusManager.clearFocus(force = true)
                   } catch (_: Throwable) {
-                    snackbarHostState.showSnackbar(ERROR_NOT_SENT_COMMENT)
+                    snackbarHostState.showSnackbar(
+                        if (editing) ERROR_NOT_EDITED_POST else ERROR_NOT_SENT_COMMENT)
                   } finally {
                     isSending = false
                   }
@@ -289,20 +349,28 @@ fun PostScreen(
               onDeletePost = {
                 scope.launch {
                   deleted = true
-                  runCatching { viewModel.deletePost(account, currentPost) }
+                  runCatching { postViewModel.deletePost(account, currentPost) }
                       .onFailure { snackbarHostState.showSnackbar(ERROR_NOT_DELETED_POST) }
                   onBack()
                 }
               },
+              onEditPostBody = {
+                topComment = currentPost.body
+                editTarget = PostEditTarget.BODY
+              },
+              onEditPostTitle = {
+                topComment = currentPost.title
+                editTarget = PostEditTarget.TITLE
+              },
               onReply = { parentId, text ->
                 scope.launch {
-                  runCatching { viewModel.addComment(account, currentPost, parentId, text) }
+                  runCatching { postViewModel.addComment(account, currentPost, parentId, text) }
                       .onFailure { snackbarHostState.showSnackbar(ERROR_SEND_REPLY) }
                 }
               },
               onDeleteComment = { comment ->
                 scope.launch {
-                  runCatching { viewModel.removeComment(account, currentPost, comment) }
+                  runCatching { postViewModel.removeComment(account, currentPost, comment) }
                       .onFailure { snackbarHostState.showSnackbar(ERROR_NOT_DELETED_COMMENT) }
                 }
               },
@@ -458,12 +526,16 @@ private fun ComposerBar(
  * @param onReplyingStateChanged Lambda to notify when reply field focus changes.
  * @param resolveUser Lambda to resolve a user ID to an Account.
  * @param modifier Modifier to be applied to the content.
+ * @param onEditPostBody Lambda to invoke when editing the post body.
+ * @param onEditPostTitle Lambda to invoke when editing the post title.
  */
 @Composable
 private fun PostContent(
     post: Post,
     currentUser: Account,
     onDeletePost: () -> Unit,
+    onEditPostBody: () -> Unit,
+    onEditPostTitle: () -> Unit,
     onReply: (parentId: String, text: String) -> Unit,
     onDeleteComment: (Comment) -> Unit,
     onReplyingStateChanged: (commentId: String, isReplying: Boolean) -> Unit,
@@ -473,6 +545,10 @@ private fun PostContent(
   val listState = rememberLazyListState()
   val expandedStates = remember { mutableStateMapOf<String, Boolean>() }
   val focusManager = LocalFocusManager.current
+
+  val canEditPost =
+      post.authorId == currentUser.uid &&
+          System.currentTimeMillis() <= post.timestamp.toDate().time + EDIT_MAX_THRESHOLD
 
   LazyColumn(
       state = listState,
@@ -489,7 +565,10 @@ private fun PostContent(
               post = post,
               author = resolveUser(post.authorId),
               currentUser = currentUser,
-              onDelete = onDeletePost)
+              canEdit = canEditPost,
+              onDelete = onDeletePost,
+              onEditBody = onEditPostBody,
+              onEditTitle = onEditPostTitle)
         }
 
         items(items = post.comments, key = { it.id }, contentType = { "root_comment" }) { root ->
@@ -512,67 +591,71 @@ private fun PostContent(
  * @param author The author of the post.
  * @param currentUser The current user's account information.
  * @param onDelete Lambda to invoke when deleting the post.
+ * @param onEditBody Lambda to invoke when editing the post body.
+ * @param onEditTitle Lambda to invoke when editing the post title.
  */
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
-private fun PostCard(post: Post, author: Account?, currentUser: Account, onDelete: () -> Unit) {
+private fun PostCard(
+    post: Post,
+    author: Account?,
+    currentUser: Account,
+    canEdit: Boolean,
+    onDelete: () -> Unit,
+    onEditBody: () -> Unit,
+    onEditTitle: () -> Unit
+) {
+  val isOwner = post.authorId == currentUser.uid
+  val showEdit = canEdit && isOwner
+
   Column(modifier = Modifier.fillMaxWidth()) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
         color = MessagingColors.messagingSurface,
         shadowElevation = Dimensions.Elevation.minimal) {
-          Box(Modifier.fillMaxWidth().testTag(PostTags.postCard(post.id))) {
+          Box(modifier = Modifier.fillMaxWidth().testTag(PostTags.postCard(post.id))) {
             Column(modifier = Modifier.fillMaxWidth().padding(Dimensions.Padding.large)) {
-              // Post metadata (author and date)
+              // Header
               PostHeader(post = post, author = author)
 
               Spacer(Modifier.height(Dimensions.Padding.large))
 
-              // Tags row at top
-              if (post.tags.isNotEmpty()) {
-                FlowRow(
-                    modifier = Modifier.testTag(PostTags.POST_TAGS_ROW),
-                    horizontalArrangement = Arrangement.spacedBy(Dimensions.Spacing.extraSmall),
-                    verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.extraSmall)) {
-                      post.tags.forEach { tag ->
-                        Surface(
-                            shape = RoundedCornerShape(Dimensions.CornerRadius.small),
-                            color = MessagingColors.redditBlueBg,
-                            modifier = Modifier.testTag(PostTags.tagChip(tag))) {
-                              Text(
-                                  text = tag,
-                                  style = MaterialTheme.typography.labelSmall,
-                                  fontSize = Dimensions.TextSize.tiny,
-                                  fontWeight = FontWeight.Bold,
-                                  color = MessagingColors.redditBlue,
-                                  modifier =
-                                      Modifier.padding(
-                                          horizontal = Dimensions.Spacing.medium,
-                                          vertical = Dimensions.Spacing.small))
-                            }
-                      }
-                    }
-                Spacer(Modifier.height(Dimensions.Spacing.medium))
-              }
+              // Tags row
+              PostTagsRow(post.tags)
 
-              // Title
-              Text(
-                  text = post.title,
-                  style = MaterialTheme.typography.titleLarge,
-                  fontSize = Dimensions.TextSize.heading,
-                  fontWeight = FontWeight.Bold,
-                  color = MessagingColors.primaryText,
-                  modifier = Modifier.testTag(PostTags.POST_TITLE))
+              // Title row
+              PostEditableRow(
+                  editVisible = showEdit,
+                  editTestTag = PostTags.POST_EDIT_BTN,
+                  editContentDescription = "Edit title",
+                  verticalAlignment = Alignment.CenterVertically,
+                  onEdit = onEditTitle) {
+                    Text(
+                        text = post.title,
+                        style = MaterialTheme.typography.titleLarge,
+                        fontSize = Dimensions.TextSize.heading,
+                        fontWeight = FontWeight.Bold,
+                        color = MessagingColors.primaryText,
+                        modifier = Modifier.weight(1f).testTag(PostTags.POST_TITLE))
+                  }
 
               Spacer(Modifier.height(Dimensions.Padding.large))
 
-              // Body
-              Text(
-                  text = post.body,
-                  style = MaterialTheme.typography.bodyMedium,
-                  fontSize = Dimensions.TextSize.body,
-                  color = MessagingColors.primaryText,
-                  modifier = Modifier.testTag(PostTags.POST_BODY))
+              // Body row
+              PostEditableRow(
+                  editVisible = showEdit,
+                  editTestTag = PostTags.POST_BODY_EDIT_BTN,
+                  editContentDescription = "Edit body",
+                  verticalAlignment = Alignment.Top,
+                  editYOffset = -Dimensions.Spacing.extraLarge,
+                  onEdit = onEditBody) {
+                    Text(
+                        text = post.body,
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontSize = Dimensions.TextSize.body,
+                        color = MessagingColors.primaryText,
+                        modifier = Modifier.weight(1f).testTag(PostTags.POST_BODY))
+                  }
 
               Spacer(Modifier.height(Dimensions.Padding.large))
 
@@ -600,21 +683,63 @@ private fun PostCard(post: Post, author: Account?, currentUser: Account, onDelet
                   }
             }
 
-            if (post.authorId == currentUser.uid) {
+            // Top-right delete button
+            if (isOwner) {
               IconButton(
                   onClick = onDelete,
-                  modifier = Modifier.align(Alignment.TopEnd).testTag(PostTags.POST_DELETE_BTN)) {
+                  modifier =
+                      Modifier.align(Alignment.TopEnd)
+                          .padding(top = Dimensions.Spacing.small, end = Dimensions.Padding.large)
+                          .testTag(PostTags.POST_DELETE_BTN)) {
                     Icon(
-                        Icons.Default.Delete,
-                        "Delete post",
+                        imageVector = Icons.Default.Delete,
+                        contentDescription = "Delete post",
                         tint = MessagingColors.redditOrange,
                         modifier = Modifier.size(Dimensions.IconSize.standard))
                   }
             }
           }
         }
+
     HorizontalDivider(
         color = MessagingColors.divider, thickness = Dimensions.DividerThickness.thick)
+  }
+}
+
+/**
+ * Composable displaying a row with optional edit button.
+ *
+ * @param editVisible Whether the edit button should be visible.
+ * @param editTestTag Test tag for the edit button.
+ * @param editContentDescription Content description for the edit button.
+ * @param verticalAlignment Vertical alignment for the row content.
+ * @param editYOffset Vertical offset for the edit button.
+ * @param onEdit Lambda to invoke when the edit button is pressed.
+ * @param content Composable content to display in the row.
+ */
+@Composable
+private fun PostEditableRow(
+    editVisible: Boolean,
+    editTestTag: String,
+    editContentDescription: String,
+    verticalAlignment: Alignment.Vertical,
+    editYOffset: Dp = Dp.Hairline,
+    onEdit: () -> Unit,
+    content: @Composable RowScope.() -> Unit
+) {
+  Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = verticalAlignment) {
+    content()
+
+    if (editVisible) {
+      IconButton(
+          onClick = onEdit, modifier = Modifier.offset(y = editYOffset).testTag(editTestTag)) {
+            Icon(
+                imageVector = Icons.Default.Edit,
+                contentDescription = editContentDescription,
+                tint = MessagingColors.secondaryText,
+                modifier = Modifier.size(Dimensions.IconSize.standard))
+          }
+    }
   }
 }
 

--- a/app/src/main/java/com/github/meeplemeet/ui/theme/Dimensions.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/theme/Dimensions.kt
@@ -20,6 +20,7 @@ object Dimensions {
     val xxLarge: Dp = 24.dp
     val xxxLarge: Dp = 32.dp
     val xxxxLarge: Dp = 60.dp
+    val huge: Dp = 80.dp
   }
 
   // Padding
@@ -105,6 +106,12 @@ object Dimensions {
     val xLarge: TextUnit = 32.sp
     val extraLarge: TextUnit = 36.sp
     val displayMedium: TextUnit = 56.sp
+  }
+
+  // Blurring levels
+  object Blurring {
+    val none: Dp = 0.dp
+    val medium: Dp = 8.dp
   }
 
   // Text indentation

--- a/app/src/main/java/com/github/meeplemeet/ui/theme/Dimensions.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/theme/Dimensions.kt
@@ -111,6 +111,9 @@ object Dimensions {
   // Blurring levels
   object Blurring {
     val none: Dp = 0.dp
+    val tiny: Dp = 1.dp
+    val extraSmall: Dp = 2.dp
+    val small: Dp = 4.dp
     val medium: Dp = 8.dp
   }
 


### PR DESCRIPTION
This PR introduces the possibility to edit and remove messages from a discussion. It adds the following features :
* A pop-up that appears when pressing a message that we own
* This pop-up allows us to decide to either remove or edit the message

**Visuals**
<video controls playsinline muted
       src="https://github.com/user-attachments/assets/e40460ef-3d5b-41b0-a8da-2500f2b7cd32">

**References**
* Issue: https://github.com/Meeple-Meet/Meeple-Meet/issues/218