### PR TITLE
Add post and comment editing functionality

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/integration/FirestorePostTests.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/FirestorePostTests.kt
@@ -411,4 +411,107 @@ class FirestorePostTests : FirestoreTests() {
     assertEquals(1, foundPost!!.commentCount)
     assertTrue(foundPost.comments.isEmpty()) // Comments not loaded
   }
+
+  @Test
+  fun testEditPostAndComment() = runBlocking {
+    // Test editing post at repository level
+    val post =
+        postRepository.createPost(
+            "Original Title", "Original Body", testAccount1.uid, listOf("tag1"))
+
+    // Edit all fields
+    postRepository.editPost(
+        post.id,
+        newTitle = "Updated Title",
+        newBody = "Updated Body",
+        newTags = listOf("tag2", "tag3"))
+    delay(500)
+
+    val updatedPost = postRepository.getPost(post.id)
+    assertEquals("Updated Title", updatedPost.title)
+    assertEquals("Updated Body", updatedPost.body)
+    assertEquals(listOf("tag2", "tag3"), updatedPost.tags)
+
+    // Edit only title
+    postRepository.editPost(post.id, newTitle = "Title Only")
+    delay(500)
+    val titleOnlyPost = postRepository.getPost(post.id)
+    assertEquals("Title Only", titleOnlyPost.title)
+    assertEquals("Updated Body", titleOnlyPost.body)
+
+    // Test editing comment at repository level
+    val commentId =
+        postRepository.addComment(post.id, "Original Comment", testAccount2.uid, post.id)
+    delay(500)
+
+    postRepository.editComment(post.id, commentId, "Updated Comment")
+    delay(500)
+
+    val postWithUpdatedComment = postRepository.getPost(post.id)
+    assertEquals("Updated Comment", postWithUpdatedComment.comments[0].text)
+  }
+
+  @Test
+  fun testEditPostAndCommentWithPermissionsAndValidation() = runTest {
+    // Test ViewModel edit with permissions
+    val post = postRepository.createPost("Test Post", "Test Body", testAccount1.uid)
+
+    // Edit as author (should succeed)
+    postVM.editPost(testAccount1, post, newTitle = "Edited by Author")
+
+    val editedPost = postRepository.getPost(post.id)
+    assertEquals("Edited by Author", editedPost.title)
+
+    // Try to edit as non-author (should fail)
+    try {
+      postVM.editPost(testAccount2, post, newTitle = "Hacked Title")
+      throw AssertionError("Expected PermissionDeniedException")
+    } catch (_: PermissionDeniedException) {
+      // Expected
+    }
+
+    // Test blank title validation
+    try {
+      postVM.editPost(testAccount1, post, newTitle = "")
+      throw AssertionError("Expected IllegalArgumentException for blank title")
+    } catch (_: IllegalArgumentException) {
+      // Expected
+    }
+
+    // Test blank body validation
+    try {
+      postVM.editPost(testAccount1, post, newBody = "")
+      throw AssertionError("Expected IllegalArgumentException for blank body")
+    } catch (_: IllegalArgumentException) {
+      // Expected
+    }
+
+    // Test comment editing with permissions
+    postRepository.addComment(post.id, "Test Comment", testAccount2.uid, post.id)
+    val postWithComment = postRepository.getPost(post.id)
+    val comment = postWithComment.comments[0]
+
+    // Edit as comment author (should succeed)
+    postVM.editComment(testAccount2, postWithComment, comment, "Edited Comment")
+
+    val postWithEditedComment = postRepository.getPost(post.id)
+    assertEquals("Edited Comment", postWithEditedComment.comments[0].text)
+
+    // Try to edit as non-author (should fail)
+    try {
+      postVM.editComment(
+          testAccount1, postWithEditedComment, postWithEditedComment.comments[0], "Hacked Comment")
+      throw AssertionError("Expected PermissionDeniedException")
+    } catch (_: PermissionDeniedException) {
+      // Expected
+    }
+
+    // Test blank comment validation
+    try {
+      postVM.editComment(testAccount2, postWithEditedComment, postWithEditedComment.comments[0], "")
+      throw AssertionError("Expected IllegalArgumentException for blank comment")
+    } catch (_: IllegalArgumentException) {
+      // Expected
+    }
+  }
 }

