### PR TITLE
Feat/offline posts

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/A_FeedsOverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/A_FeedsOverviewScreenTest.kt
@@ -130,7 +130,6 @@ class A_FeedsOverviewScreenTest : FirestoreTests() {
     createdPosts += normal
     normal = postRepository.getPost(normal.id)
     val first = createdPosts.first()
-    postVm.getPosts()
 
     /* 3  LIGHT THEME  ------------------------------------------------------ */
     theme = ThemeMode.LIGHT

--- a/app/src/androidTest/java/com/github/meeplemeet/integration/FirestorePostTests.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/FirestorePostTests.kt
@@ -16,7 +16,6 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertNotEquals
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
@@ -26,21 +25,10 @@ class FirestorePostTests : FirestoreTests() {
 
   private fun checkpoint(name: String, block: () -> Unit) = ck.ck(name, block)
 
-  private lateinit var createVM: CreatePostViewModel
-  private lateinit var postVM: PostViewModel
-  private lateinit var overviewVM: PostOverviewViewModel
-
   private val testAccount1 =
       Account(uid = "user1", handle = "alice", name = "Alice", email = "alice@test.com")
   private val testAccount2 =
       Account(uid = "user2", handle = "bob", name = "Bob", email = "bob@test.com")
-
-  @Before
-  fun setup() {
-    createVM = CreatePostViewModel()
-    postVM = PostViewModel()
-    overviewVM = PostOverviewViewModel()
-  }
 
   @Test
   fun smoke_createAndDeletePost() = runTest {
@@ -185,16 +173,19 @@ class FirestorePostTests : FirestoreTests() {
 
   @Test(expected = IllegalArgumentException::class)
   fun testCreatePostViewModelWithBlankTitle() = runBlocking {
+    val createVM = CreatePostViewModel()
     createVM.createPost("", "Content", testAccount1)
   }
 
   @Test(expected = IllegalArgumentException::class)
   fun testCreatePostViewModelWithBlankBody() = runBlocking {
+    val createVM = CreatePostViewModel()
     createVM.createPost("Title", "", testAccount1)
   }
 
   @Test
   fun testDeletePostAsAuthor() = runTest {
+    val postVM = PostViewModel()
     val post = postRepository.createPost("To Delete", "Content", testAccount1.uid)
     postVM.deletePost(testAccount1, post)
     advanceUntilIdle()
@@ -202,6 +193,7 @@ class FirestorePostTests : FirestoreTests() {
 
   @Test(expected = PermissionDeniedException::class)
   fun testDeletePostAsNonAuthor() = runTest {
+    val postVM = PostViewModel()
     val post = postRepository.createPost("Protected Post", "Content", testAccount1.uid)
 
     postVM.deletePost(testAccount2, post)
@@ -209,6 +201,7 @@ class FirestorePostTests : FirestoreTests() {
 
   @Test
   fun testAddCommentToPost() = runBlocking {
+    val postVM = PostViewModel()
     val post = postRepository.createPost("Post", "Content", testAccount1.uid)
     postVM.addComment(testAccount2, post, post.id, "VM Comment")
     delay(1000)
@@ -220,6 +213,7 @@ class FirestorePostTests : FirestoreTests() {
 
   @Test(expected = IllegalArgumentException::class)
   fun testAddBlankComment() {
+    val postVM = PostViewModel()
     val post = runBlocking { postRepository.createPost("Post", "Content", testAccount1.uid) }
 
     postVM.addComment(testAccount2, post, post.id, "")
@@ -227,6 +221,7 @@ class FirestorePostTests : FirestoreTests() {
 
   @Test
   fun testRemoveCommentAsAuthor() = runBlocking {
+    val postVM = PostViewModel()
     val post = postRepository.createPost("Post", "Content", testAccount1.uid)
     postRepository.addComment(post.id, "Comment", testAccount2.uid, post.id)
 
@@ -242,6 +237,7 @@ class FirestorePostTests : FirestoreTests() {
 
   @Test(expected = PermissionDeniedException::class)
   fun testRemoveCommentAsNonAuthor() = runTest {
+    val postVM = PostViewModel()
     val post = postRepository.createPost("Post", "Content", testAccount1.uid)
     postRepository.addComment(post.id, "Comment", testAccount2.uid, post.id)
 
@@ -310,6 +306,7 @@ class FirestorePostTests : FirestoreTests() {
 
   @Test
   fun testGetPostsViewModelInitialState() = runTest {
+    val overviewVM = PostOverviewViewModel()
     // Verify initial state is empty list
     val initialPosts = overviewVM.posts.value
     assertTrue(initialPosts.isEmpty())

--- a/app/src/androidTest/java/com/github/meeplemeet/integration/OfflinePostsSyncTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/OfflinePostsSyncTest.kt
@@ -1,0 +1,461 @@
+package com.github.meeplemeet.integration
+
+import com.github.meeplemeet.model.offline.OfflineModeManager
+import com.github.meeplemeet.utils.Checkpoint
+import com.github.meeplemeet.utils.FirestoreTests
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertNotNull
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Integration tests for offline posts synchronization with Firestore.
+ *
+ * Tests the complete offline-to-online flow:
+ * - Creating posts offline
+ * - Adding comments offline
+ * - Syncing queued posts when back online
+ * - Syncing offline comments when back online
+ * - Proper ID mapping from temp IDs to real Firestore IDs
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class OfflinePostsSyncTest : FirestoreTests() {
+  @get:Rule val ck = Checkpoint.rule()
+
+  private fun checkpoint(name: String, block: () -> Unit) = ck.ck(name, block)
+
+  @Before
+  fun setup() {
+    // Start in offline mode
+    OfflineModeManager.setInternetConnection(false)
+  }
+
+  @After
+  fun cleanup() = runBlocking {
+    // Clear offline state
+    OfflineModeManager.clearCachedPosts()
+    val queuedPosts = OfflineModeManager.getQueuedPosts()
+    queuedPosts.forEach { post -> OfflineModeManager.removeQueuedPost(post.id) }
+  }
+
+  @Test
+  fun syncQueuedPostsUploadsOfflinePostsToFirestore() = runTest {
+    checkpoint("Create posts offline") {
+      runBlocking {
+        // Given: Offline mode with queued posts
+        OfflineModeManager.setInternetConnection(false)
+
+        OfflineModeManager.createPost(
+            title = "Offline Post 1",
+            body = "Created while offline",
+            authorId = "user123",
+            tags = listOf("offline", "test"))
+
+        OfflineModeManager.createPost(
+            title = "Offline Post 2",
+            body = "Another offline post",
+            authorId = "user456",
+            tags = listOf("offline"))
+
+        delay(100)
+
+        // Verify posts are queued
+        val queuedPosts = OfflineModeManager.getQueuedPosts()
+        assertEquals(2, queuedPosts.size)
+        assertTrue(queuedPosts.all { it.id.startsWith("temp_") })
+      }
+    }
+
+    checkpoint("Sync posts when back online") {
+      runBlocking {
+        // When: Come back online and sync
+        OfflineModeManager.setInternetConnection(true)
+        OfflineModeManager.syncQueuedPosts()
+        delay(1000) // Wait for sync
+
+        // Then: Posts are uploaded to Firestore
+        val allPosts = postRepository.getPosts()
+        assertTrue(allPosts.size >= 2)
+
+        val uploadedPost1 = allPosts.find { it.title == "Offline Post 1" }
+        val uploadedPost2 = allPosts.find { it.title == "Offline Post 2" }
+
+        assertNotNull(uploadedPost1)
+        assertNotNull(uploadedPost2)
+
+        // Verify posts have real Firestore IDs (not temp)
+        assertFalse(uploadedPost1!!.id.startsWith("temp_"))
+        assertFalse(uploadedPost2!!.id.startsWith("temp_"))
+
+        // Verify post content
+        assertEquals("Created while offline", uploadedPost1.body)
+        assertEquals("user123", uploadedPost1.authorId)
+        assertEquals(listOf("offline", "test"), uploadedPost1.tags)
+
+        // Verify queue is cleared
+        val remainingQueued = OfflineModeManager.getQueuedPosts()
+        assertTrue(remainingQueued.isEmpty())
+      }
+    }
+  }
+
+  @Test
+  fun syncOfflineCommentsSyncsCommentsAndMapsIDs() = runTest {
+    var createdPostId: String = ""
+
+    checkpoint("Create post online") {
+      runBlocking {
+        // Given: Create a post online first
+        OfflineModeManager.setInternetConnection(true)
+        val post =
+            postRepository.createPost(
+                title = "Test Post", content = "For offline comments", authorId = "user123")
+        createdPostId = post.id
+        delay(500)
+      }
+    }
+
+    checkpoint("Add comments offline") {
+      runBlocking {
+        // When: Go offline and fetch the post, then add comments
+        OfflineModeManager.setInternetConnection(false)
+
+        // Fetch the post from Firestore while online to cache it
+        OfflineModeManager.setInternetConnection(true)
+        val postWithData = postRepository.getPost(createdPostId)
+        OfflineModeManager.cachePosts(listOf(postWithData))
+        delay(500)
+
+        // Now go offline
+        OfflineModeManager.setInternetConnection(false)
+
+        // Add top-level comments
+        OfflineModeManager.addComment(
+            postId = createdPostId,
+            text = "Offline comment 1",
+            authorId = "user456",
+            parentId = createdPostId)
+
+        OfflineModeManager.addComment(
+            postId = createdPostId,
+            text = "Offline comment 2",
+            authorId = "user789",
+            parentId = createdPostId)
+
+        delay(100)
+
+        // Verify comments are added with temp IDs
+        val cachedPosts = OfflineModeManager.getCachedPosts()
+        assertTrue("No posts cached", cachedPosts.isNotEmpty())
+        val updatedPost = cachedPosts.find { it.id == createdPostId }
+        assertNotNull("Post not found in cache", updatedPost)
+        assertEquals(2, updatedPost!!.comments.size)
+        assertTrue(updatedPost.comments.all { it.id.startsWith("temp_comment_") })
+      }
+    }
+
+    checkpoint("Sync comments when back online") {
+      runBlocking {
+        // When: Come back online and sync comments
+        OfflineModeManager.setInternetConnection(true)
+
+        OfflineModeManager.syncOfflineComments()
+        delay(1000) // Wait for sync
+
+        // Then: Comments are synced to Firestore
+        val syncedPost = postRepository.getPost(createdPostId)
+
+        assertEquals(2, syncedPost.comments.size)
+
+        // Verify comments have real Firestore IDs (not temp)
+        assertFalse(syncedPost.comments[0].id.startsWith("temp_comment_"))
+        assertFalse(syncedPost.comments[1].id.startsWith("temp_comment_"))
+
+        // Verify comment content
+        val commentTexts = syncedPost.comments.map { it.text }
+        assertTrue(commentTexts.contains("Offline comment 1"))
+        assertTrue(commentTexts.contains("Offline comment 2"))
+
+        // Verify cache is cleared after sync
+        val cachedPosts = OfflineModeManager.getCachedPosts()
+        assertTrue(cachedPosts.isEmpty())
+      }
+    }
+  }
+
+  @Test
+  fun syncNestedOfflineCommentsPreservesHierarchy() = runTest {
+    var createdPostId: String = ""
+    var parentCommentId: String = ""
+
+    checkpoint("Create post and add parent comment online") {
+      runBlocking {
+        // Given: Post with a parent comment created online
+        OfflineModeManager.setInternetConnection(true)
+        val post =
+            postRepository.createPost(
+                title = "Nested Comments Post",
+                content = "Testing nested comments",
+                authorId = "user123")
+        createdPostId = post.id
+
+        parentCommentId =
+            postRepository.addComment(
+                postId = post.id, text = "Parent comment", authorId = "user456", parentId = post.id)
+
+        delay(500)
+
+        // Fetch and cache the post with parent comment
+        val postWithComment = postRepository.getPost(post.id)
+        OfflineModeManager.cachePosts(listOf(postWithComment))
+        delay(500)
+      }
+    }
+
+    checkpoint("Add reply offline") {
+      runBlocking {
+        // When: Go offline and add reply to parent comment
+        OfflineModeManager.setInternetConnection(false)
+
+        val cachedPosts = OfflineModeManager.getCachedPosts()
+        assertTrue("No posts cached", cachedPosts.isNotEmpty())
+        val cachedPost = cachedPosts.find { it.id == createdPostId }
+        assertNotNull("Post not found in cache", cachedPost)
+        val parentComment = cachedPost!!.comments[0]
+
+        // Add reply to parent comment
+        OfflineModeManager.addComment(
+            postId = cachedPost.id,
+            text = "Offline reply to parent",
+            authorId = "user789",
+            parentId = parentComment.id)
+
+        delay(100)
+
+        // Verify reply is nested under parent
+        val updatedPost = OfflineModeManager.getCachedPosts().find { it.id == createdPostId }
+        assertNotNull("Updated post not found", updatedPost)
+        assertEquals(1, updatedPost!!.comments.size)
+        assertEquals(1, updatedPost.comments[0].children.size)
+        assertEquals("Offline reply to parent", updatedPost.comments[0].children[0].text)
+      }
+    }
+
+    checkpoint("Sync nested comments") {
+      runBlocking {
+        // When: Come back online and sync
+        OfflineModeManager.setInternetConnection(true)
+
+        OfflineModeManager.syncOfflineComments()
+        delay(1000)
+
+        // Then: Nested structure is preserved in Firestore
+        val syncedPost = postRepository.getPost(createdPostId)
+
+        assertEquals(1, syncedPost.comments.size)
+        assertEquals("Parent comment", syncedPost.comments[0].text)
+
+        // Verify reply is nested correctly
+        assertEquals(1, syncedPost.comments[0].children.size)
+        assertEquals("Offline reply to parent", syncedPost.comments[0].children[0].text)
+
+        // All IDs are real Firestore IDs
+        assertFalse(syncedPost.comments[0].id.startsWith("temp_comment_"))
+        assertFalse(syncedPost.comments[0].children[0].id.startsWith("temp_comment_"))
+      }
+    }
+  }
+
+  @Test
+  fun syncHandlesMultipleNestedLevels() = runTest {
+    var createdPostId: String = ""
+
+    checkpoint("Setup post with comment hierarchy") {
+      runBlocking {
+        // Given: Create post online
+        OfflineModeManager.setInternetConnection(true)
+        val post =
+            postRepository.createPost(
+                title = "Deep Nesting",
+                content = "Testing deep comment nesting",
+                authorId = "user1")
+        createdPostId = post.id
+
+        // Add level 1 comment online
+        val level1Id = postRepository.addComment(post.id, "Level 1", "user2", post.id)
+        delay(200)
+
+        // Fetch and cache post
+        val postWithL1 = postRepository.getPost(post.id)
+        OfflineModeManager.cachePosts(listOf(postWithL1))
+        delay(500)
+      }
+    }
+
+    checkpoint("Add nested replies offline") {
+      runBlocking {
+        // When: Go offline and add nested replies
+        OfflineModeManager.setInternetConnection(false)
+
+        val cachedPosts = OfflineModeManager.getCachedPosts()
+        assertTrue("No posts cached", cachedPosts.isNotEmpty())
+        val cachedPost = cachedPosts.find { it.id == createdPostId }
+        assertNotNull("Post not found in cache", cachedPost)
+        val level1Comment = cachedPost!!.comments[0]
+
+        // Add level 2 reply offline
+        OfflineModeManager.addComment(cachedPost.id, "Level 2 offline", "user3", level1Comment.id)
+        delay(50)
+
+        // Get updated post with level 2
+        val postWithL2 = OfflineModeManager.getCachedPosts().find { it.id == createdPostId }
+        assertNotNull("Post with L2 not found", postWithL2)
+        val level2Comment = postWithL2!!.comments[0].children[0]
+
+        // Add level 3 reply offline
+        OfflineModeManager.addComment(cachedPost.id, "Level 3 offline", "user4", level2Comment.id)
+        delay(50)
+
+        // Verify 3-level nesting locally
+        val finalPost = OfflineModeManager.getCachedPosts().find { it.id == createdPostId }
+        assertNotNull("Final post not found", finalPost)
+        assertEquals(1, finalPost!!.comments.size)
+        assertEquals(1, finalPost.comments[0].children.size)
+        assertEquals(1, finalPost.comments[0].children[0].children.size)
+      }
+    }
+
+    checkpoint("Sync preserves all nesting levels") {
+      runBlocking {
+        // When: Sync to Firestore
+        OfflineModeManager.setInternetConnection(true)
+
+        OfflineModeManager.syncOfflineComments()
+        delay(1000)
+
+        // Then: All nesting levels preserved
+        val syncedPost = postRepository.getPost(createdPostId)
+
+        assertEquals("Level 1", syncedPost.comments[0].text)
+        assertEquals("Level 2 offline", syncedPost.comments[0].children[0].text)
+        assertEquals("Level 3 offline", syncedPost.comments[0].children[0].children[0].text)
+
+        // All have real IDs
+        assertFalse(syncedPost.comments[0].id.startsWith("temp_"))
+        assertFalse(syncedPost.comments[0].children[0].id.startsWith("temp_"))
+        assertFalse(syncedPost.comments[0].children[0].children[0].id.startsWith("temp_"))
+      }
+    }
+  }
+
+  @Test
+  fun syncQueuedPostsDoesNothingWhenOffline() = runTest {
+    checkpoint("Create posts offline") {
+      runBlocking {
+        // Given: Offline with queued posts
+        OfflineModeManager.setInternetConnection(false)
+        OfflineModeManager.createPost("Offline Post", "Body", "user1")
+        delay(100)
+
+        assertEquals(1, OfflineModeManager.getQueuedPosts().size)
+      }
+    }
+
+    checkpoint("Try to sync while still offline") {
+      runBlocking {
+        // When: Try to sync while offline
+        OfflineModeManager.syncQueuedPosts()
+        delay(100)
+
+        // Then: Posts remain queued (not synced)
+        assertEquals(1, OfflineModeManager.getQueuedPosts().size)
+      }
+    }
+  }
+
+  @Test
+  fun syncOfflineCommentsDoesNothingWhenOffline() = runTest {
+    var createdPostId: String = ""
+
+    checkpoint("Setup") {
+      runBlocking {
+        // Given: Post with offline comments
+        OfflineModeManager.setInternetConnection(true)
+        val post = postRepository.createPost("Post", "Body", "user1")
+        createdPostId = post.id
+
+        // Fetch and cache it
+        val postData = postRepository.getPost(post.id)
+        OfflineModeManager.cachePosts(listOf(postData))
+        delay(500)
+
+        OfflineModeManager.setInternetConnection(false)
+        OfflineModeManager.addComment(post.id, "Offline comment", "user2", post.id)
+        delay(100)
+
+        val cachedPosts = OfflineModeManager.getCachedPosts()
+        assertTrue("No cached posts", cachedPosts.isNotEmpty())
+        val cachedPost = cachedPosts.find { it.id == createdPostId }
+        assertNotNull("Post not found", cachedPost)
+        assertEquals(1, cachedPost!!.comments.size)
+      }
+    }
+
+    checkpoint("Try to sync while offline") {
+      runBlocking {
+        // When: Try to sync while offline
+        OfflineModeManager.syncOfflineComments()
+        delay(100)
+
+        // Then: Comments remain cached (not synced)
+        val cachedPosts = OfflineModeManager.getCachedPosts()
+        assertTrue("No cached posts after sync", cachedPosts.isNotEmpty())
+        val cachedPost = cachedPosts.find { it.id == createdPostId }
+        assertNotNull("Post not found after sync", cachedPost)
+        assertEquals(1, cachedPost!!.comments.size)
+        assertTrue(cachedPost.comments[0].id.startsWith("temp_comment_"))
+      }
+    }
+  }
+
+  @Test
+  fun cachePostsFetchesFullPostsWithComments() = runTest {
+    var createdPostId: String = ""
+
+    checkpoint("Create post with comments online") {
+      runBlocking {
+        // Given: Post with comments in Firestore
+        OfflineModeManager.setInternetConnection(true)
+        val post = postRepository.createPost("Full Post", "Body", "user1")
+        createdPostId = post.id
+        postRepository.addComment(post.id, "Comment 1", "user2", post.id)
+        postRepository.addComment(post.id, "Comment 2", "user3", post.id)
+        delay(500)
+      }
+    }
+
+    checkpoint("Cache posts fetches with comments") {
+      runBlocking {
+        // When: Fetch and cache the post
+        val fullPost = postRepository.getPost(createdPostId)
+        OfflineModeManager.cachePosts(listOf(fullPost))
+        delay(1000) // Wait for cachePosts coroutine to complete
+
+        // Then: Cached post includes comments
+        val cachedPosts = OfflineModeManager.getCachedPosts()
+        val cachedPost = cachedPosts.find { it.title == "Full Post" }
+
+        assertNotNull("Post not found in cache", cachedPost)
+        assertEquals(2, cachedPost!!.comments.size)
+      }
+    }
+  }
+}

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/MainTabComposableTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/MainTabComposableTest.kt
@@ -240,6 +240,7 @@ class MainTabComposableTest : FirestoreTests() {
     compose.setContent {
       AppTheme {
         MainTab(
+            online = true,
             viewModel = profileVM,
             account = accountState.value,
             onFriendsClick = { friendsClicked = true },

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/PostScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/PostScreenTest.kt
@@ -2,6 +2,7 @@
 // and user combinations instructions. Improvements were then added by hand.
 package com.github.meeplemeet.ui
 
+import android.content.Context
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -63,9 +64,9 @@ class PostScreenTest {
 
     private val accounts = mutableMapOf(marco.uid to marco, alex.uid to alex, dany.uid to dany)
 
-    override fun getOtherAccount(uid: String, onResult: (Account) -> Unit) {
-      if (uid.isBlank()) return
-      accounts[uid]?.let { onResult(it) }
+    override fun getAccount(id: String, context: Context, onResult: (Account?) -> Unit) {
+      if (id.isBlank()) return
+      accounts[id]?.let { onResult(it) }
     }
 
     fun addAccount(account: Account) {

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/PostScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/PostScreenTest.kt
@@ -17,20 +17,20 @@ import com.github.meeplemeet.model.account.Account
 import com.github.meeplemeet.model.account.AccountViewModel
 import com.github.meeplemeet.model.posts.Comment
 import com.github.meeplemeet.model.posts.Post
-import com.github.meeplemeet.model.posts.PostRepository
 import com.github.meeplemeet.model.posts.PostViewModel
 import com.github.meeplemeet.ui.posts.COMMENT_TEXT_ZONE_PLACEHOLDER
 import com.github.meeplemeet.ui.posts.PostScreen
 import com.github.meeplemeet.ui.posts.PostTags
 import com.github.meeplemeet.ui.theme.AppTheme
 import com.github.meeplemeet.utils.Checkpoint
+import com.github.meeplemeet.utils.FirestoreTests
 import com.google.firebase.Timestamp
 import kotlinx.coroutines.CoroutineScope
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
-class PostScreenTest {
+class PostScreenTest : FirestoreTests() {
 
   @get:Rule val compose = createComposeRule()
   @get:Rule val ck = Checkpoint.Rule()
@@ -75,7 +75,6 @@ class PostScreenTest {
   }
 
   /* ViewModels */
-  private lateinit var postRepo: PostRepository
   private lateinit var postVM: PostViewModel
   private lateinit var accountVM: FakeAccountViewModel
 
@@ -122,8 +121,8 @@ class PostScreenTest {
             comments = listOf(c1, c2))
     postByMarco = postByAlex.copy(id = "p2", authorId = marco.uid)
 
-    postRepo = PostRepository()
-    postVM = PostViewModel(postRepo)
+    // Use postRepository from FirestoreTests parent class
+    postVM = PostViewModel(postRepository)
     accountVM = FakeAccountViewModel()
   }
 

--- a/app/src/androidTest/java/com/github/meeplemeet/utils/FirestoreTests.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/utils/FirestoreTests.kt
@@ -10,6 +10,7 @@ import com.github.meeplemeet.model.discussions.DiscussionRepository
 import com.github.meeplemeet.model.images.ImageRepository
 import com.github.meeplemeet.model.map.MarkerPreviewRepository
 import com.github.meeplemeet.model.map.StorableGeoPinRepository
+import com.github.meeplemeet.model.offline.OfflineModeManager
 import com.github.meeplemeet.model.posts.PostRepository
 import com.github.meeplemeet.model.sessions.SessionRepository
 import com.github.meeplemeet.model.shared.game.FirestoreGameRepository
@@ -140,6 +141,9 @@ open class FirestoreTests {
       UiBehaviorConfig.hideBottomBarWhenInputFocused = false
       UiBehaviorConfig.clearFocusOnKeyboardHide = false
     }
+
+    // Set online mode for tests that expect Firestore interaction
+    OfflineModeManager.setInternetConnection(true)
 
     db = FirebaseProvider.db
     auth = FirebaseProvider.auth

--- a/app/src/main/java/com/github/meeplemeet/MainActivity.kt
+++ b/app/src/main/java/com/github/meeplemeet/MainActivity.kt
@@ -190,7 +190,7 @@ fun MeepleMeetApp(
   var accountId by remember { mutableStateOf(FirebaseProvider.auth.currentUser?.uid ?: "") }
   val accountFlow =
       remember(accountId, signedOut) {
-        if (!signedOut) viewModel.accountFlow(accountId) else MutableStateFlow(null)
+        if (!signedOut) viewModel.accountFlow(accountId, context) else MutableStateFlow(null)
       }
   val account by accountFlow.collectAsStateWithLifecycle()
 
@@ -207,6 +207,8 @@ fun MeepleMeetApp(
 
   var spaceId by remember { mutableStateOf("") }
   var spaceRenter by remember { mutableStateOf<SpaceRenter?>(null) }
+
+  val online by OfflineModeManager.hasInternetConnection.collectAsStateWithLifecycle()
 
   DisposableEffect(Unit) {
     val listener = FirebaseAuth.AuthStateListener { accountId = it.currentUser?.uid ?: "" }
@@ -406,6 +408,7 @@ fun MeepleMeetApp(
         ProfileScreen(
             navigation = navigationActions,
             account = account!!,
+            online = online,
             onSignOutOrDel = {
               navigationActions.navigateTo(MeepleMeetScreen.SignIn)
               signedOut = true

--- a/app/src/main/java/com/github/meeplemeet/MainActivity.kt
+++ b/app/src/main/java/com/github/meeplemeet/MainActivity.kt
@@ -35,6 +35,7 @@ import com.github.meeplemeet.model.images.ImageRepository
 import com.github.meeplemeet.model.map.MarkerPreviewRepository
 import com.github.meeplemeet.model.map.PinType
 import com.github.meeplemeet.model.map.StorableGeoPinRepository
+import com.github.meeplemeet.model.offline.OfflineModeManager
 import com.github.meeplemeet.model.posts.PostRepository
 import com.github.meeplemeet.model.sessions.SessionRepository
 import com.github.meeplemeet.model.shared.game.BggGameRepository
@@ -166,6 +167,7 @@ class MainActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     MapsInitializer.initialize(applicationContext)
+    OfflineModeManager.start(applicationContext)
     setContent { AppTheme { Surface(modifier = Modifier.fillMaxSize()) { MeepleMeetApp() } } }
   }
 

--- a/app/src/main/java/com/github/meeplemeet/model/MainActivityViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/MainActivityViewModel.kt
@@ -1,6 +1,7 @@
 // Docs generated with Claude Code.
 package com.github.meeplemeet.model
 
+import android.content.Context
 import androidx.lifecycle.viewModelScope
 import com.github.meeplemeet.RepositoryProvider
 import com.github.meeplemeet.model.account.Account
@@ -8,10 +9,13 @@ import com.github.meeplemeet.model.account.AccountRepository
 import com.github.meeplemeet.model.auth.AuthenticationViewModel
 import com.github.meeplemeet.model.discussions.Discussion
 import com.github.meeplemeet.model.discussions.DiscussionRepository
+import com.github.meeplemeet.model.offline.OfflineModeManager
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 
 /**
  * Main view model for the application that provides real-time data flows for accounts and
@@ -37,34 +41,58 @@ class MainActivityViewModel(
    */
   override fun signOut() {
     discussionFlows.clear()
-    accountFlows.clear()
     super.signOut()
   }
-
-  // Holds cached [StateFlow]s of accounts keyed by account ID to avoid duplicate listeners.
-  private val accountFlows = mutableMapOf<String, StateFlow<Account?>>()
 
   /**
    * Returns a real-time flow of account data for the specified account ID.
    *
-   * This method manages a cache of StateFlows to avoid creating duplicate Firestore listeners. The
-   * flow emits updated account data whenever changes occur in Firestore, including the account's
-   * discussion previews.
+   * This method integrates both online and offline modes:
+   * - When online: Creates a Firestore listener that emits real-time updates and caches data
+   * - When offline: Loads account from the offline cache using OfflineModeManager
+   *
+   * The flow combines the internet connection state with the appropriate data source, automatically
+   * switching between online (Firestore) and offline (cached) data as connectivity changes.
+   *
+   * ## Caching Behavior
+   * - When online, accounts are loaded via OfflineModeManager which caches them
+   * - When offline, accounts are retrieved from OfflineModeManager cache
+   * - When transitioning from offline to online, the flow switches to live Firestore data
    *
    * @param accountId The ID of the account to observe
+   * @param context Android context for accessing offline storage (required for offline mode)
    * @return A [StateFlow] that emits the account or null if the account doesn't exist or ID is
    *   blank
    */
-  fun accountFlow(accountId: String): StateFlow<Account?> {
+  fun accountFlow(accountId: String, context: Context): StateFlow<Account?> {
     if (accountId.isBlank()) return MutableStateFlow(null)
-    return accountFlows.getOrPut(accountId) {
-      accountRepository
-          .listenAccount(accountId)
-          .stateIn(
-              scope = viewModelScope,
-              started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 0),
-              initialValue = null)
+
+    // Create a flow that combines online/offline state with account data
+    val accountDataFlow = MutableStateFlow<Account?>(null)
+
+    // Listen to connectivity changes and load account accordingly
+    viewModelScope.launch {
+      OfflineModeManager.hasInternetConnection.collect {
+        // Always use OfflineModeManager.loadAccount - it handles both cache and fetch
+        OfflineModeManager.loadAccount(accountId, context) { account ->
+          accountDataFlow.value = account
+        }
+      }
     }
+
+    // Combine connectivity state with account data and listen to Firestore when online
+    return combine(
+            OfflineModeManager.hasInternetConnection,
+            accountRepository.listenAccount(accountId),
+            accountDataFlow) { isOnline, liveAccount, loadedAccount ->
+              // When online, prefer live Firestore data
+              // When offline, use the loaded account from cache
+              if (isOnline) liveAccount else loadedAccount
+            }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 0),
+            initialValue = null)
   }
 
   // Holds cached [StateFlow]s of discussions keyed by discussion ID to avoid duplicate listeners.

--- a/app/src/main/java/com/github/meeplemeet/model/account/AccountRepository.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/AccountRepository.kt
@@ -231,6 +231,28 @@ class AccountRepository :
   }
 
   /**
+   * Safely retrieves an account and its associated data by ID, returning null on failure.
+   *
+   * This is a safe wrapper around [getAccount] that catches any exceptions (including
+   * [AccountNotFoundException]) and returns null instead of throwing. This is useful for scenarios
+   * where an account might not exist or the fetch might fail due to network issues, and you want to
+   * handle the absence gracefully.
+   *
+   * @param id The account ID to retrieve
+   * @param getAllData If true, fetches all subcollections (previews, relationships, notifications).
+   *   If false, returns account with empty subcollections. Defaults to true.
+   * @return The Account object with populated data, or null if the account doesn't exist or an
+   *   error occurs
+   */
+  suspend fun getAccountSafe(id: String, getAllData: Boolean = true): Account? {
+    return try {
+      getAccount(id, getAllData)
+    } catch (_: Exception) {
+      null
+    }
+  }
+
+  /**
    * Retrieves multiple accounts and their discussion previews, relationships, and notifications
    * concurrently.
    *
@@ -247,6 +269,28 @@ class AccountRepository :
   suspend fun getAccounts(ids: List<String>, getAllData: Boolean = true): List<Account> =
       coroutineScope {
         ids.map { id -> async { getAccount(id, getAllData) } }.awaitAll()
+      }
+
+  /**
+   * Safely retrieves multiple accounts concurrently, returning null for any that fail to load.
+   *
+   * This is a safe wrapper around [getAccounts] that uses [getAccountSafe] for each account,
+   * ensuring that if any account fails to load (doesn't exist, network error, etc.), the operation
+   * continues and returns null for that specific account rather than throwing an exception for the
+   * entire batch.
+   *
+   * The result list will always have the same size and order as the input IDs list, with null
+   * values in positions where accounts couldn't be retrieved.
+   *
+   * @param ids List of account IDs to retrieve
+   * @param getAllData If true, fetches all subcollections (previews, relationships, notifications)
+   *   for each account. If false, returns accounts with empty subcollections. Defaults to true.
+   * @return List of Account objects (or null for failed retrievals) in the same order as the input
+   *   IDs
+   */
+  suspend fun getAccountsSafe(ids: List<String>, getAllData: Boolean = true): List<Account?> =
+      coroutineScope {
+        ids.map { id -> async { getAccountSafe(id, getAllData) } }.awaitAll()
       }
 
   /**
@@ -330,6 +374,16 @@ class AccountRepository :
    */
   suspend fun deleteAccount(id: String) {
     fullyDeleteDocument(collection.document(id))
+  }
+
+  /**
+   * Updates an account document from it's offline changes.
+   *
+   * @param id The account ID to update
+   * @param changes The changes made offline
+   */
+  suspend fun updateAccount(id: String, changes: Map<String, Any>) {
+    collection.document(id).update(changes).await()
   }
 
   /**

--- a/app/src/main/java/com/github/meeplemeet/model/account/AccountViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/AccountViewModel.kt
@@ -3,6 +3,7 @@ package com.github.meeplemeet.model.account
 
 import android.content.Context
 import com.github.meeplemeet.RepositoryProvider
+import com.github.meeplemeet.model.offline.OfflineModeManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -20,38 +21,6 @@ interface AccountViewModel {
   val scope: CoroutineScope
 
   /**
-   * Retrieves an account by its ID.
-   *
-   * @param id The account ID to retrieve
-   * @throws IllegalArgumentException if the ID is blank
-   */
-  fun getAccount(id: String) {
-    require(id.isNotBlank()) { BLANK_ACCOUNT_ID_ERROR }
-    scope.launch { RepositoryProvider.accounts.getAccount(id, false) }
-  }
-
-  /**
-   * Retrieves multiple accounts by their IDs and provides them to a callback.
-   *
-   * Additionally, this method preloads each account's profile picture in the provided context.
-   *
-   * @param uids List of account IDs to retrieve
-   * @param context Context used for loading profile pictures
-   * @param onResult Callback that receives the list of retrieved accounts
-   */
-  fun getAccounts(uids: List<String>, context: Context, onResult: (List<Account>) -> Unit) {
-    scope.launch {
-      val accounts = RepositoryProvider.accounts.getAccounts(uids)
-      onResult(accounts)
-      accounts.forEach { account ->
-        launch {
-          runCatching { RepositoryProvider.images.loadAccountProfilePicture(account.uid, context) }
-        }
-      }
-    }
-  }
-
-  /**
    * Retrieves an account by ID and provides it to a callback.
    *
    * This method is useful when you need to fetch account data without updating the current
@@ -61,25 +30,9 @@ interface AccountViewModel {
    * @param onResult Callback that receives the retrieved account
    * @throws IllegalArgumentException if the ID is blank
    */
-  fun getOtherAccount(id: String, onResult: (Account) -> Unit) {
+  fun getAccount(id: String, context: Context, onResult: (Account?) -> Unit) {
     require(id.isNotBlank()) { BLANK_ACCOUNT_ID_ERROR }
-    scope.launch { onResult(RepositoryProvider.accounts.getAccount(id, false)) }
-  }
-
-  /**
-   * Retrieves an account by ID and provides it to a callback, preloading its profile picture.
-   *
-   * @param id The account ID to retrieve
-   * @param context Context used for loading the profile picture
-   * @param onResult Callback that receives the retrieved account
-   */
-  fun getOtherAccount(id: String, context: Context, onResult: (Account) -> Unit) {
-    require(id.isNotBlank()) { BLANK_ACCOUNT_ID_ERROR }
-    scope.launch {
-      val account = RepositoryProvider.accounts.getAccount(id, false)
-      onResult(account)
-      runCatching { RepositoryProvider.images.loadAccountProfilePicture(account.uid, context) }
-    }
+    scope.launch { OfflineModeManager.loadAccount(id, context) { onResult(it) } }
   }
 
   /**
@@ -88,8 +41,8 @@ interface AccountViewModel {
    * @param uids List of account IDs to retrieve
    * @param onResult Callback that receives the list of retrieved accounts
    */
-  fun getAccounts(uids: List<String>, onResult: (List<Account>) -> Unit) {
-    scope.launch { onResult(RepositoryProvider.accounts.getAccounts(uids)) }
+  fun getAccounts(uids: List<String>, context: Context, onResult: (List<Account?>) -> Unit) {
+    scope.launch { OfflineModeManager.loadAccounts(uids, context, scope) { onResult(it) } }
   }
 
   /**
@@ -196,5 +149,15 @@ interface AccountViewModel {
       // Delete the account
       RepositoryProvider.accounts.deleteAccount(account.uid)
     }
+  }
+
+  /**
+   * Updates an account document from it's offline changes.
+   *
+   * @param account The account to update
+   * @param changes The changes made offline
+   */
+  fun updateAccount(account: Account, changes: Map<String, Any>) {
+    scope.launch { RepositoryProvider.accounts.updateAccount(account.uid, changes) }
   }
 }

--- a/app/src/main/java/com/github/meeplemeet/model/offline/OfflineMode.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/offline/OfflineMode.kt
@@ -29,10 +29,10 @@ import com.github.meeplemeet.model.space_renter.SpaceRenter
  *   have been loaded and cached for offline viewing.
  */
 data class OfflineMode(
-    val accounts: Map<String, Pair<Account, Map<String, Any>>>,
-    val discussions: Map<String, Pair<Discussion, List<Message>>>,
-    val posts: Map<String, Pair<Post, Boolean>>,
-    val shopsToAdd: Map<String, Pair<Shop, Map<String, Any>>>,
-    val spaceRentersToAdd: Map<String, Pair<SpaceRenter, Map<String, Any>>>,
-    val loadedPins: Map<String, GeoPinWithLocation>
+    val accounts: Map<String, Pair<Account, Map<String, Any>>> = emptyMap(),
+    val discussions: Map<String, Pair<Discussion, List<Message>>> = emptyMap(),
+    val posts: Map<String, Pair<Post, Boolean>> = emptyMap(),
+    val shopsToAdd: Map<String, Pair<Shop, Map<String, Any>>> = emptyMap(),
+    val spaceRentersToAdd: Map<String, Pair<SpaceRenter, Map<String, Any>>> = emptyMap(),
+    val loadedPins: Map<String, GeoPinWithLocation> = emptyMap(),
 )

--- a/app/src/main/java/com/github/meeplemeet/model/offline/OfflineMode.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/offline/OfflineMode.kt
@@ -8,33 +8,39 @@ import com.github.meeplemeet.model.posts.Post
 import com.github.meeplemeet.model.shops.Shop
 import com.github.meeplemeet.model.space_renter.SpaceRenter
 
+const val LOAD_FACTOR = 0.9f
+
 /**
  * Represents the offline mode state for the application, caching data for offline access.
  *
  * This data class holds cached entities that have been loaded from the repository, allowing the
- * application to function with limited connectivity. LinkedHashMaps are used to maintain insertion
- * order, enabling LRU-style cache eviction when size limits are enforced.
+ * application to function with limited connectivity. LinkedHashMaps are configured with accessOrder
+ * = true to enable proper LRU (Least Recently Used) cache eviction when size limits are enforced.
  *
  * @property accounts Map of account IDs to pairs of Account objects and their associated metadata.
- *   LinkedHashMap maintains insertion order for potential cache eviction.
+ *   LinkedHashMap maintains access order (LRU) for cache eviction.
  * @property discussions Map of discussion IDs to pairs of Discussion objects and their cached
- *   messages. LinkedHashMap maintains insertion order for potential cache eviction.
+ *   messages. LinkedHashMap maintains access order (LRU) for cache eviction.
  * @property posts Map of post IDs to pairs of Post objects and a boolean flag. LinkedHashMap
- *   maintains insertion order for potential cache eviction.
+ *   maintains access order (LRU) for cache eviction.
  * @property shopsToAdd Map of shop IDs to pairs of Shop objects and their associated metadata.
- *   LinkedHashMap maintains insertion order for potential cache eviction.
+ *   LinkedHashMap maintains access order (LRU) for cache eviction.
  * @property spaceRentersToAdd Map of space renter IDs to pairs of SpaceRenter objects and their
- *   associated metadata. LinkedHashMap maintains insertion order for potential cache eviction.
+ *   associated metadata. LinkedHashMap maintains access order (LRU) for cache eviction.
  * @property loadedPins Map of pin IDs to GeoPinWithLocation objects, representing map pins that
- *   have been loaded and cached for offline viewing. LinkedHashMap maintains insertion order for
- *   potential cache eviction.
+ *   have been loaded and cached for offline viewing. LinkedHashMap maintains access order (LRU) for
+ *   cache eviction.
  */
 data class OfflineMode(
-    val accounts: LinkedHashMap<String, Pair<Account, Map<String, Any>>> = LinkedHashMap(),
-    val discussions: LinkedHashMap<String, Pair<Discussion, List<Message>>> = LinkedHashMap(),
-    val posts: LinkedHashMap<String, Pair<Post, Boolean>> = LinkedHashMap(),
-    val shopsToAdd: LinkedHashMap<String, Pair<Shop, Map<String, Any>>> = LinkedHashMap(),
+    val accounts: LinkedHashMap<String, Pair<Account, Map<String, Any>>> =
+        LinkedHashMap(16, LOAD_FACTOR, true),
+    val discussions: LinkedHashMap<String, Pair<Discussion, List<Message>>> =
+        LinkedHashMap(16, LOAD_FACTOR, true),
+    val posts: LinkedHashMap<String, Pair<Post, Boolean>> = LinkedHashMap(16, LOAD_FACTOR, true),
+    val shopsToAdd: LinkedHashMap<String, Pair<Shop, Map<String, Any>>> =
+        LinkedHashMap(16, LOAD_FACTOR, true),
     val spaceRentersToAdd: LinkedHashMap<String, Pair<SpaceRenter, Map<String, Any>>> =
-        LinkedHashMap(),
-    val loadedPins: LinkedHashMap<String, GeoPinWithLocation> = LinkedHashMap(),
+        LinkedHashMap(16, LOAD_FACTOR, true),
+    val loadedPins: LinkedHashMap<String, GeoPinWithLocation> =
+        LinkedHashMap(16, LOAD_FACTOR, true),
 )

--- a/app/src/main/java/com/github/meeplemeet/model/offline/OfflineMode.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/offline/OfflineMode.kt
@@ -8,6 +8,14 @@ import com.github.meeplemeet.model.posts.Post
 import com.github.meeplemeet.model.shops.Shop
 import com.github.meeplemeet.model.space_renter.SpaceRenter
 
+/**
+ * Maximum number of accounts to cache in offline mode.
+ *
+ * When this limit is exceeded, the oldest accounts (in insertion order) are evicted from the cache
+ * and their profile pictures are deleted from local storage to free up space.
+ */
+const val MAX_CACHED_ACCOUNTS = 50
+
 const val LOAD_FACTOR = 0.9f
 
 /**
@@ -33,7 +41,7 @@ const val LOAD_FACTOR = 0.9f
  */
 data class OfflineMode(
     val accounts: LinkedHashMap<String, Pair<Account, Map<String, Any>>> =
-        LinkedHashMap(16, LOAD_FACTOR, true),
+        LinkedHashMap(MAX_CACHED_ACCOUNTS, LOAD_FACTOR, true),
     val discussions: LinkedHashMap<String, Pair<Discussion, List<Message>>> =
         LinkedHashMap(16, LOAD_FACTOR, true),
     val posts: LinkedHashMap<String, Pair<Post, Boolean>> = LinkedHashMap(16, LOAD_FACTOR, true),

--- a/app/src/main/java/com/github/meeplemeet/model/offline/OfflineMode.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/offline/OfflineMode.kt
@@ -9,30 +9,32 @@ import com.github.meeplemeet.model.shops.Shop
 import com.github.meeplemeet.model.space_renter.SpaceRenter
 
 /**
- * Represents the offline mode state for the application, storing all data that needs to be
- * synchronized when the device goes back online.
+ * Represents the offline mode state for the application, caching data for offline access.
  *
- * This data class holds pending changes made while offline, including new or modified entities that
- * should be uploaded to the backend once connectivity is restored.
+ * This data class holds cached entities that have been loaded from the repository, allowing the
+ * application to function with limited connectivity. LinkedHashMaps are used to maintain insertion
+ * order, enabling LRU-style cache eviction when size limits are enforced.
  *
  * @property accounts Map of account IDs to pairs of Account objects and their associated metadata.
- *   The metadata map contains additional information needed for synchronization.
- * @property discussions Map of discussion IDs to pairs of Discussion objects and their associated
- *   pending messages.
- * @property posts Map of post IDs to Post objects representing posts created (true) or modified
- *   offline (false).
- * @property shopsToAdd Map of shop IDs to pairs of Shop objects and their associated metadata,
- *   representing shops to be created or updated when online.
+ *   LinkedHashMap maintains insertion order for potential cache eviction.
+ * @property discussions Map of discussion IDs to pairs of Discussion objects and their cached
+ *   messages. LinkedHashMap maintains insertion order for potential cache eviction.
+ * @property posts Map of post IDs to pairs of Post objects and a boolean flag. LinkedHashMap
+ *   maintains insertion order for potential cache eviction.
+ * @property shopsToAdd Map of shop IDs to pairs of Shop objects and their associated metadata.
+ *   LinkedHashMap maintains insertion order for potential cache eviction.
  * @property spaceRentersToAdd Map of space renter IDs to pairs of SpaceRenter objects and their
- *   associated metadata, representing space renters to be created or updated when online.
+ *   associated metadata. LinkedHashMap maintains insertion order for potential cache eviction.
  * @property loadedPins Map of pin IDs to GeoPinWithLocation objects, representing map pins that
- *   have been loaded and cached for offline viewing.
+ *   have been loaded and cached for offline viewing. LinkedHashMap maintains insertion order for
+ *   potential cache eviction.
  */
 data class OfflineMode(
-    val accounts: Map<String, Pair<Account, Map<String, Any>>> = emptyMap(),
-    val discussions: Map<String, Pair<Discussion, List<Message>>> = emptyMap(),
-    val posts: Map<String, Pair<Post, Boolean>> = emptyMap(),
-    val shopsToAdd: Map<String, Pair<Shop, Map<String, Any>>> = emptyMap(),
-    val spaceRentersToAdd: Map<String, Pair<SpaceRenter, Map<String, Any>>> = emptyMap(),
-    val loadedPins: Map<String, GeoPinWithLocation> = emptyMap(),
+    val accounts: LinkedHashMap<String, Pair<Account, Map<String, Any>>> = LinkedHashMap(),
+    val discussions: LinkedHashMap<String, Pair<Discussion, List<Message>>> = LinkedHashMap(),
+    val posts: LinkedHashMap<String, Pair<Post, Boolean>> = LinkedHashMap(),
+    val shopsToAdd: LinkedHashMap<String, Pair<Shop, Map<String, Any>>> = LinkedHashMap(),
+    val spaceRentersToAdd: LinkedHashMap<String, Pair<SpaceRenter, Map<String, Any>>> =
+        LinkedHashMap(),
+    val loadedPins: LinkedHashMap<String, GeoPinWithLocation> = LinkedHashMap(),
 )

--- a/app/src/main/java/com/github/meeplemeet/model/offline/OfflineMode.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/offline/OfflineMode.kt
@@ -1,0 +1,38 @@
+package com.github.meeplemeet.model.offline
+
+import com.github.meeplemeet.model.account.Account
+import com.github.meeplemeet.model.discussions.Discussion
+import com.github.meeplemeet.model.discussions.Message
+import com.github.meeplemeet.model.map.GeoPinWithLocation
+import com.github.meeplemeet.model.posts.Post
+import com.github.meeplemeet.model.shops.Shop
+import com.github.meeplemeet.model.space_renter.SpaceRenter
+
+/**
+ * Represents the offline mode state for the application, storing all data that needs to be
+ * synchronized when the device goes back online.
+ *
+ * This data class holds pending changes made while offline, including new or modified entities that
+ * should be uploaded to the backend once connectivity is restored.
+ *
+ * @property accounts Map of account IDs to pairs of Account objects and their associated metadata.
+ *   The metadata map contains additional information needed for synchronization.
+ * @property discussions Map of discussion IDs to pairs of Discussion objects and their associated
+ *   pending messages.
+ * @property posts Map of post IDs to Post objects representing posts created (true) or modified
+ *   offline (false).
+ * @property shopsToAdd Map of shop IDs to pairs of Shop objects and their associated metadata,
+ *   representing shops to be created or updated when online.
+ * @property spaceRentersToAdd Map of space renter IDs to pairs of SpaceRenter objects and their
+ *   associated metadata, representing space renters to be created or updated when online.
+ * @property loadedPins Map of pin IDs to GeoPinWithLocation objects, representing map pins that
+ *   have been loaded and cached for offline viewing.
+ */
+data class OfflineMode(
+    val accounts: Map<String, Pair<Account, Map<String, Any>>>,
+    val discussions: Map<String, Pair<Discussion, List<Message>>>,
+    val posts: Map<String, Pair<Post, Boolean>>,
+    val shopsToAdd: Map<String, Pair<Shop, Map<String, Any>>>,
+    val spaceRentersToAdd: Map<String, Pair<SpaceRenter, Map<String, Any>>>,
+    val loadedPins: Map<String, GeoPinWithLocation>
+)

--- a/app/src/main/java/com/github/meeplemeet/model/offline/OfflineMode.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/offline/OfflineMode.kt
@@ -1,4 +1,5 @@
 package com.github.meeplemeet.model.offline
+// AI was used on this fille
 
 import com.github.meeplemeet.model.account.Account
 import com.github.meeplemeet.model.discussions.Discussion

--- a/app/src/main/java/com/github/meeplemeet/model/offline/OfflineModeManager.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/offline/OfflineModeManager.kt
@@ -1,12 +1,5 @@
 package com.github.meeplemeet.model.offline
 
-import com.github.meeplemeet.model.account.Account
-import com.github.meeplemeet.model.discussions.Discussion
-import com.github.meeplemeet.model.discussions.Message
-import com.github.meeplemeet.model.map.GeoPinWithLocation
-import com.github.meeplemeet.model.posts.Post
-import com.github.meeplemeet.model.shops.Shop
-import com.github.meeplemeet.model.space_renter.SpaceRenter
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -48,81 +41,11 @@ object OfflineModeManager {
   val offlineModeFlow: StateFlow<OfflineMode> = _offlineModeFlow.asStateFlow()
 
   /**
-   * Replaces the entire offline mode state with a new instance.
-   *
-   * @param newOfflineMode The new offline mode data to set
-   */
-  fun updateOfflineMode(newOfflineMode: OfflineMode) {
-    _offlineModeFlow.value = newOfflineMode
-  }
-
-  /**
-   * Updates only the accounts map in the offline mode state.
-   *
-   * @param accounts The new accounts map to set
-   */
-  fun updateAccounts(accounts: Map<String, Pair<Account, Map<String, Any>>>) {
-    _offlineModeFlow.value = _offlineModeFlow.value.copy(accounts = accounts)
-  }
-
-  /**
-   * Updates only the discussions map in the offline mode state.
-   *
-   * @param discussions The new discussions map to set
-   */
-  fun updateDiscussions(discussions: Map<String, Pair<Discussion, List<Message>>>) {
-    _offlineModeFlow.value = _offlineModeFlow.value.copy(discussions = discussions)
-  }
-
-  /**
-   * Updates only the posts map in the offline mode state.
-   *
-   * @param posts The new posts map to set (Post paired with Boolean flag)
-   */
-  fun updatePosts(posts: Map<String, Pair<Post, Boolean>>) {
-    _offlineModeFlow.value = _offlineModeFlow.value.copy(posts = posts)
-  }
-
-  /**
-   * Updates only the shops to add map in the offline mode state.
-   *
-   * @param shops The new shops map to set
-   */
-  fun updateShopsToAdd(shops: Map<String, Pair<Shop, Map<String, Any>>>) {
-    _offlineModeFlow.value = _offlineModeFlow.value.copy(shopsToAdd = shops)
-  }
-
-  /**
-   * Updates only the space renters to add map in the offline mode state.
-   *
-   * @param spaceRenters The new space renters map to set
-   */
-  fun updateSpaceRentersToAdd(spaceRenters: Map<String, Pair<SpaceRenter, Map<String, Any>>>) {
-    _offlineModeFlow.value = _offlineModeFlow.value.copy(spaceRentersToAdd = spaceRenters)
-  }
-
-  /**
-   * Updates only the loaded pins map in the offline mode state.
-   *
-   * @param pins The new pins map to set
-   */
-  fun updateLoadedPins(pins: Map<String, GeoPinWithLocation>) {
-    _offlineModeFlow.value = _offlineModeFlow.value.copy(loadedPins = pins)
-  }
-
-  /**
    * Clears all offline mode data by resetting to empty maps.
    *
    * This is useful when exiting offline mode or when the user logs out.
    */
   fun clearOfflineMode() {
-    _offlineModeFlow.value =
-        OfflineMode(
-            accounts = emptyMap(),
-            discussions = emptyMap(),
-            posts = emptyMap(),
-            shopsToAdd = emptyMap(),
-            spaceRentersToAdd = emptyMap(),
-            loadedPins = emptyMap())
+    _offlineModeFlow.value = OfflineMode()
   }
 }

--- a/app/src/main/java/com/github/meeplemeet/model/offline/OfflineModeManager.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/offline/OfflineModeManager.kt
@@ -1,5 +1,10 @@
 package com.github.meeplemeet.model.offline
 
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -61,6 +66,56 @@ object OfflineModeManager {
    * [kotlinx.coroutines.flow.collect] in coroutines to observe changes.
    */
   val offlineModeFlow: StateFlow<OfflineMode> = _offlineModeFlow.asStateFlow()
+
+  /**
+   * Internal mutable state flow tracking the device's online connectivity status. Defaults to false
+   * (offline) until network connectivity is verified.
+   */
+  private val _hasInternetConnection = MutableStateFlow(false)
+
+  /** StateFlow indicating whether the device currently has a valid internet connection. */
+  val hasInternetConnection: StateFlow<Boolean> = _hasInternetConnection
+
+  /**
+   * Starts monitoring network connectivity changes.
+   *
+   * This function registers a network callback that monitors the device's internet connectivity
+   * status and updates the [hasInternetConnection] StateFlow accordingly. The callback:
+   * - Checks for internet capability when a network becomes available
+   * - Verifies that the network connection is validated (has actual internet access)
+   * - Updates the online state to false when the network is lost
+   *
+   * This should typically be called once during application initialization (e.g., in MainActivity
+   * onCreate or Application.onCreate).
+   *
+   * @param context Android context used to access the ConnectivityManager system service
+   */
+  fun start(context: Context) {
+    val cm = context.getSystemService(ConnectivityManager::class.java)
+
+    val request =
+        NetworkRequest.Builder().addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET).build()
+
+    cm.registerNetworkCallback(
+        request,
+        object : ConnectivityManager.NetworkCallback() {
+
+          override fun onAvailable(network: Network) {
+            val caps = cm.getNetworkCapabilities(network)
+            val valid = caps?.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED) == true
+            _hasInternetConnection.value = valid
+          }
+
+          override fun onCapabilitiesChanged(network: Network, capabilities: NetworkCapabilities) {
+            val valid = capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+            _hasInternetConnection.value = valid
+          }
+
+          override fun onLost(network: Network) {
+            _hasInternetConnection.value = false
+          }
+        })
+  }
 
   /**
    * Clears all offline mode data by resetting to empty maps.

--- a/app/src/main/java/com/github/meeplemeet/model/offline/OfflineModeManager.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/offline/OfflineModeManager.kt
@@ -5,6 +5,28 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 /**
+ * Caps the size of a LinkedHashMap by removing the oldest entries until the size is at or below the
+ * maximum.
+ *
+ * This function enforces a maximum size constraint on a LinkedHashMap by removing entries in
+ * insertion order (oldest first) until the map size is within the specified limit. LinkedHashMap
+ * maintains insertion order, so the first entries are the oldest.
+ *
+ * @param T The type of values stored in the map
+ * @param map The LinkedHashMap to cap
+ * @param max The maximum number of entries to retain
+ * @return A new Map containing the remaining entries after capping
+ */
+private fun <T> cap(map: LinkedHashMap<String, T>, max: Int): LinkedHashMap<String, T> {
+  while (map.size > max) {
+    val oldestKey = map.entries.first().key
+    map.remove(oldestKey)
+  }
+
+  return map
+}
+
+/**
  * Singleton manager for offline mode state across the application.
  *
  * This object provides a centralized, reactive way to manage offline data including accounts,

--- a/app/src/main/java/com/github/meeplemeet/model/offline/OfflineModeManager.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/offline/OfflineModeManager.kt
@@ -5,9 +5,15 @@ import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
+import com.github.meeplemeet.RepositoryProvider
+import com.github.meeplemeet.model.account.Account
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import okhttp3.internal.toImmutableMap
 
 /**
  * Caps the size of a LinkedHashMap by removing the least recently used entries until the size is at
@@ -29,15 +35,19 @@ import kotlinx.coroutines.flow.asStateFlow
  * @param T The type of values stored in the map
  * @param map The LinkedHashMap to cap (modified in place, must have accessOrder=true)
  * @param max The maximum number of entries to retain
- * @return A new Map containing the remaining entries after capping
+ * @return Pair of (the modified map, list of removed values for cleanup)
  */
-private fun <T> cap(map: LinkedHashMap<String, T>, max: Int): LinkedHashMap<String, T> {
+private fun <T> cap(
+    map: LinkedHashMap<String, T>,
+    max: Int
+): Pair<LinkedHashMap<String, T>, List<T>> {
+  val removed = mutableListOf<T?>()
   while (map.size > max) {
     val oldestKey = map.entries.first().key
-    map.remove(oldestKey)
+    removed.add(map.remove(oldestKey))
   }
 
-  return map
+  return Pair(map, removed.filterNotNull().toList())
 }
 
 /**
@@ -84,6 +94,8 @@ object OfflineModeManager {
 
   /** StateFlow indicating whether the device currently has a valid internet connection. */
   val hasInternetConnection: StateFlow<Boolean> = _hasInternetConnection
+
+  var dispatcher = Dispatchers.IO
 
   /**
    * Starts monitoring network connectivity changes.
@@ -133,5 +145,183 @@ object OfflineModeManager {
    */
   fun clearOfflineMode() {
     _offlineModeFlow.value = OfflineMode()
+  }
+
+  /**
+   * Retrieves an account by UID, first checking the offline cache, then fetching from repository if
+   * needed.
+   *
+   * This function implements a two-tier loading strategy:
+   * 1. **Cache hit**: Returns immediately if account exists in offline cache
+   * 2. **Cache miss**: Fetches from repository, caches the result, and downloads profile picture
+   *
+   * ## Caching Behavior
+   * - When fetching from repository, the account is added to the offline cache
+   * - Profile picture is downloaded asynchronously and cached locally
+   * - If cache exceeds [MAX_CACHED_ACCOUNTS], oldest accounts are evicted
+   * - Evicted accounts have their profile pictures deleted from local storage
+   *
+   * ## Thread Safety
+   * This function is suspend and should be called from a coroutine. Updates to the offline mode
+   * state flow are thread-safe.
+   *
+   * ## Error Handling
+   * - If repository fetch fails, null is returned via callback
+   * - Profile picture download errors are silently caught (non-critical)
+   *
+   * @param uid The unique identifier of the account to retrieve
+   * @param context Android context for accessing local storage
+   * @param onResult Callback invoked with the Account if found, or null if not found or an error
+   *   occurs
+   */
+  suspend fun loadAccount(uid: String, context: Context, onResult: (Account?) -> Unit) {
+    val state = _offlineModeFlow.value.accounts
+    val cached = state[uid]?.first
+
+    if (cached != null) {
+      onResult(cached)
+      return
+    }
+
+    val fetched = RepositoryProvider.accounts.getAccountSafe(uid, false)
+    if (fetched != null) {
+      // Create new map to avoid mutating StateFlow's internal state
+      val newState = LinkedHashMap(state).apply { this[uid] = fetched to emptyMap() }
+      val (capped, removed) = cap(newState, MAX_CACHED_ACCOUNTS)
+      _offlineModeFlow.value = _offlineModeFlow.value.copy(accounts = capped)
+      runCatching {
+        RepositoryProvider.images.loadAccountProfilePicture(uid, context)
+        removed.forEach { (account, _) ->
+          RepositoryProvider.images.deleteLocalAccountProfilePicture(account.uid, context)
+        }
+      }
+    }
+
+    onResult(fetched)
+  }
+
+  /**
+   * Retrieves multiple accounts by their UIDs, optimizing by fetching only missing accounts from
+   * the repository.
+   *
+   * This function efficiently retrieves multiple accounts by:
+   * 1. Checking the offline cache for each UID
+   * 2. Identifying which accounts are missing from cache
+   * 3. Fetching only the missing accounts from the repository in a batch
+   * 4. Merging cached and fetched results in the original order
+   * 5. Asynchronously downloading profile pictures for all accounts
+   *
+   * ## Performance Optimization
+   * - Batch fetches missing accounts in a single repository call
+   * - Profile pictures are downloaded in parallel in the background
+   * - Only missing accounts are fetched from repository (cache-first strategy)
+   *
+   * ## Caching Behavior
+   * - Successfully fetched accounts are added to the offline cache
+   * - If cache exceeds [MAX_CACHED_ACCOUNTS], oldest accounts are evicted
+   * - Evicted accounts have their profile pictures deleted asynchronously
+   *
+   * ## Order Preservation
+   * The result list always has the same size and order as the input UIDs list. If any fetch fails,
+   * the corresponding position will contain null.
+   *
+   * ## Thread Safety
+   * - State updates are thread-safe via StateFlow
+   * - Profile picture downloads run on Dispatchers.IO in the provided scope
+   * - Main callback is invoked on the calling coroutine's context
+   *
+   * ## Error Handling
+   * - Failed fetches result in null at that position
+   * - Profile picture download errors are silently caught (non-critical)
+   *
+   * @param uids List of unique identifiers of the accounts to retrieve
+   * @param context Android context for accessing local storage
+   * @param scope CoroutineScope for launching background image operations
+   * @param onResult Callback invoked with a list of Accounts (or null for missing/failed accounts)
+   *   in the same order as the input UIDs
+   */
+  suspend fun loadAccounts(
+      uids: List<String>,
+      context: Context,
+      scope: CoroutineScope,
+      onResult: (List<Account?>) -> Unit
+  ) {
+    val state = _offlineModeFlow.value.accounts
+
+    // Step 1: Check cache and identify missing accounts
+    val cached = uids.map { uid -> state[uid]?.first }
+    val missingIndices = cached.withIndex().filter { it.value == null }.map { it.index }
+    val missingUids = missingIndices.map { uids[it] }
+
+    // Step 2: Batch fetch missing accounts from repository
+    val fetched: List<Account?> =
+        if (missingUids.isEmpty()) emptyList()
+        else RepositoryProvider.accounts.getAccountsSafe(missingUids, false)
+
+    // Step 3: Merge cached and fetched results in original order
+    val merged = MutableList<Account?>(uids.size) { null }
+    for ((i, account) in cached.withIndex()) merged[i] = account
+    for ((offset, value) in missingIndices.withIndex()) {
+      merged[value] = fetched.getOrNull(offset)
+    }
+
+    // Step 4: Update cache with ONLY newly fetched accounts and apply capping
+    // Create new map to avoid mutating StateFlow's internal state
+    val newState = LinkedHashMap(state)
+    for ((offset, idx) in missingIndices.withIndex()) {
+      val acc = fetched.getOrNull(offset)
+      if (acc != null) newState[uids[idx]] = acc to emptyMap()
+    }
+    val (capped, removed) = cap(newState, MAX_CACHED_ACCOUNTS)
+    _offlineModeFlow.value = _offlineModeFlow.value.copy(accounts = capped)
+
+    // Step 5: Asynchronously download profile pictures for all accounts
+    scope.launch(dispatcher) {
+      merged.forEach { account ->
+        if (account != null)
+            runCatching {
+              RepositoryProvider.images.loadAccountProfilePicture(account.uid, context)
+            }
+      }
+
+      // Clean up profile pictures for evicted accounts
+      removed.forEach { (account, _) ->
+        runCatching {
+          RepositoryProvider.images.deleteLocalAccountProfilePicture(account.uid, context)
+        }
+      }
+    }
+
+    onResult(merged)
+  }
+
+  /**
+   * Records a change to an account property in the offline cache.
+   *
+   * This function tracks pending changes to account properties that will be synchronized later. If
+   * the account is not already in the cache, it is added. Changes are accumulated in a map keyed by
+   * property name.
+   *
+   * ## Use Cases
+   * - Recording user profile edits while offline
+   * - Tracking pending updates before synchronization
+   * - Maintaining change history for conflict resolution
+   *
+   * ## Thread Safety
+   * Updates to the offline mode state flow are thread-safe.
+   *
+   * @param account The account being modified
+   * @param property The name of the property being changed (e.g., "username", "bio")
+   * @param newValue The new value for the property
+   */
+  fun setAccountChange(account: Account, property: String, newValue: Any) {
+    val state = _offlineModeFlow.value.accounts
+    val (existingAccount, existingChanges) = state[account.uid] ?: return
+    val updatedChanges =
+        existingChanges.toMutableMap().apply { put(property, newValue) }.toImmutableMap()
+    // Create new map to avoid mutating StateFlow's internal state
+    val newState = LinkedHashMap(state)
+    newState[account.uid] = existingAccount to updatedChanges
+    _offlineModeFlow.value = _offlineModeFlow.value.copy(accounts = newState)
   }
 }

--- a/app/src/main/java/com/github/meeplemeet/model/offline/OfflineModeManager.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/offline/OfflineModeManager.kt
@@ -10,15 +10,24 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 /**
- * Caps the size of a LinkedHashMap by removing the oldest entries until the size is at or below the
- * maximum.
+ * Caps the size of a LinkedHashMap by removing the least recently used entries until the size is at
+ * or below the maximum.
  *
- * This function enforces a maximum size constraint on a LinkedHashMap by removing entries in
- * insertion order (oldest first) until the map size is within the specified limit. LinkedHashMap
- * maintains insertion order, so the first entries are the oldest.
+ * This function enforces a maximum size constraint on a LinkedHashMap by removing entries in access
+ * order (least recently used first) until the map size is within the specified limit. LinkedHashMap
+ * with accessOrder=true maintains LRU ordering, so the first entries are the least recently
+ * accessed.
+ *
+ * ## Eviction Strategy
+ * Uses true LRU (Least Recently Used) behavior: entries that haven't been accessed recently are
+ * evicted first. This is optimal for caching scenarios where recently accessed items are more
+ * likely to be accessed again.
+ *
+ * ## Thread Safety
+ * This function modifies the input map in place. Callers must ensure thread-safe access.
  *
  * @param T The type of values stored in the map
- * @param map The LinkedHashMap to cap
+ * @param map The LinkedHashMap to cap (modified in place, must have accessOrder=true)
  * @param max The maximum number of entries to retain
  * @return A new Map containing the remaining entries after capping
  */

--- a/app/src/main/java/com/github/meeplemeet/model/offline/OfflineModeManager.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/offline/OfflineModeManager.kt
@@ -1,0 +1,128 @@
+package com.github.meeplemeet.model.offline
+
+import com.github.meeplemeet.model.account.Account
+import com.github.meeplemeet.model.discussions.Discussion
+import com.github.meeplemeet.model.discussions.Message
+import com.github.meeplemeet.model.map.GeoPinWithLocation
+import com.github.meeplemeet.model.posts.Post
+import com.github.meeplemeet.model.shops.Shop
+import com.github.meeplemeet.model.space_renter.SpaceRenter
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Singleton manager for offline mode state across the application.
+ *
+ * This object provides a centralized, reactive way to manage offline data including accounts,
+ * discussions, posts, shops, space renters, and map pins. Uses Kotlin StateFlow to enable reactive
+ * updates across all observers.
+ *
+ * Example usage in Composable:
+ * ```
+ * @Composable
+ * fun MyScreen() {
+ *     val offlineMode by OfflineModeManager.offlineModeFlow.collectAsState()
+ *     Text("Accounts: ${offlineMode.accounts.size}")
+ * }
+ * ```
+ *
+ * Example usage in ViewModels:
+ * ```
+ * viewModelScope.launch {
+ *     OfflineModeManager.offlineModeFlow.collect { offlineMode ->
+ *         // React to changes
+ *     }
+ * }
+ * ```
+ */
+object OfflineModeManager {
+  private val _offlineModeFlow = MutableStateFlow(OfflineMode())
+
+  /**
+   * StateFlow of the current offline mode data. Observers will be notified of any changes.
+   *
+   * Use [androidx.compose.runtime.collectAsState] in Composable or
+   * [kotlinx.coroutines.flow.collect] in coroutines to observe changes.
+   */
+  val offlineModeFlow: StateFlow<OfflineMode> = _offlineModeFlow.asStateFlow()
+
+  /**
+   * Replaces the entire offline mode state with a new instance.
+   *
+   * @param newOfflineMode The new offline mode data to set
+   */
+  fun updateOfflineMode(newOfflineMode: OfflineMode) {
+    _offlineModeFlow.value = newOfflineMode
+  }
+
+  /**
+   * Updates only the accounts map in the offline mode state.
+   *
+   * @param accounts The new accounts map to set
+   */
+  fun updateAccounts(accounts: Map<String, Pair<Account, Map<String, Any>>>) {
+    _offlineModeFlow.value = _offlineModeFlow.value.copy(accounts = accounts)
+  }
+
+  /**
+   * Updates only the discussions map in the offline mode state.
+   *
+   * @param discussions The new discussions map to set
+   */
+  fun updateDiscussions(discussions: Map<String, Pair<Discussion, List<Message>>>) {
+    _offlineModeFlow.value = _offlineModeFlow.value.copy(discussions = discussions)
+  }
+
+  /**
+   * Updates only the posts map in the offline mode state.
+   *
+   * @param posts The new posts map to set (Post paired with Boolean flag)
+   */
+  fun updatePosts(posts: Map<String, Pair<Post, Boolean>>) {
+    _offlineModeFlow.value = _offlineModeFlow.value.copy(posts = posts)
+  }
+
+  /**
+   * Updates only the shops to add map in the offline mode state.
+   *
+   * @param shops The new shops map to set
+   */
+  fun updateShopsToAdd(shops: Map<String, Pair<Shop, Map<String, Any>>>) {
+    _offlineModeFlow.value = _offlineModeFlow.value.copy(shopsToAdd = shops)
+  }
+
+  /**
+   * Updates only the space renters to add map in the offline mode state.
+   *
+   * @param spaceRenters The new space renters map to set
+   */
+  fun updateSpaceRentersToAdd(spaceRenters: Map<String, Pair<SpaceRenter, Map<String, Any>>>) {
+    _offlineModeFlow.value = _offlineModeFlow.value.copy(spaceRentersToAdd = spaceRenters)
+  }
+
+  /**
+   * Updates only the loaded pins map in the offline mode state.
+   *
+   * @param pins The new pins map to set
+   */
+  fun updateLoadedPins(pins: Map<String, GeoPinWithLocation>) {
+    _offlineModeFlow.value = _offlineModeFlow.value.copy(loadedPins = pins)
+  }
+
+  /**
+   * Clears all offline mode data by resetting to empty maps.
+   *
+   * This is useful when exiting offline mode or when the user logs out.
+   */
+  fun clearOfflineMode() {
+    _offlineModeFlow.value =
+        OfflineMode(
+            accounts = emptyMap(),
+            discussions = emptyMap(),
+            posts = emptyMap(),
+            shopsToAdd = emptyMap(),
+            spaceRentersToAdd = emptyMap(),
+            loadedPins = emptyMap())
+  }
+}

--- a/app/src/main/java/com/github/meeplemeet/model/offline/OfflineModeManager.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/offline/OfflineModeManager.kt
@@ -1,4 +1,5 @@
 package com.github.meeplemeet.model.offline
+// AI was used on this fille
 
 import android.content.Context
 import android.net.ConnectivityManager
@@ -101,6 +102,16 @@ object OfflineModeManager {
   val hasInternetConnection: StateFlow<Boolean> = _hasInternetConnection
 
   var dispatcher = Dispatchers.IO
+
+  /**
+   * Sets the internet connection state. For testing purposes only. In production, connection state
+   * is managed by the network callback in start().
+   *
+   * @param connected true if connected, false if offline
+   */
+  fun setInternetConnection(connected: Boolean) {
+    _hasInternetConnection.value = connected
+  }
 
   /**
    * Starts monitoring network connectivity changes.

--- a/app/src/main/java/com/github/meeplemeet/model/posts/PostOverviewViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/posts/PostOverviewViewModel.kt
@@ -6,11 +6,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.github.meeplemeet.RepositoryProvider
 import com.github.meeplemeet.model.account.AccountViewModel
+import com.github.meeplemeet.model.offline.OfflineModeManager
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.launch
 
 /**
  * ViewModel for managing the overview/feed of posts.
@@ -26,65 +24,14 @@ class PostOverviewViewModel(private val repository: PostRepository = RepositoryP
   override val scope: CoroutineScope
     get() = this.viewModelScope
 
-  private val _posts = MutableStateFlow<List<Post>>(emptyList())
-
-  /**
-   * StateFlow containing the current list of posts.
-   *
-   * Posts are provided without their comments for efficient preview display. The list is sorted by
-   * timestamp with newest posts first. UI components can collect this flow to observe updates.
-   */
-  val posts: StateFlow<List<Post>> = _posts
-
-  private val _errorMsg = MutableStateFlow("")
-  val errorMessage: StateFlow<String> = _errorMsg
+  val posts: StateFlow<List<Post>>
+  val errorMessage: StateFlow<String>
 
   init {
-    startListening()
-  }
-
-  /**
-   * Starts listening to real-time updates of all posts from the repository.
-   *
-   * This function launches a coroutine in the viewModelScope to collect posts from the repository's
-   * Flow. Posts are retrieved without their comments for efficient loading in overview/feed
-   * screens. The listener remains active for the lifetime of the ViewModel, automatically updating
-   * the UI when posts are added, modified, or removed in Firestore.
-   */
-  private fun startListening() {
-    viewModelScope.launch {
-      repository
-          .listenPosts()
-          .catch { e ->
-            _posts.value = emptyList()
-            _errorMsg.value = "An error occurred while listening to posts: ${e.message}"
-          }
-          .collect { fetchedPosts ->
-            _posts.value = fetchedPosts
-            _errorMsg.value = ""
-          }
-    }
-  }
-
-  /**
-   * Fetches all posts from the repository and updates the [posts] StateFlow.
-   *
-   * This function launches a coroutine in the viewModelScope to fetch posts asynchronously. Posts
-   * are retrieved without their comments for efficient loading in overview/feed screens.
-   *
-   * @deprecated This method is no longer needed as the ViewModel automatically listens to posts on
-   *   initialization. Kept for backward compatibility.
-   */
-  fun getPosts() {
-    viewModelScope.launch {
-      try {
-        val fetchedPosts = repository.getPosts()
-        _posts.value = fetchedPosts
-        _errorMsg.value = ""
-      } catch (_: Exception) {
-        _posts.value = emptyList()
-        _errorMsg.value = "An error occurred while getting all posts."
-      }
-    }
+    // Delegate all flow logic to OfflineModeManager
+    val (postsFlow, errorFlow) =
+        OfflineModeManager.createPostsOverviewFlow(viewModelScope, repository)
+    posts = postsFlow
+    errorMessage = errorFlow
   }
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/account/CreateAccountScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/CreateAccountScreen.kt
@@ -336,6 +336,7 @@ fun CreateAccountScreen(
                       Modifier.fillMaxWidth().padding(bottom = CreateAccountScreenUi.mediumPadding))
 
               RoleCheckBox(
+                  online = true,
                   isChecked = isShopChecked,
                   onCheckedChange = { checked: Boolean -> isShopChecked = checked },
                   label = "Sell items",
@@ -343,6 +344,7 @@ fun CreateAccountScreen(
                   testTag = CreateAccountTestTags.CHECKBOX_OWNER)
 
               RoleCheckBox(
+                  online = true,
                   isChecked = isSpaceRented,
                   onCheckedChange = { checked: Boolean -> isSpaceRented = checked },
                   label = "Rent out spaces",
@@ -363,6 +365,7 @@ fun CreateAccountScreen(
  */
 @Composable
 fun RoleCheckBox(
+    online: Boolean,
     isChecked: Boolean,
     onCheckedChange: (Boolean) -> Unit,
     label: String,
@@ -371,8 +374,9 @@ fun RoleCheckBox(
 ) {
   Row(
       verticalAlignment = Alignment.CenterVertically,
-      modifier = Modifier.fillMaxWidth().clickable { onCheckedChange(!isChecked) }) {
+      modifier = Modifier.fillMaxWidth().clickable { if (online) onCheckedChange(!isChecked) }) {
         Checkbox(
+            enabled = online,
             checked = isChecked,
             modifier = Modifier.testTag(testTag),
             onCheckedChange = onCheckedChange,

--- a/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
@@ -70,6 +70,7 @@ import com.github.meeplemeet.model.account.Account
 import com.github.meeplemeet.model.account.NotificationSettings
 import com.github.meeplemeet.model.account.ProfileScreenViewModel
 import com.github.meeplemeet.model.images.ImageFileUtils
+import com.github.meeplemeet.model.offline.OfflineModeManager
 import com.github.meeplemeet.ui.FocusableInputField
 import com.github.meeplemeet.ui.theme.AppColors
 import com.github.meeplemeet.ui.theme.Dimensions
@@ -270,13 +271,21 @@ object MainTabUi {
 fun MainTab(
     viewModel: ProfileScreenViewModel = viewModel(),
     account: Account,
+    online: Boolean,
     onFriendsClick: () -> Unit,
     onNotificationClick: () -> Unit,
     onSignOutOrDel: () -> Unit,
     onDelete: () -> Unit
 ) {
   var pref by remember { mutableStateOf(NotificationSettings.EVERYONE) }
+  val cache by OfflineModeManager.offlineModeFlow.collectAsState()
   val focusManager = LocalFocusManager.current
+
+  LaunchedEffect(online) {
+    if (online && cache.accounts[account.uid] != null)
+        viewModel.updateAccount(account, cache.accounts[account.uid]!!.second)
+  }
+
   Column(
       modifier =
           Modifier.fillMaxSize()
@@ -290,20 +299,26 @@ fun MainTab(
         PublicInfo(
             account = account,
             viewModel = viewModel,
+            online = online,
             onFriendsClick = onFriendsClick,
             onNotificationClick = onNotificationClick,
             onSignOut = onSignOutOrDel)
 
-        PrivateInfo(account = account, viewModel = viewModel)
+        PrivateInfo(account = account, viewModel = viewModel, online)
 
         NotificationSettingsSection(
             preference = pref,
             onPreferenceChange = {
               pref = it
-              viewModel.setAccountNotificationSettings(account, it)
+
+              if (online) viewModel.setAccountNotificationSettings(account, it)
+              else
+                  OfflineModeManager.setAccountChange(
+                      account, Account::notificationSettings.name, it)
             })
 
         Button(
+            enabled = online,
             onClick = { showDelDialog = true },
             shape = RoundedCornerShape(Dimensions.CornerRadius.medium),
             elevation = ButtonDefaults.buttonElevation(Dimensions.Elevation.medium),
@@ -346,6 +361,7 @@ fun MainTab(
 fun PublicInfo(
     account: Account,
     viewModel: ProfileScreenViewModel,
+    online: Boolean,
     onFriendsClick: () -> Unit,
     onNotificationClick: () -> Unit,
     onSignOut: () -> Unit
@@ -363,7 +379,7 @@ fun PublicInfo(
               Row(
                   modifier = Modifier.fillMaxWidth().padding(start = Dimensions.Padding.xLarge),
                   verticalAlignment = Alignment.CenterVertically) {
-                    DisplayAvatar(viewModel, account)
+                    DisplayAvatar(viewModel, account, online)
 
                     Spacer(modifier = Modifier.weight(1f))
 
@@ -375,7 +391,7 @@ fun PublicInfo(
                         onSignOut = onSignOut)
                   }
 
-              PublicInfoInputs(account = account, viewModel = viewModel)
+              PublicInfoInputs(account = account, viewModel = viewModel, online = online)
             }
       }
 }
@@ -491,7 +507,7 @@ fun PublicInfoActions(
  * @param viewModel viewmodel used by this screen
  */
 @Composable
-fun PublicInfoInputs(account: Account, viewModel: ProfileScreenViewModel) {
+fun PublicInfoInputs(account: Account, viewModel: ProfileScreenViewModel, online: Boolean) {
   var name by remember { mutableStateOf(account.name) }
   var desc by remember { mutableStateOf(account.description ?: "") }
 
@@ -510,11 +526,12 @@ fun PublicInfoInputs(account: Account, viewModel: ProfileScreenViewModel) {
             isError = nameError,
             onFocusChanged = { focused ->
               if (!focused && !nameError) {
-                viewModel.setAccountName(account, name)
+                if (online) viewModel.setAccountName(account, name)
+                else OfflineModeManager.setAccountChange(account, Account::name.name, name)
               }
             })
 
-        if (nameError) {
+        RenderIf(nameError) {
           Text(
               text = MainTabUi.PublicInfo.NAME_INPUT_FIELD_ERR,
               color = AppColors.negative,
@@ -535,18 +552,15 @@ fun PublicInfoInputs(account: Account, viewModel: ProfileScreenViewModel) {
         val errorHandle = showErrors && errorMsg.isNotBlank() && handle != account.handle
 
         FocusableInputField(
+            enabled = online,
             value = handle,
             modifier =
                 Modifier.testTag(PublicInfoTestTags.INPUT_HANDLE)
                     .padding(bottom = Dimensions.Padding.medium),
             onValueChange = {
               handle = it
-              if (it.isNotBlank()) {
-                showErrors = true
-                viewModel.checkHandleAvailable(it)
-              } else {
-                showErrors = false
-              }
+              showErrors = it.isNotBlank()
+              if (showErrors) viewModel.checkHandleAvailable(it)
             },
             label = { Text(text = MainTabUi.PublicInfo.HANDLE_INPUT_FIELD) },
             leadingIcon = {
@@ -562,7 +576,7 @@ fun PublicInfoInputs(account: Account, viewModel: ProfileScreenViewModel) {
               if (!focused && !errorHandle) viewModel.setAccountHandle(account, newHandle = handle)
             })
 
-        if (errorHandle) {
+        RenderIf(errorHandle) {
           Text(
               text = errorMsg,
               color = AppColors.negative,
@@ -586,8 +600,10 @@ fun PublicInfoInputs(account: Account, viewModel: ProfileScreenViewModel) {
             value = desc,
             onValueChange = { desc = it },
             singleLine = false,
-            onFocusChanged = { focused ->
-              if (!focused) viewModel.setAccountDescription(account, newDescription = desc)
+            onFocusChanged = {
+              if (it) return@FocusableInputField
+              if (online) viewModel.setAccountDescription(account, newDescription = desc)
+              else OfflineModeManager.setAccountChange(account, Account::description.name, desc)
             })
 
         Spacer(modifier = Modifier.height(Dimensions.Spacing.medium))
@@ -601,28 +617,21 @@ fun PublicInfoInputs(account: Account, viewModel: ProfileScreenViewModel) {
  * @param account Current user
  */
 @Composable
-fun DisplayAvatar(viewModel: ProfileScreenViewModel, account: Account) {
+fun DisplayAvatar(viewModel: ProfileScreenViewModel, account: Account, online: Boolean) {
   val context = LocalContext.current
   val scope = rememberCoroutineScope()
   var showChooser by remember { mutableStateOf(false) }
-  var isSending by remember { mutableStateOf(false) }
   var showPermissionDenied by remember { mutableStateOf(false) }
 
   // --- Upload function ---
-  val setPhoto: suspend (String) -> Unit = { path ->
-    isSending = true
-    try {
-
-      viewModel.setAccountPhoto(account, context, path)
-    } finally {
-      isSending = false
-    }
+  val setPhoto: suspend (String) -> Unit = {
+    runCatching { viewModel.setAccountPhoto(account, context, it) }
   }
 
   // --- Camera launcher ---
   val cameraLauncher =
       rememberLauncherForActivityResult(ActivityResultContracts.TakePicturePreview()) { bitmap ->
-        if (bitmap != null) {
+        bitmap?.let {
           scope.launch {
             val path = ImageFileUtils.saveBitmapToCache(context, bitmap)
             setPhoto(path)
@@ -643,7 +652,7 @@ fun DisplayAvatar(viewModel: ProfileScreenViewModel, account: Account) {
   // --- Gallery launcher ---
   val galleryLauncher =
       rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
-        if (uri != null) {
+        uri?.let {
           scope.launch {
             val path = ImageFileUtils.cacheUriToFile(context, uri)
             setPhoto(path)
@@ -655,7 +664,7 @@ fun DisplayAvatar(viewModel: ProfileScreenViewModel, account: Account) {
   Box(
       modifier =
           Modifier.size(MainTabUi.AVATAR_SIZE)
-              .clickable { showChooser = true }
+              .clickable { if (online) showChooser = true }
               .testTag(PublicInfoTestTags.AVATAR_CONTAINER),
       contentAlignment = Alignment.TopEnd) {
         if (account.photoUrl.isNullOrBlank()) {
@@ -695,7 +704,7 @@ fun DisplayAvatar(viewModel: ProfileScreenViewModel, account: Account) {
       }
 
   // --- Chooser dialog ---
-  if (showChooser) {
+  RenderIf(showChooser) {
     AvatarChooserDialog(
         onDismiss = { showChooser = false },
         onCamera = {
@@ -715,7 +724,7 @@ fun DisplayAvatar(viewModel: ProfileScreenViewModel, account: Account) {
   }
 
   // --- Permission denied ---
-  if (showPermissionDenied) {
+  RenderIf(showPermissionDenied) {
     AlertDialog(
         containerColor = AppColors.primary,
         modifier = Modifier.testTag(PublicInfoTestTags.CAMERA_PERMISSION_DIALOG),
@@ -811,7 +820,7 @@ fun AvatarChooserDialog(
  * @param viewModel viewmodel used by this screen
  */
 @Composable
-fun PrivateInfo(account: Account, viewModel: ProfileScreenViewModel) {
+fun PrivateInfo(account: Account, viewModel: ProfileScreenViewModel, online: Boolean) {
 
   val uiState by viewModel.uiState.collectAsState()
 
@@ -840,6 +849,7 @@ fun PrivateInfo(account: Account, viewModel: ProfileScreenViewModel) {
 
               // EMAIL SECTION
               EmailSection(
+                  online = online,
                   email = email,
                   isVerified = isVerified,
                   onEmailChange = { newEmail -> email = newEmail },
@@ -854,7 +864,7 @@ fun PrivateInfo(account: Account, viewModel: ProfileScreenViewModel) {
                   })
 
               // ROLES SECTION
-              RolesSection(account = account, viewModel = viewModel)
+              RolesSection(account = account, viewModel = viewModel, online = online)
               Spacer(modifier = Modifier.height(Dimensions.Spacing.medium))
             }
       }
@@ -871,6 +881,7 @@ fun PrivateInfo(account: Account, viewModel: ProfileScreenViewModel) {
  */
 @Composable
 fun EmailSection(
+    online: Boolean,
     email: String,
     isVerified: Boolean,
     onEmailChange: (String) -> Unit,
@@ -896,6 +907,7 @@ fun EmailSection(
               horizontalArrangement = Arrangement.SpaceBetween,
               verticalAlignment = Alignment.CenterVertically) {
                 FocusableInputField(
+                    enabled = online,
                     label = { Text(text = MainTabUi.PrivateInfo.EMAIL_INPUT_FIELD) },
                     value = email,
                     onValueChange = { new ->
@@ -908,6 +920,7 @@ fun EmailSection(
                     trailingIcon = {
                       if (!isVerified && !emailError) {
                         IconButton(
+                            enabled = online,
                             modifier =
                                 Modifier.padding(top = Dimensions.Padding.small)
                                     .testTag(PrivateInfoTestTags.EMAIL_SEND_BUTTON),
@@ -1018,7 +1031,7 @@ fun ToastHost(toast: ToastData?, duration: Long = 1500L, onToastFinished: () -> 
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun RolesSection(account: Account, viewModel: ProfileScreenViewModel) {
+fun RolesSection(account: Account, viewModel: ProfileScreenViewModel, online: Boolean) {
 
   var isShopChecked by remember { mutableStateOf(account.shopOwner) }
   var isSpaceRented by remember { mutableStateOf(account.spaceRenter) }
@@ -1042,6 +1055,7 @@ fun RolesSection(account: Account, viewModel: ProfileScreenViewModel) {
       }
 
   RoleCheckBox(
+      online = online,
       isChecked = isShopChecked,
       onCheckedChange = { checked ->
         if (!checked) {
@@ -1057,6 +1071,7 @@ fun RolesSection(account: Account, viewModel: ProfileScreenViewModel) {
       testTag = PrivateInfoTestTags.ROLE_SHOP_CHECKBOX)
 
   RoleCheckBox(
+      online = online,
       isChecked = isSpaceRented,
       onCheckedChange = { checked ->
         if (!checked) {
@@ -1126,7 +1141,7 @@ private fun RemoveCatalogDialog(
         RoleAction.SpaceOff -> MainTabUi.PrivateInfo.ROLE_ACTION_SPACE
       }
 
-  if (visible) {
+  RenderIf(visible) {
     AlertDialog(
         containerColor = AppColors.primary,
         modifier = Modifier.testTag(PrivateInfoTestTags.ROLE_DIALOG),
@@ -1253,7 +1268,7 @@ private fun NotificationOptionRow(
  */
 @Composable
 fun DeleteAccountDialog(show: Boolean, onCancel: () -> Unit, onConfirm: () -> Unit) {
-  if (show) {
+  RenderIf(show) {
     AlertDialog(
         containerColor = AppColors.primary,
         modifier = Modifier.testTag(DeleteAccSectionTestTags.POPUP),
@@ -1287,4 +1302,9 @@ fun DeleteAccountDialog(show: Boolean, onCancel: () -> Unit, onConfirm: () -> Un
               }
         })
   }
+}
+
+@Composable
+fun RenderIf(condition: Boolean, composable: @Composable () -> Unit) {
+  if (condition) composable()
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/account/NotificationsTab.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/NotificationsTab.kt
@@ -678,7 +678,7 @@ private fun NotificationRowContent(
   LaunchedEffect(notif.uid) {
     when (notif.type) {
       NotificationType.FRIEND_REQUEST -> {
-        viewModel.getOtherAccount(notif.senderOrDiscussionId) { acc ->
+        viewModel.getAccount(notif.senderOrDiscussionId, context) { acc ->
           friend = acc
           viewModel.loadAccountImage(notif.senderOrDiscussionId, context) { avatarBytes = it }
         }

--- a/app/src/main/java/com/github/meeplemeet/ui/account/ProfileScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/ProfileScreen.kt
@@ -43,6 +43,7 @@ fun ProfileScreen(
     navigation: NavigationActions,
     viewModel: ProfileScreenViewModel = viewModel(),
     account: Account,
+    online: Boolean,
     onSignOutOrDel: () -> Unit,
     onDelete: () -> Unit,
     onFriendClick: () -> Unit,
@@ -65,6 +66,7 @@ fun ProfileScreen(
               MainTab(
                   viewModel = viewModel,
                   account = account,
+                  online = online,
                   onFriendsClick = onFriendClick,
                   onNotificationClick = onNotificationClick,
                   onSignOutOrDel = onSignOutOrDel,

--- a/app/src/main/java/com/github/meeplemeet/ui/components/SessionDetailsCard.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/SessionDetailsCard.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import coil.compose.rememberAsyncImagePainter
@@ -44,6 +45,7 @@ fun SessionDetailsCard(
     modifier: Modifier = Modifier,
     onClose: () -> Unit = {}
 ) {
+  val context = LocalContext.current
   val date =
       remember(session.date) {
         SimpleDateFormat("dd/MM/yyyy", Locale.getDefault()).format(session.date.toDate())
@@ -54,7 +56,7 @@ fun SessionDetailsCard(
     names.clear()
     session.participants.forEach { id ->
       if (id.isBlank()) names += "Unknown"
-      else viewModel.getOtherAccount(id) { acc -> names += acc.name }
+      else viewModel.getAccount(id, context) { it?.let { names += it.name } }
     }
   }
 

--- a/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionDetailsScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionDetailsScreen.kt
@@ -203,7 +203,9 @@ fun DiscussionDetailsScreen(
   /** Populate selectedMembers with current discussion participants */
   LaunchedEffect(discussion.participants) {
     selectedMembers.clear()
-    viewModel.getAccounts(discussion.participants) { accounts -> selectedMembers.addAll(accounts) }
+    viewModel.getAccounts(discussion.participants, context) { accounts ->
+      selectedMembers.addAll(accounts.filterNotNull())
+    }
     /** Add current account only if not already present */
     account.let {
       if (selectedMembers.none { member -> member.uid == it.uid }) {

--- a/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionScreen.kt
@@ -228,13 +228,15 @@ fun DiscussionScreen(
   LaunchedEffect(discussionState) { discussionState?.let { disc -> discussionName = disc.name } }
 
   LaunchedEffect(messages) {
-    messages.forEach { msg ->
-      if (!userCache.containsKey(msg.senderId) && msg.senderId != account.uid) {
-        try {
-          viewModel.getOtherAccount(msg.senderId) { acct -> userCache[msg.senderId] = acct }
-        } catch (_: Exception) {}
-      }
-    }
+    messages
+        .map { it.senderId }
+        .toSet()
+        .toList()
+        .let {
+          viewModel.getAccounts(it, context) { accounts ->
+            accounts.forEach { account -> if (account != null) userCache[account.uid] = account }
+          }
+        }
   }
 
   LaunchedEffect(messages.size) {

--- a/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionsOverviewScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionsOverviewScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -95,6 +96,7 @@ fun DiscussionsOverviewScreen(
     onClickAddDiscussion: () -> Unit = {},
     onSelectDiscussion: (Discussion) -> Unit = {},
 ) {
+  val context = LocalContext.current
   val discussionPreviewsSorted =
       remember(account.previews) {
         account.previews.values.sortedByDescending { it.lastMessageAt.toDate() }
@@ -153,7 +155,9 @@ fun DiscussionsOverviewScreen(
                           key1 = senderId,
                           initialValue = if (isMe) DiscussionCommons.YOU_SENDER_NAME else null) {
                             if (senderId.isNotBlank() && !isMe) {
-                              viewModel.getOtherAccount(senderId) { acc -> value = acc.name }
+                              viewModel.getAccount(senderId, context) { acc ->
+                                value = acc?.name ?: "Unknown"
+                              }
                             }
                           }
 

--- a/app/src/main/java/com/github/meeplemeet/ui/posts/PostScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/posts/PostScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
@@ -179,6 +180,7 @@ fun PostScreen(
   val userCache = remember { mutableStateMapOf<String, Account>() }
   val scope = rememberCoroutineScope()
   val focusManager = LocalFocusManager.current
+  val context = LocalContext.current
   val snackbarHostState = remember { SnackbarHostState() }
 
   var topComment by rememberSaveable { mutableStateOf("") }
@@ -236,7 +238,9 @@ fun PostScreen(
               walk(p.comments)
             }
             .filterNot { it.isBlank() || it in userCache }
-    accountViewModel.getAccounts(toFetch) { it.forEach { acc -> userCache[acc.uid] = acc } }
+    accountViewModel.getAccounts(toFetch, context) {
+      it.forEach { acc -> if (acc != null) userCache[acc.uid] = acc }
+    }
   }
 
   Scaffold(

--- a/app/src/main/java/com/github/meeplemeet/ui/posts/PostsOverviewScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/posts/PostsOverviewScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -71,6 +72,7 @@ fun PostsOverviewScreen(
     onClickAddPost: () -> Unit = {},
     onSelectPost: (Post) -> Unit = {},
 ) {
+  val context = LocalContext.current
   val posts by viewModel.posts.collectAsState()
   val postsSorted = remember(posts) { posts.sortedByDescending { it.timestamp } }
 
@@ -122,7 +124,9 @@ fun PostsOverviewScreen(
 
                   val authorName by
                       produceState<String?>(key1 = post.authorId, initialValue = null) {
-                        viewModel.getOtherAccount(post.authorId) { acc -> value = acc.name }
+                        viewModel.getAccount(post.authorId, context) { acc ->
+                          value = acc?.name ?: "Unknown"
+                        }
                       }
 
                   FeedCard(

--- a/app/src/main/java/com/github/meeplemeet/ui/sessions/CreateSessionScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/sessions/CreateSessionScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -153,14 +154,15 @@ fun CreateSessionScreen(
   val snackbar = remember { SnackbarHostState() }
   val scope = rememberCoroutineScope()
   val focusManager = LocalFocusManager.current
+  val context = LocalContext.current
   var isInputFocused by remember { mutableStateOf(false) }
   // Helper to show error messages in a snackbar
   val showError: (String) -> Unit = { msg -> scope.launch { snackbar.showSnackbar(msg) } }
 
   // Fetch participants and possibly trigger game query on discussion change
   LaunchedEffect(discussion.uid) {
-    viewModel.getAccounts(discussion.participants) { fetched ->
-      form = form.copy(participants = (fetched + account).distinctBy { it.uid })
+    viewModel.getAccounts(discussion.participants, context) { fetched ->
+      form = form.copy(participants = (fetched.filterNotNull() + account).distinctBy { it.uid })
     }
 
     // If a game query was already entered, trigger search

--- a/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionDetailsScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionDetailsScreen.kt
@@ -61,6 +61,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
@@ -350,11 +351,14 @@ fun ParticipantsSection(
 ) {
   val participants = form.participants
   val currentCount = participants.size
+  val context = LocalContext.current
 
   // Fetch discussion members (UID -> Account) once and keep in state
   var candidateAccounts by remember { mutableStateOf<List<Account>>(emptyList()) }
   LaunchedEffect(discussion.participants) {
-    viewModel.getAccounts(discussion.participants) { accounts -> candidateAccounts = accounts }
+    viewModel.getAccounts(discussion.participants, context) { accounts ->
+      candidateAccounts = accounts.filterNotNull()
+    }
   }
 
   // UI shell

--- a/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionsOverviewScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionsOverviewScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -310,6 +311,7 @@ fun SessionCard(
     modifier: Modifier = Modifier,
     onClick: () -> Unit = {}
 ) {
+  val context = LocalContext.current
   val date =
       remember(session.date) {
         SimpleDateFormat("dd/MM/yyyy", Locale.getDefault()).format(session.date.toDate())
@@ -320,14 +322,8 @@ fun SessionCard(
 
   LaunchedEffect(session.participants) {
     names.clear()
-    session.participants.forEach { id ->
-      if (id.isBlank()) {
-        names += "Unknown"
-      } else {
-        viewModel.getOtherAccount(id) { acc ->
-          names += acc.name // re-composition happens on each addition
-        }
-      }
+    viewModel.getAccounts(session.participants.toSet().toList(), context) {
+      it.forEach { account -> names += account?.name ?: "Unknown" }
     }
   }
   /* ----------------------------------------------------- */

--- a/app/src/test/java/com/github/meeplemeet/model/OfflinePostsTest.kt
+++ b/app/src/test/java/com/github/meeplemeet/model/OfflinePostsTest.kt
@@ -1,0 +1,326 @@
+package com.github.meeplemeet.model
+// AI was used for this file
+
+import com.github.meeplemeet.model.offline.OfflineModeManager
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Comprehensive unit tests for offline posts functionality in OfflineModeManager.
+ *
+ * Tests cover:
+ * - Creating posts offline (with temp IDs)
+ * - Queuing posts for sync
+ * - Caching posts for offline viewing
+ * - Adding comments offline
+ * - Syncing queued posts when back online
+ * - Syncing offline comments when back online
+ * - Deleting posts (both temp and real)
+ * - Post flow creation
+ * - Edge cases and error handling
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class OfflinePostsTest {
+
+  private val testDispatcher = StandardTestDispatcher()
+
+  @Before
+  fun setup() {
+    OfflineModeManager.dispatcher = testDispatcher
+    // Start in offline mode
+    OfflineModeManager.setInternetConnection(false)
+  }
+
+  @After
+  fun teardown() = runTest {
+    OfflineModeManager.clearCachedPosts()
+    // Clear queued posts
+    val queuedPosts = OfflineModeManager.getQueuedPosts()
+    queuedPosts.forEach { post -> OfflineModeManager.removeQueuedPost(post.id) }
+    OfflineModeManager.setInternetConnection(false)
+  }
+
+  // ==================== CREATE POST OFFLINE ====================
+
+  @Test
+  fun `createPost offline queues post with temp ID`() = runTest {
+    // Given: Offline mode
+    OfflineModeManager.setInternetConnection(false)
+
+    // When: Create a post
+    OfflineModeManager.createPost(
+        title = "Offline Post",
+        body = "Created while offline",
+        authorId = "user123",
+        tags = listOf("test", "offline"))
+    advanceUntilIdle()
+
+    // Then: Post is queued with temp ID
+    val queuedPosts = OfflineModeManager.getQueuedPosts()
+    assertEquals(1, queuedPosts.size)
+
+    val post = queuedPosts[0]
+    assertTrue(post.id.startsWith("temp_"))
+    assertEquals("Offline Post", post.title)
+    assertEquals("Created while offline", post.body)
+    assertEquals("user123", post.authorId)
+    assertEquals(listOf("test", "offline"), post.tags)
+    assertEquals(0, post.commentCount)
+    assertTrue(post.comments.isEmpty())
+  }
+
+  @Test
+  fun `createPost offline limits queue size to MAX_OFFLINE_CREATED_POSTS`() = runTest {
+    // Given: Offline mode
+    OfflineModeManager.setInternetConnection(false)
+
+    // When: Create more than MAX_OFFLINE_CREATED_POSTS (which is 2)
+    OfflineModeManager.createPost("Post 1", "Body 1", "user1")
+    advanceUntilIdle()
+    OfflineModeManager.createPost("Post 2", "Body 2", "user2")
+    advanceUntilIdle()
+    OfflineModeManager.createPost("Post 3", "Body 3", "user3")
+    advanceUntilIdle()
+
+    // Then: Only the last 2 posts are kept (oldest evicted)
+    val queuedPosts = OfflineModeManager.getQueuedPosts()
+    assertEquals(2, queuedPosts.size)
+    assertEquals("Post 2", queuedPosts[0].title)
+    assertEquals("Post 3", queuedPosts[1].title)
+  }
+
+  @Test
+  fun `createPost with no tags creates post without tags`() = runTest {
+    // Given: Offline mode
+    OfflineModeManager.setInternetConnection(false)
+
+    // When: Create post without tags
+    OfflineModeManager.createPost(
+        title = "No Tags Post", body = "No tags here", authorId = "user456")
+    advanceUntilIdle()
+
+    // Then: Post has empty tags list
+    val queuedPosts = OfflineModeManager.getQueuedPosts()
+    assertEquals(1, queuedPosts.size)
+    assertTrue(queuedPosts[0].tags.isEmpty())
+  }
+
+  // ==================== CACHE POSTS ====================
+  // Note: cachePosts() requires Firestore access to fetch full posts
+  // These tests are covered in OfflinePostsSyncTest integration tests
+
+  @Test
+  fun `clearCachedPosts removes all cached posts`() = runTest {
+    // This test just verifies clearCachedPosts doesn't crash
+    // Actual caching behavior is tested in integration tests
+    OfflineModeManager.clearCachedPosts()
+    advanceUntilIdle()
+
+    // Then: Cache is empty
+    val cachedPosts = OfflineModeManager.getCachedPosts()
+    assertTrue(cachedPosts.isEmpty())
+  }
+
+  // ==================== GET ALL POSTS FOR DISPLAY ====================
+
+  @Test
+  fun `getAllPostsForDisplay returns queued posts`() = runTest {
+    // Given: Queued posts
+    OfflineModeManager.setInternetConnection(false)
+
+    // Create queued post
+    OfflineModeManager.createPost("Queued Post", "Body", "user1")
+    advanceUntilIdle()
+
+    // When: Get all posts for display
+    val allPosts = OfflineModeManager.getAllPostsForDisplay()
+
+    // Then: Queued post is included
+    assertEquals(1, allPosts.size)
+    assertTrue(allPosts.any { it.title == "Queued Post" })
+  }
+
+  @Test
+  fun `getAllPostsForDisplay returns posts sorted by timestamp`() = runTest {
+    // Given: Posts with different timestamps
+    OfflineModeManager.setInternetConnection(false)
+
+    // Create posts with delay to ensure different timestamps
+    OfflineModeManager.createPost("First Post", "Body", "user1")
+    advanceUntilIdle()
+    Thread.sleep(10)
+
+    OfflineModeManager.createPost("Second Post", "Body", "user2")
+    advanceUntilIdle()
+
+    // When: Get all posts
+    val allPosts = OfflineModeManager.getAllPostsForDisplay()
+
+    // Then: Sorted newest first (MAX_OFFLINE_CREATED_POSTS is 2)
+    assertEquals(2, allPosts.size)
+    // Most recent post should be first
+    assertEquals("Second Post", allPosts[0].title)
+    assertEquals("First Post", allPosts[1].title)
+  }
+
+  // ==================== ADD COMMENT OFFLINE ====================
+  // Note: addComment to cached posts requires Firestore to fetch the post first
+  // These tests are covered in OfflinePostsSyncTest integration tests
+
+  @Test
+  fun `addComment throws exception when trying to comment on queued post`() = runTest {
+    // Given: Offline mode with a queued post
+    OfflineModeManager.setInternetConnection(false)
+    OfflineModeManager.createPost("Queued Post", "Body", "user1")
+    advanceUntilIdle()
+
+    val queuedPost = OfflineModeManager.getQueuedPosts()[0]
+
+    // When/Then: Adding comment throws exception
+    try {
+      OfflineModeManager.addComment(queuedPost.id, "Comment", "user2", queuedPost.id)
+      advanceUntilIdle()
+      assert(false) { "Should have thrown IllegalStateException" }
+    } catch (e: IllegalStateException) {
+      assertEquals("Cannot add comments to posts that are waiting to be uploaded.", e.message)
+    }
+  }
+
+  // ==================== DELETE POST ====================
+
+  @Test
+  fun `deletePost removes queued post when ID starts with temp`() = runTest {
+    // Given: Offline mode with a queued post
+    OfflineModeManager.setInternetConnection(false)
+    OfflineModeManager.createPost("Temp Post", "Body", "user1")
+    advanceUntilIdle()
+
+    val queuedPost = OfflineModeManager.getQueuedPosts()[0]
+    assertTrue(queuedPost.id.startsWith("temp_"))
+
+    // When: Delete the post
+    OfflineModeManager.deletePost(queuedPost)
+    advanceUntilIdle()
+
+    // Then: Post is removed from queue
+    val queuedPosts = OfflineModeManager.getQueuedPosts()
+    assertTrue(queuedPosts.isEmpty())
+  }
+
+  @Test
+  fun `removeQueuedPost removes specific post from queue`() = runTest {
+    // Given: Multiple queued posts
+    OfflineModeManager.setInternetConnection(false)
+    OfflineModeManager.createPost("Post 1", "Body 1", "user1")
+    advanceUntilIdle()
+    OfflineModeManager.createPost("Post 2", "Body 2", "user2")
+    advanceUntilIdle()
+
+    val posts = OfflineModeManager.getQueuedPosts()
+    val postToRemove = posts[0]
+
+    // When: Remove specific post
+    OfflineModeManager.removeQueuedPost(postToRemove.id)
+    advanceUntilIdle()
+
+    // Then: Only that post is removed
+    val remainingPosts = OfflineModeManager.getQueuedPosts()
+    assertEquals(1, remainingPosts.size)
+    assertEquals("Post 2", remainingPosts[0].title)
+  }
+
+  // ==================== ONLINE MODE ====================
+
+  @Test
+  fun `hasInternetConnection defaults to false`() {
+    // When: Check initial state
+    val isOnline = OfflineModeManager.hasInternetConnection.value
+
+    // Then: Defaults to false (offline)
+    assertFalse(isOnline)
+  }
+
+  @Test
+  fun `setInternetConnection changes connection state`() {
+    // Given: Initially offline
+    OfflineModeManager.setInternetConnection(false)
+    assertFalse(OfflineModeManager.hasInternetConnection.value)
+
+    // When: Set to online
+    OfflineModeManager.setInternetConnection(true)
+
+    // Then: State changes
+    assertTrue(OfflineModeManager.hasInternetConnection.value)
+  }
+
+  // ==================== EDGE CASES ====================
+
+  @Test
+  fun `getQueuedPosts returns empty list when no posts queued`() {
+    // When: Get queued posts with none queued
+    val queuedPosts = OfflineModeManager.getQueuedPosts()
+
+    // Then: Returns empty list
+    assertTrue(queuedPosts.isEmpty())
+  }
+
+  @Test
+  fun `getCachedPosts returns empty list when no posts cached`() {
+    // When: Get cached posts with none cached
+    val cachedPosts = OfflineModeManager.getCachedPosts()
+
+    // Then: Returns empty list
+    assertTrue(cachedPosts.isEmpty())
+  }
+
+  @Test
+  fun `getAllPostsForDisplay returns empty list when no posts`() {
+    // When: Get all posts with none available
+    val allPosts = OfflineModeManager.getAllPostsForDisplay()
+
+    // Then: Returns empty list
+    assertTrue(allPosts.isEmpty())
+  }
+
+  @Test
+  fun `addComment to non-existent post does nothing`() = runTest {
+    // Given: Offline mode with no cached posts
+    OfflineModeManager.setInternetConnection(false)
+
+    // When: Try to add comment to non-existent post
+    OfflineModeManager.addComment("nonexistent", "Comment", "user1", "nonexistent")
+    advanceUntilIdle()
+
+    // Then: No error thrown, no posts created
+    val cachedPosts = OfflineModeManager.getCachedPosts()
+    assertTrue(cachedPosts.isEmpty())
+  }
+
+  @Test
+  fun `createPost generates unique temp IDs`() = runTest {
+    // Given: Offline mode
+    OfflineModeManager.setInternetConnection(false)
+
+    // When: Create multiple posts quickly
+    OfflineModeManager.createPost("Post 1", "Body 1", "user1")
+    advanceUntilIdle()
+    OfflineModeManager.createPost("Post 2", "Body 2", "user2")
+    advanceUntilIdle()
+
+    // Then: All posts have unique IDs
+    val queuedPosts = OfflineModeManager.getQueuedPosts()
+    val ids = queuedPosts.map { it.id }
+    assertEquals(ids.size, ids.toSet().size) // All unique
+  }
+
+  // Note: Tests for addComment with cached posts and comment sorting
+  // require Firestore access and are covered in integration tests
+}


### PR DESCRIPTION
**Summary :**
This PR adds caching, and handling general behavior related to posts when offline.

**Description :**
* I added fields in the offline mode object to store cached posts and a queue to cache the posts created while offline
* I added the functions needed to cache posts, fetch the posts from the cache or the db and synchronize the db when back online
* I added backend logic in the offline mode manager to call needed function while online and offline
* I delegated logic from the view models to the offline mode manager