### PR TITLE
Hide messages from blocked users in discussions

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/ui/DiscussionsOverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/DiscussionsOverviewScreenTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.platform.app.InstrumentationRegistry
 import com.github.meeplemeet.model.account.Account
+import com.github.meeplemeet.model.account.RelationshipStatus
 import com.github.meeplemeet.model.discussions.Discussion
 import com.github.meeplemeet.model.discussions.DiscussionViewModel
 import com.github.meeplemeet.model.navigation.LocalNavigationVM
@@ -203,6 +204,31 @@ class DiscussionsOverviewScreenTest : FirestoreTests() {
       // DiscussionCommons.NO_MESSAGES_DEFAULT_TEXT
       compose.onNodeWithText("Weekend Plan").assertIsDisplayed()
       compose.onNodeWithText("(No messages yet)").assertIsDisplayed()
+    }
+  }
+
+  @Test
+  fun blockedSender_hidesMessagePreview() = runBlocking {
+    // Block Bob
+    val meWithBlockedBob =
+        me.copy(relationships = me.relationships + (bob.uid to RelationshipStatus.BLOCKED))
+
+    compose.setContent {
+      CompositionLocalProvider(LocalNavigationVM provides navVM) {
+        AppTheme { DiscussionsOverviewScreen(account = meWithBlockedBob, navigation = nav) }
+      }
+    }
+
+    checkpoint("Blocked sender shows hidden message") {
+      compose.waitForIdle()
+      compose.onNodeWithText("Gloomhaven").assertIsDisplayed()
+      compose.onNodeWithText("Hidden: blocked sender", substring = true).assertIsDisplayed()
+      compose.onNodeWithText("Bob: Ready at 7?", substring = true).assertDoesNotExist()
+    }
+
+    checkpoint("Non-blocked messages still display") {
+      compose.onNodeWithText("Catan Crew").assertIsDisplayed()
+      compose.onNodeWithText("You: Bring snacks", substring = true).assertIsDisplayed()
     }
   }
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/account/FriendsScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/FriendsScreen.kt
@@ -59,7 +59,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.layout.ContentScale
@@ -338,7 +337,7 @@ fun FriendsScreen(
   var sentRequests by remember { mutableStateOf<List<Account>>(emptyList()) }
   var blockedUsers by remember { mutableStateOf<List<Account>>(emptyList()) }
 
-  LaunchedEffect(account.uid) {
+  LaunchedEffect(account.relationships) {
     viewModel.getAccounts(account.relationships.keys.toList(), context) { list ->
       val f = mutableListOf<Account>()
       val s = mutableListOf<Account>()

--- a/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionScreen.kt
@@ -73,6 +73,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.AsyncImage
 import com.github.meeplemeet.model.account.Account
+import com.github.meeplemeet.model.account.RelationshipStatus
 import com.github.meeplemeet.model.discussions.Discussion
 import com.github.meeplemeet.model.discussions.DiscussionViewModel
 import com.github.meeplemeet.model.discussions.EDIT_MAX_THRESHOLD
@@ -225,7 +226,6 @@ fun DiscussionScreen(
   val networkMonitorStarted by
       OfflineModeManager.networkMonitorStarted.collectAsStateWithLifecycle()
   val effectiveOnline = online || !networkMonitorStarted
-  val offlineMode by OfflineModeManager.offlineModeFlow.collectAsStateWithLifecycle()
 
   var selectedMessageForActions by remember { mutableStateOf<Message?>(null) }
   var messageBeingEdited by remember { mutableStateOf<Message?>(null) }
@@ -395,6 +395,10 @@ fun DiscussionScreen(
                           itemsIndexed(items = messages, key = { _, msg -> msg.uid }) {
                               index,
                               message ->
+                            if (account.relationships[message.senderId] ==
+                                RelationshipStatus.BLOCKED)
+                                return@itemsIndexed
+
                             val isMine = message.senderId == account.uid
                             val senderAccount = userCache[message.senderId]
                             val sender =

--- a/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionsOverviewScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionsOverviewScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.meeplemeet.model.account.Account
+import com.github.meeplemeet.model.account.RelationshipStatus
 import com.github.meeplemeet.model.discussions.Discussion
 import com.github.meeplemeet.model.discussions.DiscussionViewModel
 import com.github.meeplemeet.model.discussions.DiscussionsOverviewViewModel
@@ -163,6 +164,7 @@ fun DiscussionsOverviewScreen(
 
                   val senderId = preview.lastMessageSender
                   val isMe = (senderId == account.uid)
+                  val senderBlocked = account.relationships[senderId] == RelationshipStatus.BLOCKED
                   val senderName by
                       produceState(
                           key1 = senderId,
@@ -175,7 +177,8 @@ fun DiscussionsOverviewScreen(
                           }
 
                   val msgText = buildString {
-                    if (preview.lastMessage.isBlank()) {
+                    if (senderBlocked) append("Hidden: blocked sender")
+                    else if (preview.lastMessage.isBlank()) {
                       append(DiscussionCommons.NO_MESSAGES_DEFAULT_TEXT)
                     } else {
                       if (isMe) append("${DiscussionCommons.YOU_SENDER_NAME}: ")
@@ -244,7 +247,7 @@ private fun EmptyDiscussionsListText() {
  */
 @Composable
 @Preview(showBackground = true)
-public fun DiscussionCard(
+fun DiscussionCard(
     modifier: Modifier = Modifier,
     discussionName: String = "Hello",
     lastMsg: String = "Hello world",


### PR DESCRIPTION
Messages from blocked users are now filtered from both the discussion thread view and the discussions overview preview. In the overview, blocked sender messages display "Hidden: blocked sender" instead of the
  actual message content. In the discussion thread, messages from blocked users are not rendered at all.

Also fixes FriendsScreen to properly react to relationship changes by updating the LaunchedEffect dependency from account.uid to account.relationships.

  ---
  🤖 Generated with https://claude.com/claude-code