### PR TITLE
Feat/refactor session creation screen

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/ui/CreateSessionScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/CreateSessionScreenTest.kt
@@ -19,6 +19,7 @@ import com.github.meeplemeet.ui.components.ComponentsTestTags
 import com.github.meeplemeet.ui.navigation.NavigationTestTags
 import com.github.meeplemeet.ui.sessions.CreateSessionScreen
 import com.github.meeplemeet.ui.sessions.SessionCreationTestTags
+import com.github.meeplemeet.ui.sessions.SessionTestTags
 import com.github.meeplemeet.ui.theme.AppTheme
 import com.github.meeplemeet.utils.Checkpoint
 import com.google.firebase.Timestamp
@@ -82,8 +83,6 @@ class CreateSessionScreenTest {
 
   private fun gameInput() = allInputs()[1]
 
-  private fun locationInput() = allInputs()[2]
-
   private class FakeGameRepository : GameRepository {
     var throwOnSearch: Boolean = false
 
@@ -106,7 +105,7 @@ class CreateSessionScreenTest {
   }
 
   private inner class TestCreateSessionViewModel(
-      accountRepository: com.github.meeplemeet.model.account.AccountRepository,
+      accountRepository: AccountRepository,
       sessionRepository: SessionRepository,
       gameRepository: GameRepository
   ) : CreateSessionViewModel(accountRepository, sessionRepository, gameRepository) {
@@ -248,9 +247,24 @@ class CreateSessionScreenTest {
       harness.discussion.value = baseDiscussion.copy(participants = listOf(me.uid))
       compose.waitForIdle()
 
+      // Fill in title and game
       titleInput().performTextInput("Friday Night Board Game Jam")
       gameInput().performTextInput("Root")
-      locationInput().performTextInput("Table A1")
+
+      // Open location dialog and search for a location
+      compose.onNodeWithTag(SessionTestTags.LOCATION_PICKER_BUTTON).performClick()
+      compose.waitForIdle()
+      compose.onNodeWithTag(SessionTestTags.LOCATION_PICKER_DIALOG).assertIsDisplayed()
+      compose
+          .onNodeWithTag(ComponentsTestTags.SESSION_LOCATION_SEARCH_INPUT)
+          .performTextInput("EPFL")
+      compose.waitForIdle()
+
+      // Close the dialog
+      compose.onNodeWithText("OK").performClick()
+      compose.waitForIdle()
+
+      // Button should still be disabled because date and time are not set
       createBtn().assertIsNotEnabled()
     }
 
@@ -261,7 +275,7 @@ class CreateSessionScreenTest {
       compose.onNodeWithTag(SessionCreationTestTags.GAME_SEARCH_ERROR).assertExists()
 
       checkpoint("organisation_section_shows_location_label") {
-        compose.onAllNodesWithText("Location").onFirst().assertExists()
+        compose.onNodeWithTag(SessionTestTags.LOCATION_PICKER_BUTTON).assertExists()
       }
 
       checkpoint("initial_load_fetches_participants_once") {

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/components/SessionComponentsTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/components/SessionComponentsTest.kt
@@ -493,7 +493,7 @@ class SessionComponentsTest : FirestoreTests() {
     val initial = LocalDate.of(2025, 1, 5)
 
     var date by mutableStateOf<LocalDate?>(initial)
-    set {
+    set({
       Column {
         DatePickerDockedField(
             value = date,
@@ -510,7 +510,7 @@ class SessionComponentsTest : FirestoreTests() {
             label = "Read-only date",
             editable = false)
       }
-    }
+    })
 
     // Check initial date is displayed
     composeRule.onNodeWithText(initial.format(fmt)).assertExists()
@@ -527,7 +527,7 @@ class SessionComponentsTest : FirestoreTests() {
     composeRule.runOnUiThread { date = null }
     composeRule
         .onNodeWithTag(SessionTestTags.DATE_FIELD + "0", useUnmergedTree = true)
-        .assertTextEquals("")
+        .assertTextContains("Select a date")
   }
 
   fun timePicker_displays_and_opens_dialog() {

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/components/SessionComponentsTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/components/SessionComponentsTest.kt
@@ -525,9 +525,7 @@ class SessionComponentsTest : FirestoreTests() {
 
     // Check null date handling
     composeRule.runOnUiThread { date = null }
-    composeRule
-        .onNodeWithTag(SessionTestTags.DATE_FIELD + "0", useUnmergedTree = true)
-        .assertTextContains("Select a date")
+    composeRule.onNodeWithText("Date", useUnmergedTree = true).assertExists()
   }
 
   fun timePicker_displays_and_opens_dialog() {

--- a/app/src/main/java/com/github/meeplemeet/model/sessions/CreateSessionViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/sessions/CreateSessionViewModel.kt
@@ -73,11 +73,13 @@ open class CreateSessionViewModel(
     viewModelScope.launch {
       // Add all the participants that accept friend request from everyone or only there friends
       val participantsToAdd =
-          participants.filter { account ->
-            account.notificationSettings == NotificationSettings.EVERYONE ||
-                account.notificationSettings == NotificationSettings.FRIENDS_ONLY &&
-                    requester.relationships[account.uid] == RelationshipStatus.FRIEND
-          }
+          participants
+              .filter { account ->
+                account.notificationSettings == NotificationSettings.EVERYONE ||
+                    account.notificationSettings == NotificationSettings.FRIENDS_ONLY &&
+                        requester.relationships[account.uid] == RelationshipStatus.FRIEND
+              }
+              .filterNot { it.uid == requester.uid } // Exclude requester to avoid duplication
 
       sessionRepository.createSession(
           discussion.uid,

--- a/app/src/main/java/com/github/meeplemeet/model/sessions/CreateSessionViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/sessions/CreateSessionViewModel.kt
@@ -1,4 +1,5 @@
 package com.github.meeplemeet.model.sessions
+//AI was used on this file
 
 import androidx.lifecycle.viewModelScope
 import com.github.meeplemeet.RepositoryProvider

--- a/app/src/main/java/com/github/meeplemeet/model/sessions/CreateSessionViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/sessions/CreateSessionViewModel.kt
@@ -7,11 +7,9 @@ import com.github.meeplemeet.model.PermissionDeniedException
 import com.github.meeplemeet.model.account.Account
 import com.github.meeplemeet.model.account.AccountRepository
 import com.github.meeplemeet.model.account.AccountViewModel
-import com.github.meeplemeet.model.account.HandlesRepository
 import com.github.meeplemeet.model.account.NotificationSettings
 import com.github.meeplemeet.model.account.RelationshipStatus
 import com.github.meeplemeet.model.discussions.Discussion
-import com.github.meeplemeet.model.shared.DEBOUNCE_TIME_MS
 import com.github.meeplemeet.model.shared.SearchViewModel
 import com.github.meeplemeet.model.shared.game.Game
 import com.github.meeplemeet.model.shared.game.GameRepository
@@ -19,11 +17,6 @@ import com.github.meeplemeet.model.shared.location.Location
 import com.google.firebase.Timestamp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.launch
 
 private const val ERROR_ADMIN_PERMISSION = "Only discussion admins can perform this operation"
@@ -32,35 +25,10 @@ private const val ERROR_ADMIN_PERMISSION = "Only discussion admins can perform t
 open class CreateSessionViewModel(
     private val accountRepository: AccountRepository = RepositoryProvider.accounts,
     private val sessionRepository: SessionRepository = RepositoryProvider.sessions,
-    gameRepository: GameRepository = RepositoryProvider.games,
-    private val handlesRepository: HandlesRepository = RepositoryProvider.handles
+    gameRepository: GameRepository = RepositoryProvider.games
 ) : SearchViewModel(gameRepository), AccountViewModel {
   override val scope: CoroutineScope
     get() = this.viewModelScope
-
-  /** StateFlow containing account suggestions from handle searches. */
-  private val handleQueryFlow = MutableSharedFlow<String>(extraBufferCapacity = 64)
-  private val _handleSuggestions = MutableStateFlow<List<Account>>(emptyList())
-  val handleSuggestions: StateFlow<List<Account>> = _handleSuggestions
-
-  init {
-    viewModelScope.launch {
-      handleQueryFlow.debounce(DEBOUNCE_TIME_MS).collectLatest { prefix ->
-        if (prefix.isBlank()) {
-          _handleSuggestions.value = emptyList()
-          return@collectLatest
-        }
-
-        try {
-          handlesRepository.searchByHandle(prefix).collect { list ->
-            _handleSuggestions.value = list.take(30) // SUGGESTIONS_LIMIT
-          }
-        } catch (_: Exception) {
-          _handleSuggestions.value = emptyList()
-        }
-      }
-    }
-  }
 
   /**
    * Checks if an account has admin privileges for a discussion.
@@ -209,21 +177,5 @@ open class CreateSessionViewModel(
     if (!isAdmin(requester, discussion)) throw PermissionDeniedException(ERROR_ADMIN_PERMISSION)
 
     setGameQuery(query)
-  }
-
-  /**
-   * Searches for accounts by handle prefix.
-   *
-   * Updates handleSuggestions with matching accounts.
-   *
-   * @param prefix The handle prefix to search for
-   */
-  fun searchByHandle(prefix: String) {
-    if (prefix.isBlank()) {
-      _handleSuggestions.value = emptyList()
-      return
-    }
-
-    handleQueryFlow.tryEmit(prefix)
   }
 }

--- a/app/src/main/java/com/github/meeplemeet/model/sessions/CreateSessionViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/sessions/CreateSessionViewModel.kt
@@ -1,5 +1,5 @@
 package com.github.meeplemeet.model.sessions
-//AI was used on this file
+// AI was used on this file
 
 import androidx.lifecycle.viewModelScope
 import com.github.meeplemeet.RepositoryProvider

--- a/app/src/main/java/com/github/meeplemeet/ui/components/SessionComponents.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/SessionComponents.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -27,9 +28,12 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.CalendarToday
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDefaults
@@ -51,6 +55,7 @@ import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TimeInput
 import androidx.compose.material3.TimePickerDefaults
@@ -66,7 +71,9 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
@@ -87,6 +94,9 @@ import com.github.meeplemeet.model.space_renter.SpaceRenterSearchViewModel
 import com.github.meeplemeet.ui.FocusableInputField
 import com.github.meeplemeet.ui.navigation.NavigationTestTags
 import com.github.meeplemeet.ui.sessions.SessionTestTags
+import com.github.meeplemeet.ui.sessions.SessionTestTags.LOCATION_PICKER_BUTTON
+import com.github.meeplemeet.ui.sessions.SessionTestTags.LOCATION_PICKER_DIALOG
+import com.github.meeplemeet.ui.sessions.isDateTimeInPast
 import com.github.meeplemeet.ui.theme.AppColors
 import com.github.meeplemeet.ui.theme.Dimensions
 import java.time.Instant
@@ -121,6 +131,9 @@ object ComponentsTestTags {
 /** Common labels, placeholders, and button texts used across components. */
 private const val LABEL_DATE = "Date"
 private const val LABEL_TIME = "Time"
+private const val LABEL_SELECT_DATE = "Select a date"
+private const val LABEL_SELECT_TIME = "Select a time"
+private const val TEXT_SELECT_LOCATION = "Select a location"
 private const val LABEL_LOCATION = "Location"
 private const val PLACEHOLDER_LOCATION = "Enter an address"
 private const val PLACEHOLDER_SEARCH_GAMES = "Search games"
@@ -276,6 +289,70 @@ fun IconTextField(
               unfocusedIndicatorColor = MaterialTheme.colorScheme.onSurfaceVariant,
               disabledIndicatorColor =
                   MaterialTheme.colorScheme.onBackground.copy(alpha = OUTLINE_DEFAULT_ALPHA),
+
+              // background
+              focusedContainerColor = Color.Transparent,
+              unfocusedContainerColor = Color.Transparent,
+              disabledContainerColor = Color.Transparent,
+
+              // cursor
+              cursorColor = MaterialTheme.colorScheme.onBackground,
+          ),
+  )
+}
+
+/**
+ * A text field with optional leading and trailing icons.
+ *
+ * @param value The current value of the text field.
+ * @param onValueChange Callback function to be invoked when the text field value changes.
+ * @param placeholder Placeholder text to be displayed when the text field is empty.
+ * @param editable Whether the text field is editable or read-only.
+ * @param leadingIcon Optional composable for the leading icon.
+ * @param trailingIcon Optional composable for the trailing icon.
+ * @param textStyle The style to be applied to the text inside the text field.
+ * @param modifier Modifier to be applied to the OutlinedTextField.
+ */
+@Composable
+fun IconTextFieldNew(
+    value: String,
+    onValueChange: (String) -> Unit,
+    placeholder: String,
+    editable: Boolean = true,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    textStyle: TextStyle = MaterialTheme.typography.bodySmall,
+    modifier: Modifier
+) {
+  TextField(
+      value = value,
+      onValueChange = { if (editable) onValueChange(it) },
+      modifier = modifier,
+      enabled = false,
+      readOnly = !editable,
+      leadingIcon = leadingIcon,
+      trailingIcon = trailingIcon,
+      placeholder = { Text(placeholder, color = MaterialTheme.colorScheme.onSurfaceVariant) },
+      textStyle = textStyle,
+      colors =
+          TextFieldDefaults.colors(
+              // text
+              focusedTextColor = MaterialTheme.colorScheme.onBackground,
+              unfocusedTextColor = MaterialTheme.colorScheme.onBackground,
+              disabledTextColor = MaterialTheme.colorScheme.onBackground,
+
+              // icons
+              focusedLeadingIconColor = MaterialTheme.colorScheme.onBackground,
+              unfocusedLeadingIconColor = MaterialTheme.colorScheme.onBackground,
+              disabledLeadingIconColor = MaterialTheme.colorScheme.onBackground,
+              focusedTrailingIconColor = MaterialTheme.colorScheme.onBackground,
+              unfocusedTrailingIconColor = MaterialTheme.colorScheme.onBackground,
+              disabledTrailingIconColor = MaterialTheme.colorScheme.onBackground,
+
+              // indicator
+              focusedIndicatorColor = Color.Transparent,
+              unfocusedIndicatorColor = Color.Transparent,
+              disabledIndicatorColor = Color.Transparent,
 
               // background
               focusedContainerColor = Color.Transparent,
@@ -511,19 +588,18 @@ fun DatePickerDockedField(
     testTagDate: String = SessionTestTags.DATE_FIELD
 ) {
   var showDialogDate by remember { mutableStateOf(false) }
-  val text = value?.format(displayFormatter) ?: ""
+  val text = value?.format(displayFormatter) ?: LABEL_SELECT_DATE
 
-  IconTextField(
+  IconTextFieldNew(
       value = text,
       onValueChange = {},
       placeholder = label,
       editable = editable,
-      leadingIcon = { Icon(Icons.Default.CalendarToday, contentDescription = LABEL_DATE) },
-      trailingIcon = {
+      leadingIcon = {
         if (editable) {
-          TextButton(
+          IconButton(
               onClick = { showDialogDate = true }, modifier = Modifier.testTag(testTagPick)) {
-                Text(BUTTON_PICK)
+                Icon(Icons.Default.CalendarToday, contentDescription = LABEL_DATE)
               }
         }
       },
@@ -636,23 +712,19 @@ fun TimePickerField(
           initialMinute = value?.minute ?: Dimensions.Numbers.defaultTimeMinute)
   val text = value?.format(displayFormatter) ?: ""
 
-  FocusableInputField(
+  IconTextFieldNew(
       value = text,
       onValueChange = { /* read-only; picker controls it */},
-      label = { Text(label) },
-      readOnly = true,
-      leadingIcon = { Icon(Icons.Default.Timer, contentDescription = LABEL_TIME) },
-      trailingIcon = {
-        TextButton(
+      placeholder = label,
+      editable = false,
+      leadingIcon = {
+        IconButton(
             onClick = { open = true },
             modifier = Modifier.testTag(SessionTestTags.TIME_PICK_BUTTON)) {
-              Text(BUTTON_PICK)
+              Icon(Icons.Default.Timer, contentDescription = LABEL_TIME)
             }
       },
-      modifier =
-          Modifier.fillMaxWidth()
-              .height(Dimensions.IconSize.giant)
-              .testTag(SessionTestTags.TIME_FIELD))
+      modifier = Modifier.fillMaxWidth(1f).testTag(SessionTestTags.TIME_FIELD))
 
   if (open) {
     AlertDialog(
@@ -755,21 +827,146 @@ fun TimePickerField(
   }
 }
 
+/**
+ * A combined date and time picker component.
+ *
+ * @param date The currently selected date.
+ * @param time The currently selected time.
+ * @param onDateChange Callback function to be invoked when a new date is selected.
+ * @param onFocusChanged Callback function to be invoked when the focus state changes.
+ * @param onTimeChange Callback function to be invoked when a new time is selected.
+ */
+@Composable
+fun DateAndTimePicker(
+    date: LocalDate?,
+    time: LocalTime?,
+    onDateChange: (LocalDate?) -> Unit,
+    onFocusChanged: (Boolean) -> Unit = {},
+    onTimeChange: (LocalTime?) -> Unit
+) {
+  Row(modifier = Modifier.fillMaxWidth().background(AppColors.secondary)) {
+    Box(Modifier.fillMaxWidth(0.5f).onFocusChanged { onFocusChanged(it.isFocused) }) {
+      DatePickerDockedField(
+          value = date, onValueChange = onDateChange, label = LABEL_SELECT_DATE, editable = true)
+    }
+
+    Column {
+      Box(Modifier.onFocusChanged { onFocusChanged(it.isFocused) }) {
+        TimePickerField(value = time, onValueChange = onTimeChange, label = LABEL_SELECT_TIME)
+      }
+
+      // Show error if date/time is in the past
+      if (isDateTimeInPast(date, time)) {
+        Spacer(Modifier.height(Dimensions.Spacing.extraSmall))
+        Text(
+            text = "Cannot create a session in the past",
+            color = MaterialTheme.colorScheme.error,
+            style = MaterialTheme.typography.bodySmall,
+            modifier = Modifier.padding(start = Dimensions.Padding.medium))
+      }
+    }
+  }
+}
+
+/**
+ * A button that opens a dialog to search and select a session location.
+ *
+ * @param account The user's account.
+ * @param discussion The discussion associated with the session.
+ * @param viewModel The CreateSessionViewModel for managing session state.
+ * @param buttonTestTag Test tag for the location picker button.
+ * @param dialogTestTag Test tag for the location picker dialog.
+ */
+@Composable
+fun SessionLocationSearchButton(
+    account: Account,
+    discussion: Discussion,
+    viewModel: CreateSessionViewModel,
+    buttonTestTag: String = LOCATION_PICKER_BUTTON,
+    dialogTestTag: String = LOCATION_PICKER_DIALOG
+) {
+  var showDialog by rememberSaveable { mutableStateOf(false) }
+  var selectedLocationLabel by rememberSaveable {
+    mutableStateOf(
+        discussion.session?.location?.name?.takeIf { it.isNotBlank() } ?: TEXT_SELECT_LOCATION)
+  }
+
+  Button(
+      onClick = { showDialog = true },
+      modifier =
+          Modifier.fillMaxWidth()
+              .heightIn(min = Dimensions.ContainerSize.timeFieldHeight)
+              .testTag(buttonTestTag),
+      colors = ButtonDefaults.buttonColors(containerColor = AppColors.secondary),
+      shape = RectangleShape,
+      contentPadding = PaddingValues(Dimensions.Padding.extraMedium)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Start) {
+              Icon(imageVector = Icons.Default.LocationOn, contentDescription = "Location Pin")
+              Spacer(Modifier.width(Dimensions.Spacing.medium))
+              Text(
+                  text = selectedLocationLabel,
+                  style = MaterialTheme.typography.bodySmall,
+                  color = AppColors.textIcons,
+                  modifier = Modifier.weight(1f),
+                  maxLines = 6,
+                  softWrap = true)
+            }
+      }
+
+  if (showDialog) {
+    AlertDialog(
+        onDismissRequest = { showDialog = false },
+        modifier = Modifier.testTag(dialogTestTag),
+        containerColor = AppColors.primary,
+        title = { Text(LABEL_LOCATION, color = AppColors.textIcons) },
+        text = {
+          Column(modifier = Modifier.fillMaxWidth()) {
+            SessionLocationSearchBar(
+                account = account,
+                discussion = discussion,
+                viewModel = viewModel,
+                onLocationSelected = { location ->
+                  selectedLocationLabel = location.name.ifBlank { TEXT_SELECT_LOCATION }
+                })
+          }
+        },
+        confirmButton = { TextButton(onClick = { showDialog = false }) { Text(BUTTON_OK) } },
+        dismissButton = { TextButton(onClick = { showDialog = false }) { Text(BUTTON_CANCEL) } })
+  }
+}
+
+/**
+ * A search bar for selecting a session location.
+ *
+ * @param account The user's account.
+ * @param discussion The discussion associated with the session.
+ * @param viewModel The CreateSessionViewModel for managing session state.
+ * @param onLocationSelected Callback function invoked when a location is selected.
+ * @param inputFieldTestTag Test tag for the input field.
+ * @param dropdownItemTestTag Test tag for the dropdown items.
+ */
 @Composable
 fun SessionLocationSearchBar(
     account: Account,
     discussion: Discussion,
     viewModel: CreateSessionViewModel,
+    onLocationSelected: (Location) -> Unit = {},
     inputFieldTestTag: String = ComponentsTestTags.SESSION_LOCATION_SEARCH_INPUT,
     dropdownItemTestTag: String = ComponentsTestTags.SESSION_LOCATION_SEARCH_ITEM
 ) {
   LocationSearchBar(
-      setLocation = { viewModel.setLocation(account, discussion, it) },
+      setLocation = { location ->
+        viewModel.setLocation(account, discussion, location)
+        onLocationSelected(location)
+      },
       setLocationQuery = { viewModel.setLocationQuery(account, discussion, it) },
-      discussion.session?.location ?: Location(),
-      viewModel,
-      inputFieldTestTag,
-      dropdownItemTestTag)
+      initial = discussion.session?.location ?: Location(),
+      viewModel = viewModel,
+      inputFieldTestTag = inputFieldTestTag,
+      dropdownItemTestTag = dropdownItemTestTag)
 }
 
 @Composable

--- a/app/src/main/java/com/github/meeplemeet/ui/components/SessionComponents.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/SessionComponents.kt
@@ -321,7 +321,6 @@ fun IconTextFieldNew(
     editable: Boolean = true,
     leadingIcon: @Composable (() -> Unit)? = null,
     trailingIcon: @Composable (() -> Unit)? = null,
-    textStyle: TextStyle = MaterialTheme.typography.bodySmall,
     modifier: Modifier
 ) {
   TextField(
@@ -333,7 +332,6 @@ fun IconTextFieldNew(
       leadingIcon = leadingIcon,
       trailingIcon = trailingIcon,
       placeholder = { Text(placeholder, color = MaterialTheme.colorScheme.onSurfaceVariant) },
-      textStyle = textStyle,
       colors =
           TextFieldDefaults.colors(
               // text
@@ -599,7 +597,10 @@ fun DatePickerDockedField(
         if (editable) {
           IconButton(
               onClick = { showDialogDate = true }, modifier = Modifier.testTag(testTagPick)) {
-                Icon(Icons.Default.CalendarToday, contentDescription = LABEL_DATE)
+                Icon(
+                    Icons.Default.CalendarToday,
+                    contentDescription = LABEL_DATE,
+                    tint = AppColors.neutral)
               }
         }
       },
@@ -710,7 +711,7 @@ fun TimePickerField(
           is24Hour = is24Hour,
           initialHour = value?.hour ?: Dimensions.Numbers.defaultTimeHour,
           initialMinute = value?.minute ?: Dimensions.Numbers.defaultTimeMinute)
-  val text = value?.format(displayFormatter) ?: ""
+  val text = value?.format(displayFormatter) ?: LABEL_SELECT_TIME
 
   IconTextFieldNew(
       value = text,
@@ -721,7 +722,7 @@ fun TimePickerField(
         IconButton(
             onClick = { open = true },
             modifier = Modifier.testTag(SessionTestTags.TIME_PICK_BUTTON)) {
-              Icon(Icons.Default.Timer, contentDescription = LABEL_TIME)
+              Icon(Icons.Default.Timer, contentDescription = LABEL_TIME, tint = AppColors.neutral)
             }
       },
       modifier = Modifier.fillMaxWidth(1f).testTag(SessionTestTags.TIME_FIELD))

--- a/app/src/main/java/com/github/meeplemeet/ui/sessions/CreateSessionScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/sessions/CreateSessionScreen.kt
@@ -279,7 +279,9 @@ fun CreateSessionScreen(
                   viewModel = viewModel,
                   account = account,
                   discussion = discussion,
-                  onTitleChange = { form = form.copy(title = it) },
+                  onTitleChange = {
+                    if (it.length <= MAX_TITLE_LENGTH) form = form.copy(title = it)
+                  },
                   form = form,
                   date = form.date,
                   time = form.time,
@@ -512,10 +514,6 @@ fun ParticipantsSection(
         Spacer(Modifier.height(Dimensions.Spacing.medium))
 
         UserChipsGrid(
-            participants = allCandidates,
-            onRemove = onRemove,
-            onAdd = onAdd,
-            account = account,
-            editable = true)
+            participants = allCandidates, onRemove = onRemove, account = account, editable = true)
       }
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/sessions/CreateSessionScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/sessions/CreateSessionScreen.kt
@@ -166,6 +166,8 @@ fun CreateSessionScreen(
 ) {
   // Holds the form state for the session
   var form by remember(account.uid) { mutableStateOf(SessionForm(participants = listOf(account))) }
+  // Store all discussion members separately (remains constant)
+  var allDiscussionMembers by remember { mutableStateOf<List<Account>>(emptyList()) }
   // Holds the selected location (may be null)
   val gameUi by viewModel.gameUIState.collectAsState()
   val locationUi by viewModel.locationUIState.collectAsState()
@@ -180,7 +182,8 @@ fun CreateSessionScreen(
   // Fetch participants and possibly trigger game query on discussion change
   LaunchedEffect(discussion.uid) {
     viewModel.getAccounts(discussion.participants) { fetched ->
-      form = form.copy(participants = (fetched + account).distinctBy { it.uid })
+      allDiscussionMembers = (fetched + account).distinctBy { it.uid }
+      form = form.copy(participants = allDiscussionMembers)
     }
 
     // If a game query was already entered, trigger search
@@ -294,7 +297,7 @@ fun CreateSessionScreen(
               ParticipantsSection(
                   account = account,
                   selected = form.participants,
-                  allCandidates = form.participants,
+                  allCandidates = allDiscussionMembers,
                   minPlayers = gameUi.fetchedGame?.minPlayers ?: 0,
                   maxPlayers = gameUi.fetchedGame?.maxPlayers ?: 0,
                   onAdd = { toAdd ->
@@ -415,7 +418,7 @@ fun OrganisationSection(
               MaterialTheme.colorScheme.background,
               MaterialTheme.shapes.large)
           .background(MaterialTheme.colorScheme.background, MaterialTheme.shapes.large)) {
-        Text(text = "Basic Info", style = MaterialTheme.typography.titleMedium)
+        Text(text = "Basic Info", style = MaterialTheme.typography.titleLarge)
 
         Spacer(Modifier.height(Dimensions.Spacing.small))
 
@@ -444,7 +447,7 @@ fun OrganisationSection(
 
         Spacer(Modifier.height(Dimensions.Spacing.xLarge))
 
-        Text(text = "Where & When", style = MaterialTheme.typography.titleMedium)
+        Text(text = "Where & When", style = MaterialTheme.typography.titleLarge)
 
         Spacer(Modifier.height(Dimensions.Spacing.small))
 
@@ -500,7 +503,7 @@ fun ParticipantsSection(
             horizontalArrangement = Arrangement.Start,
         ) {
           Column {
-            Text(mainSectionTitle, style = MaterialTheme.typography.titleMedium)
+            Text(mainSectionTitle, style = MaterialTheme.typography.titleLarge)
             if (minPlayers > 0 && maxPlayers > 0)
                 Text(
                     "Recommended: $minPlayers - $maxPlayers",
@@ -514,6 +517,12 @@ fun ParticipantsSection(
         Spacer(Modifier.height(Dimensions.Spacing.medium))
 
         UserChipsGrid(
-            participants = allCandidates, onRemove = onRemove, account = account, editable = true)
+            participants = allCandidates,
+            onRemove = onRemove,
+            onAdd = onAdd,
+            account = account,
+            editable = true,
+            useCheckboxes = true,
+            selectedParticipants = selected)
       }
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionDetailsScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionDetailsScreen.kt
@@ -488,7 +488,7 @@ fun UserChipsGrid(
 private fun AvatarBubble(name: String) {
   Box(
       modifier =
-          Modifier.size(Dimensions.AvatarSize.tiny).clip(CircleShape).background(Color.LightGray),
+          Modifier.size(Dimensions.AvatarSize.tiny).clip(CircleShape).background(AppColors.divider),
       contentAlignment = Alignment.Center) {
         Text(
             text = name.firstOrNull()?.uppercase() ?: "?",

--- a/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionDetailsScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionDetailsScreen.kt
@@ -709,7 +709,7 @@ fun UserChip(
                         modifier =
                             Modifier.size(Dimensions.AvatarSize.small)
                                 .clip(CircleShape)
-                                .background(Color.LightGray),
+                                .background(AppColors.divider),
                         contentAlignment = Alignment.Center) {
                           Text(
                               text = user.name.firstOrNull()?.toString() ?: "A",

--- a/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionDetailsScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionDetailsScreen.kt
@@ -1,5 +1,5 @@
 package com.github.meeplemeet.ui.sessions
-//AI was used on this file
+// AI was used on this file
 
 import android.annotation.SuppressLint
 import androidx.compose.foundation.BorderStroke
@@ -64,7 +64,6 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.meeplemeet.RepositoryProvider
 import com.github.meeplemeet.model.account.Account
@@ -461,7 +460,7 @@ fun UserChipsGrid(
           .filter { m -> m.handle.contains(searchQuery, ignoreCase = true) }
 
   // Set up vertical scroll with a maximum height
-  val maxHeight = 300.dp
+  val maxHeight = Dimensions.ContainerSize.mapHeight
   val scrollState = rememberScrollState()
 
   Column(

--- a/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionDetailsScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionDetailsScreen.kt
@@ -462,16 +462,20 @@ fun UserChipsGrid(
         // Existing participant chips - now full width rectangles
         participants.forEach { p ->
           val isSelected = selectedParticipants.any { it.uid == p.uid }
+          // Don't show checkbox for the admin/creator when using checkboxes
+          val isAdmin = p.uid == account.uid
+          val showCheckboxForUser = useCheckboxes && !isAdmin
+
           UserChip(
               user = p,
               modifier = Modifier.fillMaxWidth().testTag(SessionTestTags.chipsTag(p.uid)),
               onRemove = { if (editable) onRemove(p) },
               account = account,
               showRemoveBTN = !useCheckboxes && editable,
-              showCheckbox = useCheckboxes,
+              showCheckbox = showCheckboxForUser,
               isChecked = isSelected,
               onCheckedChange =
-                  if (useCheckboxes && onAdd != null) {
+                  if (showCheckboxForUser && onAdd != null) {
                     { checked ->
                       if (checked) {
                         onAdd(p)

--- a/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionDetailsScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionDetailsScreen.kt
@@ -741,7 +741,7 @@ fun UserChip(
   Surface(
       modifier = modifier,
       shape = appShapes.medium,
-      color = AppColors.secondary,
+      color = AppColors.primary,
       tonalElevation = Dimensions.Elevation.minimal,
       border = BorderStroke(Dimensions.DividerThickness.thin, AppColors.divider)) {
         Row(

--- a/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionDetailsScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionDetailsScreen.kt
@@ -742,8 +742,7 @@ fun UserChip(
       modifier = modifier,
       shape = appShapes.medium,
       color = AppColors.primary,
-      tonalElevation = Dimensions.Elevation.minimal,
-      border = BorderStroke(Dimensions.DividerThickness.thin, AppColors.divider)) {
+      tonalElevation = Dimensions.Elevation.minimal) {
         Row(
             modifier = Modifier.fillMaxWidth().padding(Dimensions.Padding.large),
             verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionDetailsScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionDetailsScreen.kt
@@ -1,4 +1,5 @@
 package com.github.meeplemeet.ui.sessions
+//AI was used on this file
 
 import android.annotation.SuppressLint
 import androidx.compose.foundation.BorderStroke

--- a/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionDetailsScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionDetailsScreen.kt
@@ -57,7 +57,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag


### PR DESCRIPTION
**Summary :**
This pull request introduces significant improvements to the session creation UI and underlying logic, focusing on enhancing location and date/time selection, as well as adding handle-based account search functionality. The changes modernize input components, and add new features to the session creation workflow.

**Description :**
* I changed the UI for date and time choosing putting the buttons side by side
* I changed the behavior to add a location to the session, now the user needs to press on the 'Select a location' button to open a pop up and search for the location
* I changed the UI of the 'Participants' session removing the slider, , and changed how the users in the session are displayed

<img width="366" height="749" alt="image" src="https://github.com/user-attachments/assets/e40dcfb1-8fb5-4891-8055-a7a57651a05d" />
<img width="367" height="751" alt="image" src="https://github.com/user-attachments/assets/4df3c955-d3f2-473d-b4d8-2b6dfefd4aec" />
<img width="325" height="363" alt="image" src="https://github.com/user-attachments/assets/4447b1f0-e9c4-4d02-a8d6-6f60fd67ed4e" />