### PR TITLE
Add FirestoreTests() inheritance to missing test suites

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/ui/CreateSessionScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/CreateSessionScreenTest.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import com.github.meeplemeet.model.account.Account
 import com.github.meeplemeet.model.account.AccountRepository
 import com.github.meeplemeet.model.discussions.Discussion
-import com.github.meeplemeet.model.discussions.DiscussionRepository
 import com.github.meeplemeet.model.discussions.DiscussionViewModel
 import com.github.meeplemeet.model.sessions.CreateSessionViewModel
 import com.github.meeplemeet.model.sessions.SessionRepository
@@ -21,6 +20,7 @@ import com.github.meeplemeet.ui.sessions.CreateSessionScreen
 import com.github.meeplemeet.ui.sessions.SessionCreationTestTags
 import com.github.meeplemeet.ui.theme.AppTheme
 import com.github.meeplemeet.utils.Checkpoint
+import com.github.meeplemeet.utils.FirestoreTests
 import com.google.firebase.Timestamp
 import io.mockk.*
 import java.lang.reflect.Method
@@ -35,7 +35,7 @@ import org.junit.BeforeClass
 import org.junit.Rule
 import org.junit.Test
 
-class CreateSessionScreenTest {
+class CreateSessionScreenTest : FirestoreTests() {
 
   @get:Rule(order = 0) val compose = createComposeRule()
   /* ---------- Checkpoint helper ---------- */
@@ -44,7 +44,6 @@ class CreateSessionScreenTest {
   fun checkpoint(name: String, block: () -> Unit) = ck.ck(name, block)
 
   // Repos / VMs
-  private lateinit var discussionRepository: DiscussionRepository
   private lateinit var viewModel: DiscussionViewModel
   private lateinit var accountRepo: AccountRepository
   private lateinit var sessionRepo: SessionRepository

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/CreateShopScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/CreateShopScreenTest.kt
@@ -17,6 +17,7 @@ import com.github.meeplemeet.ui.shops.AddShopContent
 import com.github.meeplemeet.ui.shops.CreateShopScreenTestTags
 import com.github.meeplemeet.ui.theme.AppTheme
 import com.github.meeplemeet.utils.Checkpoint
+import com.github.meeplemeet.utils.FirestoreTests
 import org.junit.Assert.assertEquals
 import org.junit.Assume.assumeTrue
 import org.junit.Rule
@@ -24,7 +25,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class CreateShopScreenTest {
+class CreateShopScreenTest : FirestoreTests() {
 
   /* ───────────────────────────────── RULES ───────────────────────────────── */
 

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/PostScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/PostScreenTest.kt
@@ -23,13 +23,14 @@ import com.github.meeplemeet.ui.posts.PostScreen
 import com.github.meeplemeet.ui.posts.PostTags
 import com.github.meeplemeet.ui.theme.AppTheme
 import com.github.meeplemeet.utils.Checkpoint
+import com.github.meeplemeet.utils.FirestoreTests
 import com.google.firebase.Timestamp
 import kotlinx.coroutines.CoroutineScope
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
-class PostScreenTest {
+class PostScreenTest : FirestoreTests() {
 
   @get:Rule val compose = createComposeRule()
   @get:Rule val ck = Checkpoint.Rule()

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/SignInScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/SignInScreenTest.kt
@@ -17,11 +17,12 @@ import com.github.meeplemeet.model.auth.SignInViewModel
 import com.github.meeplemeet.ui.auth.SignInScreen
 import com.github.meeplemeet.ui.auth.SignInScreenTestTags
 import com.github.meeplemeet.utils.Checkpoint
+import com.github.meeplemeet.utils.FirestoreTests
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
-class SignInScreenTest {
+class SignInScreenTest : FirestoreTests() {
   @get:Rule val compose = createComposeRule()
   @get:Rule val ck = Checkpoint.Rule()
 

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/SignUpScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/SignUpScreenTest.kt
@@ -25,11 +25,12 @@ import com.github.meeplemeet.ui.auth.SignUpScreenTestTags
 import com.github.meeplemeet.ui.auth.WEAK_PWD_TEXT
 import com.github.meeplemeet.ui.navigation.NavigationTestTags
 import com.github.meeplemeet.utils.Checkpoint
+import com.github.meeplemeet.utils.FirestoreTests
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
-class SignUpScreenTest {
+class SignUpScreenTest : FirestoreTests() {
   @get:Rule val compose = createComposeRule()
   @get:Rule val ck = Checkpoint.Rule()
 


### PR DESCRIPTION
Several test suites were not inheriting from `FirestoreTests()`, causing them to connect to the live Firebase backend instead of the local emulator. 

This PR updates 5 test suites to extend `FirestoreTests()`, ensuring consistent use of the Firestore emulator during testing and preventing unintended calls to production.

_Generated with Copilot._