### PR TITLE
BugFix: Notifications Randomly Delete

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/integration/NotificationsViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/NotificationsViewModelTest.kt
@@ -5,13 +5,13 @@ import com.github.meeplemeet.model.account.Account
 import com.github.meeplemeet.model.account.NotificationsViewModel
 import com.github.meeplemeet.model.discussions.Discussion
 import com.github.meeplemeet.utils.FirestoreTests
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.tasks.await
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 
 class NotificationsViewModelTest : FirestoreTests() {
 
@@ -20,124 +20,121 @@ class NotificationsViewModelTest : FirestoreTests() {
 
   @Before
   fun setUp() = runBlocking {
-      viewModel =
-          NotificationsViewModel(
-              accountRepository = accountRepository,
-              handlesRepository = handlesRepository,
-              imageRepository = imageRepository,
-              discussionRepository = discussionRepository,
-              gameRepository = gameRepository
-          )
+    viewModel =
+        NotificationsViewModel(
+            accountRepository = accountRepository,
+            handlesRepository = handlesRepository,
+            imageRepository = imageRepository,
+            discussionRepository = discussionRepository,
+            gameRepository = gameRepository)
 
-      // Sign in anonymously for Firebase access
-      auth.signInAnonymously().await()
+    // Sign in anonymously for Firebase access
+    auth.signInAnonymously().await()
 
-      // Create a test account
-      testAccount =
-          accountRepository.createAccount("testUser", "Test User", "test@example.com", null)
+    // Create a test account
+    testAccount = accountRepository.createAccount("testUser", "Test User", "test@example.com", null)
   }
 
   @Test
   fun getDiscussion_validId_callsOnResult() = runBlocking {
-      // Create a discussion
-      val discussion =
-          discussionRepository.createDiscussion(
-              "Test Discussion", "Description", testAccount.uid, emptyList()
-          )
+    // Create a discussion
+    val discussion =
+        discussionRepository.createDiscussion(
+            "Test Discussion", "Description", testAccount.uid, emptyList())
 
-      val latch = CountDownLatch(1)
-      var resultDiscussion: Discussion? = null
-      var deletedCalled = false
+    val latch = CountDownLatch(1)
+    var resultDiscussion: Discussion? = null
+    var deletedCalled = false
 
-      InstrumentationRegistry.getInstrumentation().runOnMainSync {
-          viewModel.getDiscussion(
-              discussionId = discussion.uid,
-              onResult = {
-                  resultDiscussion = it
-                  latch.countDown()
-              },
-              onDeleted = {
-                  deletedCalled = true
-                  latch.countDown()
-              })
-      }
+    InstrumentationRegistry.getInstrumentation().runOnMainSync {
+      viewModel.getDiscussion(
+          discussionId = discussion.uid,
+          onResult = {
+            resultDiscussion = it
+            latch.countDown()
+          },
+          onDeleted = {
+            deletedCalled = true
+            latch.countDown()
+          })
+    }
 
-      latch.await(2, TimeUnit.SECONDS)
-      Assert.assertNotNull("Discussion should be found", resultDiscussion)
-      Assert.assertEquals(discussion.uid, resultDiscussion?.uid)
-      Assert.assertEquals(false, deletedCalled)
+    latch.await(2, TimeUnit.SECONDS)
+    Assert.assertNotNull("Discussion should be found", resultDiscussion)
+    Assert.assertEquals(discussion.uid, resultDiscussion?.uid)
+    Assert.assertEquals(false, deletedCalled)
   }
 
   @Test
   fun getDiscussion_invalidId_callsOnDeleted() = runBlocking {
-      val latch = CountDownLatch(1)
-      var resultDiscussion: Discussion? = null
-      var deletedCalled = false
+    val latch = CountDownLatch(1)
+    var resultDiscussion: Discussion? = null
+    var deletedCalled = false
 
-      InstrumentationRegistry.getInstrumentation().runOnMainSync {
-          viewModel.getDiscussion(
-              discussionId = "non_existent_id",
-              onResult = {
-                  resultDiscussion = it
-                  latch.countDown()
-              },
-              onDeleted = {
-                  deletedCalled = true
-                  latch.countDown()
-              })
-      }
+    InstrumentationRegistry.getInstrumentation().runOnMainSync {
+      viewModel.getDiscussion(
+          discussionId = "non_existent_id",
+          onResult = {
+            resultDiscussion = it
+            latch.countDown()
+          },
+          onDeleted = {
+            deletedCalled = true
+            latch.countDown()
+          })
+    }
 
-      latch.await(2, TimeUnit.SECONDS)
-      Assert.assertTrue("onDeleted should be called", deletedCalled)
-      Assert.assertEquals(null, resultDiscussion)
+    latch.await(2, TimeUnit.SECONDS)
+    Assert.assertTrue("onDeleted should be called", deletedCalled)
+    Assert.assertEquals(null, resultDiscussion)
   }
 
   @Test
   fun getOtherAccountData_validId_callsOnResult() = runBlocking {
-      val latch = CountDownLatch(1)
-      var resultAccount: Account? = null
-      var deletedCalled = false
+    val latch = CountDownLatch(1)
+    var resultAccount: Account? = null
+    var deletedCalled = false
 
-      InstrumentationRegistry.getInstrumentation().runOnMainSync {
-          viewModel.getOtherAccountData(
-              id = testAccount.uid,
-              onResult = {
-                  resultAccount = it
-                  latch.countDown()
-              },
-              onDeleted = {
-                  deletedCalled = true
-                  latch.countDown()
-              })
-      }
+    InstrumentationRegistry.getInstrumentation().runOnMainSync {
+      viewModel.getOtherAccountData(
+          id = testAccount.uid,
+          onResult = {
+            resultAccount = it
+            latch.countDown()
+          },
+          onDeleted = {
+            deletedCalled = true
+            latch.countDown()
+          })
+    }
 
-      latch.await(2, TimeUnit.SECONDS)
-      Assert.assertNotNull("Account should be found", resultAccount)
-      Assert.assertEquals(testAccount.uid, resultAccount?.uid)
-      Assert.assertEquals(false, deletedCalled)
+    latch.await(2, TimeUnit.SECONDS)
+    Assert.assertNotNull("Account should be found", resultAccount)
+    Assert.assertEquals(testAccount.uid, resultAccount?.uid)
+    Assert.assertEquals(false, deletedCalled)
   }
 
   @Test
   fun getOtherAccountData_invalidId_callsOnDeleted() = runBlocking {
-      val latch = CountDownLatch(1)
-      var resultAccount: Account? = null
-      var deletedCalled = false
+    val latch = CountDownLatch(1)
+    var resultAccount: Account? = null
+    var deletedCalled = false
 
-      InstrumentationRegistry.getInstrumentation().runOnMainSync {
-          viewModel.getOtherAccountData(
-              id = "non_existent_account_id",
-              onResult = {
-                  resultAccount = it
-                  latch.countDown()
-              },
-              onDeleted = {
-                  deletedCalled = true
-                  latch.countDown()
-              })
-      }
+    InstrumentationRegistry.getInstrumentation().runOnMainSync {
+      viewModel.getOtherAccountData(
+          id = "non_existent_account_id",
+          onResult = {
+            resultAccount = it
+            latch.countDown()
+          },
+          onDeleted = {
+            deletedCalled = true
+            latch.countDown()
+          })
+    }
 
-      latch.await(2, TimeUnit.SECONDS)
-      Assert.assertTrue("onDeleted should be called", deletedCalled)
-      Assert.assertEquals(null, resultAccount)
+    latch.await(2, TimeUnit.SECONDS)
+    Assert.assertTrue("onDeleted should be called", deletedCalled)
+    Assert.assertEquals(null, resultAccount)
   }
 }

--- a/app/src/androidTest/java/com/github/meeplemeet/integration/NotificationsViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/NotificationsViewModelTest.kt
@@ -1,0 +1,143 @@
+package com.github.meeplemeet.integration
+
+import androidx.test.platform.app.InstrumentationRegistry
+import com.github.meeplemeet.model.account.Account
+import com.github.meeplemeet.model.account.NotificationsViewModel
+import com.github.meeplemeet.model.discussions.Discussion
+import com.github.meeplemeet.utils.FirestoreTests
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.tasks.await
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+class NotificationsViewModelTest : FirestoreTests() {
+
+  private lateinit var viewModel: NotificationsViewModel
+  private lateinit var testAccount: Account
+
+  @Before
+  fun setUp() = runBlocking {
+      viewModel =
+          NotificationsViewModel(
+              accountRepository = accountRepository,
+              handlesRepository = handlesRepository,
+              imageRepository = imageRepository,
+              discussionRepository = discussionRepository,
+              gameRepository = gameRepository
+          )
+
+      // Sign in anonymously for Firebase access
+      auth.signInAnonymously().await()
+
+      // Create a test account
+      testAccount =
+          accountRepository.createAccount("testUser", "Test User", "test@example.com", null)
+  }
+
+  @Test
+  fun getDiscussion_validId_callsOnResult() = runBlocking {
+      // Create a discussion
+      val discussion =
+          discussionRepository.createDiscussion(
+              "Test Discussion", "Description", testAccount.uid, emptyList()
+          )
+
+      val latch = CountDownLatch(1)
+      var resultDiscussion: Discussion? = null
+      var deletedCalled = false
+
+      InstrumentationRegistry.getInstrumentation().runOnMainSync {
+          viewModel.getDiscussion(
+              discussionId = discussion.uid,
+              onResult = {
+                  resultDiscussion = it
+                  latch.countDown()
+              },
+              onDeleted = {
+                  deletedCalled = true
+                  latch.countDown()
+              })
+      }
+
+      latch.await(2, TimeUnit.SECONDS)
+      Assert.assertNotNull("Discussion should be found", resultDiscussion)
+      Assert.assertEquals(discussion.uid, resultDiscussion?.uid)
+      Assert.assertEquals(false, deletedCalled)
+  }
+
+  @Test
+  fun getDiscussion_invalidId_callsOnDeleted() = runBlocking {
+      val latch = CountDownLatch(1)
+      var resultDiscussion: Discussion? = null
+      var deletedCalled = false
+
+      InstrumentationRegistry.getInstrumentation().runOnMainSync {
+          viewModel.getDiscussion(
+              discussionId = "non_existent_id",
+              onResult = {
+                  resultDiscussion = it
+                  latch.countDown()
+              },
+              onDeleted = {
+                  deletedCalled = true
+                  latch.countDown()
+              })
+      }
+
+      latch.await(2, TimeUnit.SECONDS)
+      Assert.assertTrue("onDeleted should be called", deletedCalled)
+      Assert.assertEquals(null, resultDiscussion)
+  }
+
+  @Test
+  fun getOtherAccountData_validId_callsOnResult() = runBlocking {
+      val latch = CountDownLatch(1)
+      var resultAccount: Account? = null
+      var deletedCalled = false
+
+      InstrumentationRegistry.getInstrumentation().runOnMainSync {
+          viewModel.getOtherAccountData(
+              id = testAccount.uid,
+              onResult = {
+                  resultAccount = it
+                  latch.countDown()
+              },
+              onDeleted = {
+                  deletedCalled = true
+                  latch.countDown()
+              })
+      }
+
+      latch.await(2, TimeUnit.SECONDS)
+      Assert.assertNotNull("Account should be found", resultAccount)
+      Assert.assertEquals(testAccount.uid, resultAccount?.uid)
+      Assert.assertEquals(false, deletedCalled)
+  }
+
+  @Test
+  fun getOtherAccountData_invalidId_callsOnDeleted() = runBlocking {
+      val latch = CountDownLatch(1)
+      var resultAccount: Account? = null
+      var deletedCalled = false
+
+      InstrumentationRegistry.getInstrumentation().runOnMainSync {
+          viewModel.getOtherAccountData(
+              id = "non_existent_account_id",
+              onResult = {
+                  resultAccount = it
+                  latch.countDown()
+              },
+              onDeleted = {
+                  deletedCalled = true
+                  latch.countDown()
+              })
+      }
+
+      latch.await(2, TimeUnit.SECONDS)
+      Assert.assertTrue("onDeleted should be called", deletedCalled)
+      Assert.assertEquals(null, resultAccount)
+  }
+}

--- a/app/src/main/java/com/github/meeplemeet/model/account/NotificationsViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/NotificationsViewModel.kt
@@ -49,14 +49,14 @@ class NotificationsViewModel(
       val disc =
           try {
             discussionRepository.getDiscussion(discussionId)
+          } catch (e: com.github.meeplemeet.model.DiscussionNotFoundException) {
+            onDeleted()
+            return@launch
           } catch (_: Exception) {
             null
           }
       if (disc != null) {
         onResult(disc)
-      } else {
-        onDeleted()
-        return@launch
       }
     }
   }