--- a/app/src/main/java/com/github/meeplemeet/model/discussions/DiscussionViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/discussions/DiscussionViewModel.kt
@@ -99,9 +99,9 @@ class DiscussionViewModel(
     if (message.senderId != sender.uid)
         throw IllegalArgumentException("Can not edit someone else's message")
 
-    if (Timestamp.now().toDate().time > message.createdAt.toDate().time + EDIT_MAX_THRESHOLD)
-        throw IllegalArgumentException(
-            "Can not edit a message after ${EDIT_MAX_THRESHOLD}ms it has been created")
+    require(Timestamp.now().toDate().time <= message.createdAt.toDate().time + EDIT_MAX_THRESHOLD) {
+      "Can not edit a message after ${EDIT_MAX_THRESHOLD}ms it has been created"
+    }
 
     val cleaned = newContent.trimEnd()
     if (cleaned.isBlank()) throw IllegalArgumentException("Message content cannot be blank")

--- a/app/src/main/java/com/github/meeplemeet/model/discussions/DiscussionViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/discussions/DiscussionViewModel.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 const val SUGGESTIONS_LIMIT = 30
-const val EDIT_MESSAGE_MAX_THRESHOLD = 2 * 60 * 60 * 1000L
+const val EDIT_MAX_THRESHOLD = 2 * 60 * 60 * 1000L
 
 /**
  * ViewModel for managing discussion messaging and real-time updates.
@@ -79,8 +79,8 @@ class DiscussionViewModel(
    * - Trailing whitespace is automatically removed
    *
    * ## Time Threshold
-   * Messages can only be edited within [EDIT_MESSAGE_MAX_THRESHOLD] (2 hours) of their creation.
-   * This prevents editing old messages that may have already been read and acted upon by other
+   * Messages can only be edited within [EDIT_MAX_THRESHOLD] (2 hours) of their creation. This
+   * prevents editing old messages that may have already been read and acted upon by other
    * participants.
    *
    * ## Behavior
@@ -93,16 +93,15 @@ class DiscussionViewModel(
    * @param newContent The new text content for the message.
    * @throws IllegalArgumentException if sender is not the message author or content is blank
    * @see DiscussionRepository.editMessage for detailed behavior
-   * @see EDIT_MESSAGE_MAX_THRESHOLD for the time limit
+   * @see EDIT_MAX_THRESHOLD for the time limit
    */
   fun editMessage(discussion: Discussion, message: Message, sender: Account, newContent: String) {
     if (message.senderId != sender.uid)
         throw IllegalArgumentException("Can not edit someone else's message")
 
-    if (Timestamp.now().toDate().time >
-        message.createdAt.toDate().time + EDIT_MESSAGE_MAX_THRESHOLD)
+    if (Timestamp.now().toDate().time > message.createdAt.toDate().time + EDIT_MAX_THRESHOLD)
         throw IllegalArgumentException(
-            "Can not edit a message after ${EDIT_MESSAGE_MAX_THRESHOLD}ms it has been created")
+            "Can not edit a message after ${EDIT_MAX_THRESHOLD}ms it has been created")
 
     val cleaned = newContent.trimEnd()
     if (cleaned.isBlank()) throw IllegalArgumentException("Message content cannot be blank")

--- a/app/src/main/java/com/github/meeplemeet/model/posts/PostViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/posts/PostViewModel.kt
@@ -55,15 +55,15 @@ class PostViewModel(private val repository: PostRepository = RepositoryProvider.
     if (post.authorId != author.uid)
         throw PermissionDeniedException("Another users post cannot be edited")
 
-    if (Timestamp.now().toDate().time > post.timestamp.toDate().time + EDIT_MAX_THRESHOLD)
-        throw IllegalArgumentException(
-            "Can not edit a post after ${EDIT_MAX_THRESHOLD}ms it has been created")
+    require(Timestamp.now().toDate().time <= post.timestamp.toDate().time + EDIT_MAX_THRESHOLD) {
+      "Can not edit a post after ${EDIT_MAX_THRESHOLD}ms it has been created"
+    }
 
-    if (newTitle != null && newTitle.isBlank())
-        throw IllegalArgumentException("Cannot create a post with an empty title")
+    require(!(newTitle != null && newTitle.isBlank())) {
+      "Cannot create a post with an empty title"
+    }
 
-    if (newBody != null && newBody.isBlank())
-        throw IllegalArgumentException("Cannot create a post with an empty body")
+    require(!(newBody != null && newBody.isBlank())) { "Cannot create a post with an empty body" }
 
     viewModelScope.launch { repository.editPost(post.id, newTitle, newBody, newTags) }
   }
@@ -123,11 +123,11 @@ class PostViewModel(private val repository: PostRepository = RepositoryProvider.
     if (comment.authorId != author.uid)
         throw PermissionDeniedException("Another users post cannot be edited")
 
-    if (Timestamp.now().toDate().time > post.timestamp.toDate().time + EDIT_MAX_THRESHOLD)
-        throw IllegalArgumentException(
-            "Can not edit a post after ${EDIT_MAX_THRESHOLD}ms it has been created")
+    require(Timestamp.now().toDate().time <= post.timestamp.toDate().time + EDIT_MAX_THRESHOLD) {
+      "Can not edit a post after ${EDIT_MAX_THRESHOLD}ms it has been created"
+    }
 
-    if (newText.isBlank()) throw IllegalArgumentException("Cannot send a blank comment")
+    require(!(newText.isBlank())) { "Cannot send a blank comment" }
 
     viewModelScope.launch { repository.editComment(post.id, comment.id, newText) }
   }


### PR DESCRIPTION
This PR adds the ability to edit posts and comments with proper permission checks and validation.

  Changes
  - Permission controls: Only post/comment authors can edit their own content
  - Time-based restrictions: Edits must be made within EDIT_MAX_THRESHOLD after creation
  - Input validation: Prevents editing with blank titles, bodies, or comment text

  ---
  🤖 Generated with https://claude.com/claude-code