### PR TITLE
Feat/archive implementation overview

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/integration/SessionOverviewViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/SessionOverviewViewModelTest.kt
@@ -106,14 +106,13 @@ class SessionOverviewViewModelTest : FirestoreTests() {
     // Archive a session with a photo URL
     val discussion = discussionRepository.createDiscussion("Archive Photo", "Test", account.uid)
     val game = gameRepository.getGameById(existingGameId)
-    val session =
-        sessionRepository.createSession(
-            discussion.uid,
-            "Archive Photo Session",
-            game.uid,
-            Timestamp.now(),
-            testLocation,
-            account.uid)
+    sessionRepository.createSession(
+        discussion.uid,
+        "Archive Photo Session",
+        game.uid,
+        Timestamp.now(),
+        testLocation,
+        account.uid)
     val photoUrl = "https://example.com/archived_photo.webp"
     val archivedId = java.util.UUID.randomUUID().toString()
     sessionRepository.archiveSession(discussion.uid, archivedId, photoUrl)
@@ -130,14 +129,13 @@ class SessionOverviewViewModelTest : FirestoreTests() {
     // Archive a session with a photo URL
     val discussion = discussionRepository.createDiscussion("Find By Photo", "Test", account.uid)
     val game = gameRepository.getGameById(existingGameId)
-    val session =
-        sessionRepository.createSession(
-            discussion.uid,
-            "Find By Photo Session",
-            game.uid,
-            Timestamp.now(),
-            testLocation,
-            account.uid)
+    sessionRepository.createSession(
+        discussion.uid,
+        "Find By Photo Session",
+        game.uid,
+        Timestamp.now(),
+        testLocation,
+        account.uid)
     val photoUrl = "https://example.com/find_by_photo.webp"
     val archivedId = java.util.UUID.randomUUID().toString()
     sessionRepository.archiveSession(discussion.uid, archivedId, photoUrl)

--- a/app/src/androidTest/java/com/github/meeplemeet/integration/SessionOverviewViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/SessionOverviewViewModelTest.kt
@@ -233,7 +233,8 @@ class SessionOverviewViewModelTest : FirestoreTests() {
         discussionRepository.createDiscussion("Past Session", "Happened earlier", account.uid)
     val game = gameRepository.getGameById(existingGameId)
 
-    val twentyFiveHoursAgo = Timestamp(java.util.Date(System.currentTimeMillis() - 25 * 60 * 60 * 1000L))
+    val twentyFiveHoursAgo =
+        Timestamp(java.util.Date(System.currentTimeMillis() - 25 * 60 * 60 * 1000L))
 
     sessionRepository.createSession(
         discussion.uid, "Past Chess Night", game.uid, twentyFiveHoursAgo, testLocation, account.uid)
@@ -269,10 +270,16 @@ class SessionOverviewViewModelTest : FirestoreTests() {
         discussionRepository.createDiscussion("Past Session With Photo", "Had a photo", account.uid)
     val game = gameRepository.getGameById(existingGameId)
 
-    val twentyFiveHoursAgo = Timestamp(java.util.Date(System.currentTimeMillis() - 25 * 60 * 60 * 1000L))
+    val twentyFiveHoursAgo =
+        Timestamp(java.util.Date(System.currentTimeMillis() - 25 * 60 * 60 * 1000L))
 
     sessionRepository.createSession(
-        discussion.uid, "Photo Chess Night", game.uid, twentyFiveHoursAgo, testLocation, account.uid)
+        discussion.uid,
+        "Photo Chess Night",
+        game.uid,
+        twentyFiveHoursAgo,
+        testLocation,
+        account.uid)
 
     // Add a photo to the session - create a valid image file
     val context = InstrumentationRegistry.getInstrumentation().targetContext
@@ -340,7 +347,8 @@ class SessionOverviewViewModelTest : FirestoreTests() {
   fun archiveSession_manually_archives_session() = runBlocking {
     // Create a discussion and session
     val discussion =
-        discussionRepository.createDiscussion("Manual Archive", "Will be manually archived", account.uid)
+        discussionRepository.createDiscussion(
+            "Manual Archive", "Will be manually archived", account.uid)
     val game = gameRepository.getGameById(existingGameId)
 
     // Create a session (time doesn't matter for manual archiving in ViewModel)

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/SessionsOverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/SessionsOverviewScreenTest.kt
@@ -142,13 +142,9 @@ class SessionsOverviewScreenTest : FirestoreTests() {
               discussion.uid, "Past Night", game.uid, pastDate, testLocation, account.uid)
 
           // Wait for session to appear
-          compose.waitUntil(2000) {
-            sessionCard(discussion.uid).isDisplayed()
-          }
+          compose.waitUntil(2000) { sessionCard(discussion.uid).isDisplayed() }
           // Wait for auto-archiving to complete (card disappears)
-          compose.waitUntil(5000) {
-            sessionCard(discussion.uid).isNotDisplayed()
-          }
+          compose.waitUntil(5000) { sessionCard(discussion.uid).isNotDisplayed() }
 
           compose.onNodeWithTag(SessionsOverviewScreenTestTags.TEST_TAG_HISTORY).performClick()
           compose.waitUntil(4000) { compose.onNodeWithText("Past Night").isDisplayed() }
@@ -184,27 +180,34 @@ class SessionsOverviewScreenTest : FirestoreTests() {
           }
 
           sessionCard(discussion.uid).assertIsDisplayed()
-          compose.onNodeWithTag(SessionsOverviewScreenTestTags.TEST_TAG_ARCHIVE_BUTTON).assertExists()
+          compose
+              .onNodeWithTag(SessionsOverviewScreenTestTags.TEST_TAG_ARCHIVE_BUTTON)
+              .assertExists()
 
           sessionCard(discussion.uid).performTouchInput { swipeLeft() }
-          compose.onNodeWithTag(SessionsOverviewScreenTestTags.TEST_TAG_ARCHIVE_BUTTON).performClick()
+          compose
+              .onNodeWithTag(SessionsOverviewScreenTestTags.TEST_TAG_ARCHIVE_BUTTON)
+              .performClick()
 
-          compose.waitUntil(2000) {
-            compose.onNodeWithText("Archive Session").isDisplayed()
-          }
-          compose.onNodeWithText("This session doesn't have an image. Are you sure you want to archive it?").assertIsDisplayed()
+          compose.waitUntil(2000) { compose.onNodeWithText("Archive Session").isDisplayed() }
+          compose
+              .onNodeWithText(
+                  "This session doesn't have an image. Are you sure you want to archive it?")
+              .assertIsDisplayed()
 
           compose.onNodeWithText("Archive").performClick()
 
-          compose.waitUntil(2000) {
-            sessionCard(discussion.uid).isNotDisplayed()
-          }
+          compose.waitUntil(2000) { sessionCard(discussion.uid).isNotDisplayed() }
           compose.onNodeWithTag(SessionsOverviewScreenTestTags.TEST_TAG_HISTORY).performClick()
           compose.waitUntil(2000) { compose.onNodeWithText("Archive Night").isDisplayed() }
 
-          compose.onNodeWithTag(SessionsOverviewScreenTestTags.TEST_TAG_NEXT_SESSIONS).performClick()
+          compose
+              .onNodeWithTag(SessionsOverviewScreenTestTags.TEST_TAG_NEXT_SESSIONS)
+              .performClick()
           compose.waitUntil(2000) {
-            compose.onNodeWithTag(SessionsOverviewScreenTestTags.TEST_TAG_NEXT_SESSIONS).isDisplayed()
+            compose
+                .onNodeWithTag(SessionsOverviewScreenTestTags.TEST_TAG_NEXT_SESSIONS)
+                .isDisplayed()
           }
         }
       }
@@ -222,13 +225,18 @@ class SessionsOverviewScreenTest : FirestoreTests() {
 
           val game = gameRepository.getGameById(testGameId)
 
-          val withinTwoHours = Timestamp(java.util.Date(System.currentTimeMillis() - (60 * 60 * 1000L)))
+          val withinTwoHours =
+              Timestamp(java.util.Date(System.currentTimeMillis() - (60 * 60 * 1000L)))
           sessionRepository.createSession(
-              discussion.uid, "User Night", game.uid, withinTwoHours, testLocation, otherUid, account.uid)
+              discussion.uid,
+              "User Night",
+              game.uid,
+              withinTwoHours,
+              testLocation,
+              otherUid,
+              account.uid)
 
-          compose.waitUntil(2000) {
-            sessionCard(discussion.uid).isDisplayed()
-          }
+          compose.waitUntil(2000) { sessionCard(discussion.uid).isDisplayed() }
 
           compose
               .onNodeWithTag(SessionsOverviewScreenTestTags.TEST_TAG_ARCHIVE_BUTTON)
@@ -243,13 +251,12 @@ class SessionsOverviewScreenTest : FirestoreTests() {
               discussionRepository.createDiscussion("Future Session", "Too far away", account.uid)
           val game = gameRepository.getGameById(testGameId)
 
-          val futureDate = Timestamp(java.util.Date(System.currentTimeMillis() + (3 * 60 * 60 * 1000L)))
+          val futureDate =
+              Timestamp(java.util.Date(System.currentTimeMillis() + (3 * 60 * 60 * 1000L)))
           sessionRepository.createSession(
               discussion.uid, "Future Night", game.uid, futureDate, testLocation, account.uid)
 
-          compose.waitUntil(2000) {
-            sessionCard(discussion.uid).isDisplayed()
-          }
+          compose.waitUntil(2000) { sessionCard(discussion.uid).isDisplayed() }
 
           compose
               .onNodeWithTag(SessionsOverviewScreenTestTags.TEST_TAG_ARCHIVE_BUTTON)

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/SessionsOverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/SessionsOverviewScreenTest.kt
@@ -141,9 +141,7 @@ class SessionsOverviewScreenTest : FirestoreTests() {
           sessionRepository.createSession(
               discussion.uid, "Past Night", game.uid, pastDate, testLocation, account.uid)
 
-          // Wait for session to appear
           compose.waitUntil(2000) { sessionCard(discussion.uid).isDisplayed() }
-          // Wait for auto-archiving to complete (card disappears)
           compose.waitUntil(5000) { sessionCard(discussion.uid).isNotDisplayed() }
 
           compose.onNodeWithTag(SessionsOverviewScreenTestTags.TEST_TAG_HISTORY).performClick()

--- a/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionsOverviewScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionsOverviewScreen.kt
@@ -129,9 +129,7 @@ fun SessionsOverviewScreen(
   val context = LocalContext.current
   LaunchedEffect(sessionMap.keys) {
     if (account != null) {
-      sessionMap.keys.forEach { id ->
-        viewModel.updateSession(context, id)
-      }
+      sessionMap.keys.forEach { id -> viewModel.updateSession(context, id) }
     }
   }
 

--- a/app/src/main/java/com/github/meeplemeet/ui/theme/Dimensions.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/theme/Dimensions.kt
@@ -47,6 +47,7 @@ object Dimensions {
     val standard: Dp = 20.dp
     val large: Dp = 24.dp
     val extraLarge: Dp = 28.dp
+    val xxLarge: Dp = 34.dp
     val huge: Dp = 48.dp
     val giant: Dp = 64.dp
     val massive: Dp = 80.dp


### PR DESCRIPTION
## Session Archiving Support Through SessionsOverviewScreen

### Overview
Implements automatic and manual session archiving functionality for the Sessions Overview screen, providing better organization of past and upcoming sessions.

### Features

**Automatic Archiving**
- Sessions are automatically archived 24 hours after their scheduled date
- Auto-archive check runs when [SessionCard](cci:1://file:///c:/Users/danym/Documents/swent/Meeple-Meet/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionsOverviewScreen.kt:378:0-505:1) mounts via `LaunchedEffect`
- Archive countdown timer displays on session cards, auto-refreshing every minute

**Manual Archiving**
- Swipe-to-reveal archive button for admin users
- Custom gesture implementation using `draggable` and `Animatable` for smooth animations
- Archive button only visible and functional for discussion admins/owners

**UI Improvements**
- "Next Sessions" tab shows all active (non-archived) sessions
- "History" tab displays archived sessions in a grid layout
- Archive timer shows time remaining until auto-archive (e.g., "Automatically archives in 23h 15min")
- Timer updates on the minute boundary using `java.util.Timer`


https://github.com/user-attachments/assets/704ae4f9-9f26-44d7-9bfb-1b6dffbf4373