@@ -73,15 +73,15 @@ class NotificationsViewModel(
       val acc =
           try {
             accountRepository.getAccount(id, false)
+          } catch (e: com.github.meeplemeet.model.AccountNotFoundException) {
+            onDeleted()
+            return@launch
           } catch (_: Exception) {
             null
           }
 
       if (acc != null) {
         onResult(acc)
-      } else {
-        onDeleted()
-        return@launch
       }
     }
   }
@@ -215,7 +215,7 @@ class NotificationsViewModel(
                         title = disc.name,
                         participants = disc.participants.size,
                         dateLabel =
-                            "Created at" +
+                            "Created at " +
                                 disc.createdAt
                                     .toDate()
                                     .toInstant()
@@ -254,6 +254,8 @@ class NotificationsViewModel(
                             icon = bytes))
                   }
                 } else {
+                  // If session is null but discussion exists, we might want to delete notification or handle it differently.
+                  // For now, let's assume if session is missing it's invalid.
                   deleteNotification(account, notif)
                 }
               }

--- a/app/src/main/java/com/github/meeplemeet/model/account/NotificationsViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/NotificationsViewModel.kt
@@ -254,7 +254,8 @@ class NotificationsViewModel(
                             icon = bytes))
                   }
                 } else {
-                  // If session is null but discussion exists, we might want to delete notification or handle it differently.
+                  // If session is null but discussion exists, we might want to delete notification
+                  // or handle it differently.
                   // For now, let's assume if session is missing it's invalid.
                   deleteNotification(account, notif)
                 }


### PR DESCRIPTION
This PR fixes a bug with the `NotificationsTab.kt` screen. Previously to handle notifications that came from a deleted object (session/discussion/account) I had simply used a try-catch clause, thinking that the only time where an exception could be thrown would be if the data fetched from the repo was invalid.
It turns out there may be other times where exceptions are thrown (but do not cause a crash in the app at all), think of data taking too long to load for example. What this caused in practice was the deletion of perfectly correct notifications.

The fix was simple, only catch the actual exception that I have to handle (AccountNotExist and DiscussionNotExist). 