### PR TITLE
Optimize game name fetch

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/integration/FirestoreMarkerPreviewTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/FirestoreMarkerPreviewTest.kt
@@ -103,6 +103,7 @@ class FirestoreMarkerPreviewTest : FirestoreTests() {
               baseDiscussion.uid,
               "Epic Game Night",
               testGame1.uid,
+              testGame1.name,
               testTimestamp,
               testLocation,
               testAccount.uid)
@@ -555,6 +556,7 @@ class FirestoreMarkerPreviewTest : FirestoreTests() {
             discussion.uid,
             "Specific Session",
             testGame1.uid,
+            testGame1.name,
             specificDate,
             testLocation,
             testAccount.uid)
@@ -603,6 +605,7 @@ class FirestoreMarkerPreviewTest : FirestoreTests() {
             discussion2.uid,
             "Train Game Night",
             testGame2.uid,
+            testGame2.name,
             testTimestamp,
             testLocation,
             testAccount.uid)
@@ -703,7 +706,13 @@ class FirestoreMarkerPreviewTest : FirestoreTests() {
       val disc = discussionRepository.createDiscussion("Session $i", "Test", testAccount.uid)
       sessions.add(
           sessionRepository.createSession(
-              disc.uid, "Game $i", testGame1.uid, testTimestamp, testLocation, testAccount.uid))
+              disc.uid,
+              "Game $i",
+              testGame1.uid,
+              testGame1.name,
+              testTimestamp,
+              testLocation,
+              testAccount.uid))
     }
 
     // Create mixed list of all pins

--- a/app/src/androidTest/java/com/github/meeplemeet/integration/FirestoreSessionTests.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/FirestoreSessionTests.kt
@@ -90,6 +90,7 @@ class FirestoreSessionTests : FirestoreTests() {
         baseDiscussion,
         "Catan Night",
         "game123",
+        "Game 123",
         testTimestamp,
         testLocation,
         account1,
@@ -101,13 +102,21 @@ class FirestoreSessionTests : FirestoreTests() {
     assertNotNull(updatedDiscussion.session)
     assertEquals("Catan Night", updatedDiscussion.session?.name)
     assertEquals("game123", updatedDiscussion.session?.gameId)
+    assertEquals("Game 123", updatedDiscussion.session?.gameName)
   }
 
   @Test
   fun canUpdateSessionName() = runTest {
     // First create a session
     viewModel.createSession(
-        account1, baseDiscussion, "Catan Night", "game123", testTimestamp, testLocation, account1)
+        account1,
+        baseDiscussion,
+        "Catan Night",
+        "game123",
+        "Game 123",
+        testTimestamp,
+        testLocation,
+        account1)
     advanceUntilIdle()
 
     val discussionWithSession = discussionRepository.getDiscussion(baseDiscussion.uid)
@@ -125,7 +134,14 @@ class FirestoreSessionTests : FirestoreTests() {
   fun canUpdateSessionLocation() = runTest {
     // First create a session
     viewModel.createSession(
-        account1, baseDiscussion, "Catan Night", "game123", testTimestamp, testLocation, account1)
+        account1,
+        baseDiscussion,
+        "Catan Night",
+        "game123",
+        "Game 123",
+        testTimestamp,
+        testLocation,
+        account1)
     advanceUntilIdle()
 
     val discussionWithSession = discussionRepository.getDiscussion(baseDiscussion.uid)
@@ -146,7 +162,14 @@ class FirestoreSessionTests : FirestoreTests() {
   fun canUpdateSessionDate() = runTest {
     // First create a session
     viewModel.createSession(
-        account1, baseDiscussion, "Catan Night", "game123", testTimestamp, testLocation, account1)
+        account1,
+        baseDiscussion,
+        "Catan Night",
+        "game123",
+        "Game 123",
+        testTimestamp,
+        testLocation,
+        account1)
     advanceUntilIdle()
 
     val discussionWithSession = discussionRepository.getDiscussion(baseDiscussion.uid)
@@ -167,7 +190,14 @@ class FirestoreSessionTests : FirestoreTests() {
   fun canAddUserToSession() = runTest {
     // First create a session
     viewModel.createSession(
-        account1, baseDiscussion, "Catan Night", "game123", testTimestamp, testLocation, account1)
+        account1,
+        baseDiscussion,
+        "Catan Night",
+        "game123",
+        "Game 123",
+        testTimestamp,
+        testLocation,
+        account1)
     advanceUntilIdle()
 
     val discussionWithSession = discussionRepository.getDiscussion(baseDiscussion.uid)
@@ -186,7 +216,14 @@ class FirestoreSessionTests : FirestoreTests() {
   fun canRemoveUserFromSession() = runTest {
     // First create a session with two participants
     viewModel.createSession(
-        account1, baseDiscussion, "Catan Night", "game123", testTimestamp, testLocation, account2)
+        account1,
+        baseDiscussion,
+        "Catan Night",
+        "game123",
+        "Game 123",
+        testTimestamp,
+        testLocation,
+        account2)
     advanceUntilIdle()
 
     val discussionWithSession = discussionRepository.getDiscussion(baseDiscussion.uid)
@@ -204,7 +241,14 @@ class FirestoreSessionTests : FirestoreTests() {
   fun canUpdateMultipleSessionFields() = runTest {
     // First create a session
     viewModel.createSession(
-        account1, baseDiscussion, "Catan Night", "game123", testTimestamp, testLocation, account1)
+        account1,
+        baseDiscussion,
+        "Catan Night",
+        "game123",
+        "Game 123",
+        testTimestamp,
+        testLocation,
+        account1)
     advanceUntilIdle()
 
     val discussionWithSession = discussionRepository.getDiscussion(baseDiscussion.uid)
@@ -228,7 +272,14 @@ class FirestoreSessionTests : FirestoreTests() {
   fun nonParticipantCannotUpdateSession() = runTest {
     // First create a session
     viewModel.createSession(
-        account1, baseDiscussion, "Catan Night", "game123", testTimestamp, testLocation, account1)
+        account1,
+        baseDiscussion,
+        "Catan Night",
+        "game123",
+        "Game 123",
+        testTimestamp,
+        testLocation,
+        account1)
     advanceUntilIdle()
 
     val discussionWithSession = discussionRepository.getDiscussion(baseDiscussion.uid)
@@ -241,7 +292,14 @@ class FirestoreSessionTests : FirestoreTests() {
   fun canDeleteSession() = runBlocking {
     // First create a session
     viewModel.createSession(
-        account1, baseDiscussion, "Catan Night", "game123", testTimestamp, testLocation, account1)
+        account1,
+        baseDiscussion,
+        "Catan Night",
+        "game123",
+        "Game 123",
+        testTimestamp,
+        testLocation,
+        account1)
     Thread.sleep(1500) // Wait for Firestore
 
     val discussionWithSession = discussionRepository.getDiscussion(baseDiscussion.uid)
@@ -258,7 +316,14 @@ class FirestoreSessionTests : FirestoreTests() {
   fun nonParticipantCannotDeleteSession() = runTest {
     // First create a session
     viewModel.createSession(
-        account1, baseDiscussion, "Catan Night", "game123", testTimestamp, testLocation, account1)
+        account1,
+        baseDiscussion,
+        "Catan Night",
+        "game123",
+        "Game 123",
+        testTimestamp,
+        testLocation,
+        account1)
     advanceUntilIdle()
 
     val discussionWithSession = discussionRepository.getDiscussion(baseDiscussion.uid)
@@ -268,22 +333,32 @@ class FirestoreSessionTests : FirestoreTests() {
   }
 
   @Test
-  fun canUpdateSessionGameId() = runTest {
+  fun canUpdateSessionGameIdAndName() = runTest {
     // First create a session
     viewModel.createSession(
-        account1, baseDiscussion, "Catan Night", "game123", testTimestamp, testLocation, account1)
+        account1,
+        baseDiscussion,
+        "Catan Night",
+        "game123",
+        "Game 123",
+        testTimestamp,
+        testLocation,
+        account1)
     advanceUntilIdle()
 
     val discussionWithSession = discussionRepository.getDiscussion(baseDiscussion.uid)
 
     val newGameId = "game456"
+    val newGameName = "Game 456"
 
     // Now update the session gameId
-    viewModel.updateSession(account1, discussionWithSession, gameId = newGameId)
+    viewModel.updateSession(
+        account1, discussionWithSession, gameId = newGameId, gameName = newGameName)
     advanceUntilIdle()
 
     val result = discussionRepository.getDiscussion(baseDiscussion.uid)
     assertEquals(newGameId, result.session?.gameId)
+    assertEquals(newGameName, result.session?.gameName)
     assertEquals("Catan Night", result.session?.name)
   }
 
@@ -300,6 +375,7 @@ class FirestoreSessionTests : FirestoreTests() {
         discussionWithTwoAdmins,
         "Catan Night",
         "game123",
+        "Game 123",
         testTimestamp,
         testLocation,
         account1,
@@ -322,7 +398,7 @@ class FirestoreSessionTests : FirestoreTests() {
   @Test
   fun creatingSessionUpdatesDiscussionState() = runTest {
     viewModel.createSession(
-        account1, baseDiscussion, "Catan Night", "game123", testTimestamp, testLocation)
+        account1, baseDiscussion, "Catan Night", "game123", "Game 123", testTimestamp, testLocation)
     advanceUntilIdle()
 
     val result = discussionRepository.getDiscussion(baseDiscussion.uid)
@@ -340,7 +416,14 @@ class FirestoreSessionTests : FirestoreTests() {
     // The test would need to be restructured or removed in a real integration test environment
     // For now, we'll just verify that creating a session works normally
     viewModel.createSession(
-        account1, baseDiscussion, "Catan Night", "game123", testTimestamp, testLocation, account1)
+        account1,
+        baseDiscussion,
+        "Catan Night",
+        "game123",
+        "Game 123",
+        testTimestamp,
+        testLocation,
+        account1)
     advanceUntilIdle()
 
     val result = discussionRepository.getDiscussion(baseDiscussion.uid)
@@ -353,7 +436,14 @@ class FirestoreSessionTests : FirestoreTests() {
     // failures
     // First create a session
     viewModel.createSession(
-        account1, baseDiscussion, "Catan Night", "game123", testTimestamp, testLocation, account1)
+        account1,
+        baseDiscussion,
+        "Catan Night",
+        "game123",
+        "Game 123",
+        testTimestamp,
+        testLocation,
+        account1)
     advanceUntilIdle()
 
     val discussionWithSession = discussionRepository.getDiscussion(baseDiscussion.uid)
@@ -372,7 +462,14 @@ class FirestoreSessionTests : FirestoreTests() {
     // failures
     // First create a session
     viewModel.createSession(
-        account1, baseDiscussion, "Catan Night", "game123", testTimestamp, testLocation, account1)
+        account1,
+        baseDiscussion,
+        "Catan Night",
+        "game123",
+        "Game 123",
+        testTimestamp,
+        testLocation,
+        account1)
     Thread.sleep(1500) // Wait for Firestore
 
     val discussionWithSession = discussionRepository.getDiscussion(baseDiscussion.uid)
@@ -388,7 +485,14 @@ class FirestoreSessionTests : FirestoreTests() {
   @Test(expected = PermissionDeniedException::class)
   fun nonParticipantCannotCreateSessionEvenWithValidData() = runTest {
     viewModel.createSession(
-        account3, baseDiscussion, "Valid Session", "game123", testTimestamp, testLocation, account3)
+        account3,
+        baseDiscussion,
+        "Valid Session",
+        "game123",
+        "Game 123",
+        testTimestamp,
+        testLocation,
+        account3)
     advanceUntilIdle()
   }
 
@@ -399,6 +503,7 @@ class FirestoreSessionTests : FirestoreTests() {
         baseDiscussion,
         "Catan Night",
         "game123",
+        "Game 123",
         testTimestamp,
         testLocation,
         account3) // account3 not in discussion
@@ -424,6 +529,7 @@ class FirestoreSessionTests : FirestoreTests() {
             baseDiscussion.uid,
             "Real Catan Night",
             "game789",
+            "Game 789",
             testTimestamp,
             testLocation,
             account1.uid,
@@ -446,6 +552,7 @@ class FirestoreSessionTests : FirestoreTests() {
             baseDiscussion.uid,
             "Original Name",
             "game123",
+            "Game 123",
             testTimestamp,
             testLocation,
             account1.uid)
@@ -464,7 +571,13 @@ class FirestoreSessionTests : FirestoreTests() {
 
     val withSession =
         realSessionRepo.createSession(
-            baseDiscussion.uid, "Session", "game123", testTimestamp, testLocation, account1.uid)
+            baseDiscussion.uid,
+            "Session",
+            "game123",
+            "Game 123",
+            testTimestamp,
+            testLocation,
+            account1.uid)
 
     val newLocation = Location(latitude = 51.5074, longitude = -0.1278, name = "London")
     val updated = realSessionRepo.updateSession(withSession.uid, location = newLocation)
@@ -479,7 +592,13 @@ class FirestoreSessionTests : FirestoreTests() {
 
     val withSession =
         realSessionRepo.createSession(
-            baseDiscussion.uid, "Session", "game123", testTimestamp, testLocation, account1.uid)
+            baseDiscussion.uid,
+            "Session",
+            "game123",
+            "Game 123",
+            testTimestamp,
+            testLocation,
+            account1.uid)
 
     val newDate = Timestamp(testTimestamp.seconds + 3600, 0) // +1 hour
     val updated = realSessionRepo.updateSession(withSession.uid, date = newDate)
@@ -488,16 +607,24 @@ class FirestoreSessionTests : FirestoreTests() {
   }
 
   @Test
-  fun repositoryCanUpdateSessionGameId() = runBlocking {
+  fun repositoryCanUpdateSessionGameIdAndName() = runBlocking {
     val realSessionRepo = SessionRepository()
 
     val withSession =
         realSessionRepo.createSession(
-            baseDiscussion.uid, "Session", "game123", testTimestamp, testLocation, account1.uid)
+            baseDiscussion.uid,
+            "Session",
+            "game123",
+            "Game 123",
+            testTimestamp,
+            testLocation,
+            account1.uid)
 
-    val updated = realSessionRepo.updateSession(withSession.uid, gameId = "game999")
+    val updated =
+        realSessionRepo.updateSession(withSession.uid, gameId = "game999", gameName = "Game 999")
 
     assertEquals("game999", updated.session?.gameId)
+    assertEquals("Game 999", updated.session?.gameName)
     assertEquals("Session", updated.session?.name)
   }
 
@@ -507,7 +634,13 @@ class FirestoreSessionTests : FirestoreTests() {
 
     val withSession =
         realSessionRepo.createSession(
-            baseDiscussion.uid, "Session", "game123", testTimestamp, testLocation, account1.uid)
+            baseDiscussion.uid,
+            "Session",
+            "game123",
+            "Game 123",
+            testTimestamp,
+            testLocation,
+            account1.uid)
 
     val newParticipants = listOf(account1.uid, account2.uid, account3.uid)
     val updated =
@@ -523,10 +656,17 @@ class FirestoreSessionTests : FirestoreTests() {
 
     val withSession =
         realSessionRepo.createSession(
-            baseDiscussion.uid, "Original", "game123", testTimestamp, testLocation, account1.uid)
+            baseDiscussion.uid,
+            "Original",
+            "game123",
+            "Game 123",
+            testTimestamp,
+            testLocation,
+            account1.uid)
 
     val newName = "Updated Name"
     val newGameId = "game999"
+    val newGameName = "Game 999"
     val newDate = Timestamp(testTimestamp.seconds + 7200, 0)
     val newLocation = Location(48.8566, 2.3522, "Paris")
     val newParticipants = listOf(account1.uid, account2.uid)
@@ -536,6 +676,7 @@ class FirestoreSessionTests : FirestoreTests() {
             withSession.uid,
             name = newName,
             gameId = newGameId,
+            gameName = newGameName,
             date = newDate,
             location = newLocation,
             newParticipantList = newParticipants)
@@ -553,10 +694,50 @@ class FirestoreSessionTests : FirestoreTests() {
 
     val withSession =
         realSessionRepo.createSession(
-            baseDiscussion.uid, "Session", "game123", testTimestamp, testLocation, account1.uid)
+            baseDiscussion.uid,
+            "Session",
+            "game123",
+            "Game 123",
+            testTimestamp,
+            testLocation,
+            account1.uid)
 
     // This should throw IllegalArgumentException
     realSessionRepo.updateSession(withSession.uid)
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun updateSessionThrowsWhenOnlyGameIdProvided() = runTest {
+    val realSessionRepo = SessionRepository()
+
+    val withSession =
+        realSessionRepo.createSession(
+            baseDiscussion.uid,
+            "Catan Night",
+            "game123",
+            "Game 123",
+            testTimestamp,
+            testLocation,
+            account1.uid)
+
+    realSessionRepo.updateSession(withSession.uid, gameId = "NoGameNameProvided")
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun updateSessionThrowsWhenOnlyGameNameProvided() = runTest {
+    val realSessionRepo = SessionRepository()
+
+    val withSession =
+        realSessionRepo.createSession(
+            baseDiscussion.uid,
+            "Catan Night",
+            "game123",
+            "Game 123",
+            testTimestamp,
+            testLocation,
+            account1.uid)
+
+    realSessionRepo.updateSession(withSession.uid, gameName = "NoGameIdProvided")
   }
 
   @Test
@@ -565,7 +746,13 @@ class FirestoreSessionTests : FirestoreTests() {
 
     val withSession =
         realSessionRepo.createSession(
-            baseDiscussion.uid, "Session", "game123", testTimestamp, testLocation, account1.uid)
+            baseDiscussion.uid,
+            "Session",
+            "game123",
+            "Game 123",
+            testTimestamp,
+            testLocation,
+            account1.uid)
 
     assertNotNull(withSession.session)
 
@@ -582,7 +769,12 @@ class FirestoreSessionTests : FirestoreTests() {
 
     val updatedDiscussion =
         realSessionRepo.createSession(
-            baseDiscussion.uid, "Planning Session", "game123", testTimestamp, testLocation)
+            baseDiscussion.uid,
+            "Planning Session",
+            "game123",
+            "Game 123",
+            testTimestamp,
+            testLocation)
 
     assertNotNull(updatedDiscussion.session)
     assertEquals(0, updatedDiscussion.session?.participants?.size)
@@ -594,6 +786,7 @@ class FirestoreSessionTests : FirestoreTests() {
 
     val originalName = "Original Session"
     val originalGameId = "game123"
+    val originalGameName = "Game 123"
     val originalLocation = testLocation
 
     val withSession =
@@ -601,6 +794,7 @@ class FirestoreSessionTests : FirestoreTests() {
             baseDiscussion.uid,
             originalName,
             originalGameId,
+            originalGameName,
             testTimestamp,
             originalLocation,
             account1.uid)
@@ -626,6 +820,7 @@ class FirestoreSessionTests : FirestoreTests() {
             baseDiscussion.uid,
             "First Session",
             "game111",
+            "Game 111",
             testTimestamp,
             testLocation,
             account1.uid)
@@ -639,6 +834,7 @@ class FirestoreSessionTests : FirestoreTests() {
             baseDiscussion.uid,
             "Second Session",
             "game222",
+            "Game 222",
             Timestamp(testTimestamp.seconds + 3600, 0),
             Location(40.7128, -74.0060, "New York"),
             account2.uid)
@@ -654,7 +850,13 @@ class FirestoreSessionTests : FirestoreTests() {
     val realSessionRepo = SessionRepository()
 
     realSessionRepo.createSession(
-        baseDiscussion.uid, "GeoPin Session", "game456", testTimestamp, testLocation, account1.uid)
+        baseDiscussion.uid,
+        "GeoPin Session",
+        "game456",
+        "Game 456",
+        testTimestamp,
+        testLocation,
+        account1.uid)
 
     val geoPinSnapshot = geoPinRepository.collection.document(baseDiscussion.uid).get().await()
 
@@ -667,7 +869,13 @@ class FirestoreSessionTests : FirestoreTests() {
     val realSessionRepo = SessionRepository()
 
     realSessionRepo.createSession(
-        baseDiscussion.uid, "To Delete", "game123", testTimestamp, testLocation, account1.uid)
+        baseDiscussion.uid,
+        "To Delete",
+        "game123",
+        "Game 123",
+        testTimestamp,
+        testLocation,
+        account1.uid)
 
     val beforeDelete = geoPinRepository.collection.document(baseDiscussion.uid).get().await()
     assert(beforeDelete.exists())
@@ -683,7 +891,13 @@ class FirestoreSessionTests : FirestoreTests() {
     val realSessionRepo = SessionRepository()
 
     realSessionRepo.createSession(
-        baseDiscussion.uid, "Session", "game123", testTimestamp, testLocation, account1.uid)
+        baseDiscussion.uid,
+        "Session",
+        "game123",
+        "Game 123",
+        testTimestamp,
+        testLocation,
+        account1.uid)
 
     val geoPinRef = geoPinRepository.collection.document(baseDiscussion.uid)
 
@@ -795,7 +1009,14 @@ class FirestoreSessionTests : FirestoreTests() {
   fun nonAdminCanLeaveSession() = runTest {
     // First create a session with two participants
     viewModel.createSession(
-        account1, baseDiscussion, "Catan Night", "game123", testTimestamp, testLocation, account2)
+        account1,
+        baseDiscussion,
+        "Catan Night",
+        "game123",
+        "Game 123",
+        testTimestamp,
+        testLocation,
+        account2)
     advanceUntilIdle()
 
     val discussionWithSession = discussionRepository.getDiscussion(baseDiscussion.uid)
@@ -822,6 +1043,7 @@ class FirestoreSessionTests : FirestoreTests() {
         updatedBaseDiscussion,
         "Catan Night",
         "game123",
+        "Game 123",
         testTimestamp,
         testLocation,
         account1,
@@ -849,6 +1071,7 @@ class FirestoreSessionTests : FirestoreTests() {
         updatedBaseDiscussion,
         "Catan Night",
         "game123",
+        "Game 123",
         testTimestamp,
         testLocation,
         account1,
@@ -874,12 +1097,12 @@ class FirestoreSessionTests : FirestoreTests() {
       // create session for even indices including account1
       if (i % 2 == 0) {
         realSessionRepo.createSession(
-            d.uid, "S$i", "game$i", testTimestamp, testLocation, account1.uid)
+            d.uid, "S$i", "game$i", "Game$i", testTimestamp, testLocation, account1.uid)
         discussionsWithSession += d.uid
       } else {
         // create session without account1
         realSessionRepo.createSession(
-            d.uid, "S$i", "game$i", testTimestamp, testLocation, account2.uid)
+            d.uid, "S$i", "game$i", "Game$i", testTimestamp, testLocation, account2.uid)
         otherDiscussions += d.uid
       }
     }
@@ -900,7 +1123,7 @@ class FirestoreSessionTests : FirestoreTests() {
     repeat(7) { i ->
       val d = discussionRepository.createDiscussion("P$i", "desc", account1.uid)
       realSessionRepo.createSession(
-          d.uid, "PS$i", "gameP$i", testTimestamp, testLocation, account1.uid)
+          d.uid, "PS$i", "gameP$i", "GameP$i", testTimestamp, testLocation, account1.uid)
       createdIds += d.uid
     }
 
@@ -915,7 +1138,14 @@ class FirestoreSessionTests : FirestoreTests() {
   fun removingLastAdminDeletesSession() = runBlocking {
     // Create a session with only one admin participant
     viewModel.createSession(
-        account1, baseDiscussion, "Catan Night", "game123", testTimestamp, testLocation, account1)
+        account1,
+        baseDiscussion,
+        "Catan Night",
+        "game123",
+        "Game 123",
+        testTimestamp,
+        testLocation,
+        account1)
     Thread.sleep(1500)
 
     val discussionWithSession = discussionRepository.getDiscussion(baseDiscussion.uid)
@@ -941,6 +1171,7 @@ class FirestoreSessionTests : FirestoreTests() {
         updatedBaseDiscussion,
         "Catan Night",
         "game123",
+        "Game 123",
         testTimestamp,
         testLocation,
         account1,

--- a/app/src/androidTest/java/com/github/meeplemeet/integration/MapViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/MapViewModelTest.kt
@@ -166,6 +166,7 @@ class MapViewModelTest : FirestoreTests() {
         discussion.uid,
         "Chess Night",
         testGame.uid,
+        testGame.name,
         Timestamp.now(),
         testLocation,
         testAccount1.uid)

--- a/app/src/androidTest/java/com/github/meeplemeet/integration/NotificationTests.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/NotificationTests.kt
@@ -304,7 +304,7 @@ class NotificationTests : FirestoreTests() {
     val testLocation = com.github.meeplemeet.model.shared.location.Location(46.5197, 6.5665, "EPFL")
     val testTimestamp = com.google.firebase.Timestamp.now()
     sessionRepository.createSession(
-        discussion.uid, "Game Night", "game123", testTimestamp, testLocation, alice.uid)
+        discussion.uid, "Game Night", "game123", "Game 123", testTimestamp, testLocation, alice.uid)
 
     accountRepository.sendJoinSessionNotification(alice.uid, bob.uid, discussion)
 

--- a/app/src/androidTest/java/com/github/meeplemeet/integration/NotificationsViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/NotificationsViewModelTest.kt
@@ -25,8 +25,7 @@ class NotificationsViewModelTest : FirestoreTests() {
             accountRepository = accountRepository,
             handlesRepository = handlesRepository,
             imageRepository = imageRepository,
-            discussionRepository = discussionRepository,
-            gameRepository = gameRepository)
+            discussionRepository = discussionRepository)
 
     // Sign in anonymously for Firebase access
     auth.signInAnonymously().await()

--- a/app/src/androidTest/java/com/github/meeplemeet/integration/SessionOverviewViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/SessionOverviewViewModelTest.kt
@@ -116,18 +116,6 @@ class SessionOverviewViewModelTest : FirestoreTests() {
   }
 
   @Test
-  fun getGameNameByGameId_returnsName_whenGameExists() = runBlocking {
-    val name = viewModel.getGameNameByGameId(existingGameId)
-    assertEquals("Chess", name)
-  }
-
-  @Test
-  fun getGameNameByGameId_returnsNull_whenGameMissing() = runBlocking {
-    val name = viewModel.getGameNameByGameId("nonexistent")
-    assertNull(name)
-  }
-
-  @Test
   fun getArchivedSessionPhotoUrls_returnsPhotoUrls() = runBlocking {
     // Archive a session with a photo URL
     val discussion = discussionRepository.createDiscussion("Archive Photo", "Test", account.uid)

--- a/app/src/androidTest/java/com/github/meeplemeet/integration/SessionOverviewViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/SessionOverviewViewModelTest.kt
@@ -63,7 +63,13 @@ class SessionOverviewViewModelTest : FirestoreTests() {
     val game = gameRepository.getGameById(existingGameId)
 
     sessionRepository.createSession(
-        discussion.uid, "Chess Night", game.uid, Timestamp.now(), testLocation, account.uid)
+        discussion.uid,
+        "Chess Night",
+        game.uid,
+        game.name,
+        Timestamp.now(),
+        testLocation,
+        account.uid)
 
     delay(100) // wait for Firestore snapshot
 
@@ -83,7 +89,13 @@ class SessionOverviewViewModelTest : FirestoreTests() {
     val game = gameRepository.getGameById(existingGameId)
 
     sessionRepository.createSession(
-        discussion.uid, "Delete Me", game.uid, Timestamp.now(), testLocation, account.uid)
+        discussion.uid,
+        "Delete Me",
+        game.uid,
+        game.name,
+        Timestamp.now(),
+        testLocation,
+        account.uid)
     delay(100)
     assertEquals(
         1,
@@ -124,6 +136,7 @@ class SessionOverviewViewModelTest : FirestoreTests() {
         discussion.uid,
         "Archive Photo Session",
         game.uid,
+        game.name,
         Timestamp.now(),
         testLocation,
         account.uid)
@@ -147,6 +160,7 @@ class SessionOverviewViewModelTest : FirestoreTests() {
         discussion.uid,
         "Find By Photo Session",
         game.uid,
+        game.name,
         Timestamp.now(),
         testLocation,
         account.uid)
@@ -176,7 +190,13 @@ class SessionOverviewViewModelTest : FirestoreTests() {
     val discussion = discussionRepository.createDiscussion("Single Archive", "Test", account.uid)
     val game = gameRepository.getGameById(existingGameId)
     sessionRepository.createSession(
-        discussion.uid, "Single Session", game.uid, Timestamp.now(), testLocation, account.uid)
+        discussion.uid,
+        "Single Session",
+        game.uid,
+        game.name,
+        Timestamp.now(),
+        testLocation,
+        account.uid)
     val photoUrl = "https://example.com/single_photo.webp"
     val archivedId = java.util.UUID.randomUUID().toString()
     sessionRepository.archiveSession(discussion.uid, archivedId, photoUrl)
@@ -205,6 +225,7 @@ class SessionOverviewViewModelTest : FirestoreTests() {
         discussion.uid,
         "ViewModel Find By Photo Session",
         game.uid,
+        game.name,
         Timestamp.now(),
         testLocation,
         account.uid)
@@ -249,7 +270,13 @@ class SessionOverviewViewModelTest : FirestoreTests() {
         Timestamp(java.util.Date(System.currentTimeMillis() - 25 * 60 * 60 * 1000L))
 
     sessionRepository.createSession(
-        discussion.uid, "Past Chess Night", game.uid, twentyFiveHoursAgo, testLocation, account.uid)
+        discussion.uid,
+        "Past Chess Night",
+        game.uid,
+        game.name,
+        twentyFiveHoursAgo,
+        testLocation,
+        account.uid)
 
     delay(1000)
 
@@ -269,7 +296,13 @@ class SessionOverviewViewModelTest : FirestoreTests() {
     val oneHourFromNow = Timestamp(System.currentTimeMillis() / 1000 + (1 * 60 * 60), 0)
 
     sessionRepository.createSession(
-        discussion.uid, "Future Chess Night", game.uid, oneHourFromNow, testLocation, account.uid)
+        discussion.uid,
+        "Future Chess Night",
+        game.uid,
+        game.name,
+        oneHourFromNow,
+        testLocation,
+        account.uid)
 
     delay(100)
 
@@ -303,7 +336,13 @@ class SessionOverviewViewModelTest : FirestoreTests() {
     val sessionDate = Timestamp(System.currentTimeMillis() / 1000 - (1 * 60 * 60), 0)
 
     sessionRepository.createSession(
-        discussion.uid, "Manual Archive Night", game.uid, sessionDate, testLocation, account.uid)
+        discussion.uid,
+        "Manual Archive Night",
+        game.uid,
+        game.name,
+        sessionDate,
+        testLocation,
+        account.uid)
 
     delay(100)
 

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/MapScreenTest.kt
@@ -621,6 +621,7 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
             discussion.uid,
             "Session Preview Test",
             testGame.uid,
+            testGame.name,
             Timestamp.now(),
             testLocation,
             regularAccount.uid)
@@ -678,6 +679,7 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
             discussion.uid,
             "Private Session",
             testGame.uid,
+            testGame.name,
             Timestamp.now(),
             testLocation,
             shopOwnerAccount.uid)

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/NotificationsTabTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/NotificationsTabTest.kt
@@ -88,8 +88,7 @@ class NotificationsTabTest : FirestoreTests() {
             accountRepository = accountRepository,
             handlesRepository = handlesRepository,
             imageRepository = imageRepository,
-            discussionRepository = discussionRepository,
-            gameRepository = gameRepository)
+            discussionRepository = discussionRepository)
     navViewModel = NavigationViewModel(accountRepository)
 
     runBlocking {

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/NotificationsTabTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/NotificationsTabTest.kt
@@ -136,6 +136,7 @@ class NotificationsTabTest : FirestoreTests() {
                   sessionDiscussion.uid,
                   "Catan Session",
                   gameId,
+                  game.name,
                   Timestamp(Date(System.currentTimeMillis() + 86400000)),
                   location = Location(0.0, 0.0, "Game Store"),
                   participants = arrayOf(otherUser.uid))

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/SessionEditScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/SessionEditScreenTest.kt
@@ -101,6 +101,7 @@ class SessionEditScreenTest : FirestoreTests() {
         discussionId = discussion.uid,
         name = "Editable Session",
         gameId = "",
+        gameName = "",
         date = futureTimestamp,
         location = Location(name = "Meeple Café"),
         admin.uid,

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/SessionScreenArchiveTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/SessionScreenArchiveTest.kt
@@ -97,6 +97,7 @@ class SessionScreenArchiveTest : FirestoreTests() {
         discussionId = discussion.uid,
         name = "Archive Session",
         gameId = sessionGame.uid,
+        gameName = sessionGame.name,
         date = Timestamp(sessionDate),
         location = Location(name = "Test Location"),
         admin.uid,

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/SessionScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/SessionScreenTest.kt
@@ -107,6 +107,7 @@ class SessionViewerScreenTest : FirestoreTests() {
         discussionId = baseDiscussion.uid,
         name = "Friday Night Session",
         gameId = sessionGame.uid,
+        gameName = sessionGame.name,
         date = futureDate,
         location = Location(name = "Meeple Café"),
         *participantIds.toTypedArray())
@@ -379,6 +380,7 @@ class SessionViewerScreenTest : FirestoreTests() {
           discussionId = soloDiscussion.uid,
           name = "Solo Admin Session",
           gameId = sessionGame.uid,
+          gameName = sessionGame.name,
           date = futureDate,
           location = Location(name = "Solo Place"),
           soloAdmin.uid)

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/SessionsOverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/SessionsOverviewScreenTest.kt
@@ -91,7 +91,13 @@ class SessionsOverviewScreenTest : FirestoreTests() {
           val game = gameRepository.getGameById(testGameId)
           val futureDate = Timestamp(java.util.Date(System.currentTimeMillis() + 86400000))
           sessionRepository.createSession(
-              discussion.uid, "Chess Night", game.uid, futureDate, testLocation, account.uid)
+              discussion.uid,
+              "Chess Night",
+              game.uid,
+              game.name,
+              futureDate,
+              testLocation,
+              account.uid)
           compose.waitUntil { emptyText().isNotDisplayed() }
           sessionCard(discussion.uid).assertIsDisplayed()
         }
@@ -105,7 +111,13 @@ class SessionsOverviewScreenTest : FirestoreTests() {
           val game = gameRepository.getGameById(testGameId)
           val futureDate = Timestamp(java.util.Date(System.currentTimeMillis() + 86400000))
           sessionRepository.createSession(
-              discussion.uid, "Tap Night", game.uid, futureDate, testLocation, account.uid)
+              discussion.uid,
+              "Tap Night",
+              game.uid,
+              game.name,
+              futureDate,
+              testLocation,
+              account.uid)
           compose.waitUntil { sessionCard(discussion.uid).isDisplayed() }
           sessionCard(discussion.uid).performClick()
           assertEquals(discussion.uid, capturedDiscussionId)
@@ -120,7 +132,13 @@ class SessionsOverviewScreenTest : FirestoreTests() {
           val game = gameRepository.getGameById(testGameId)
           val futureDate = Timestamp(java.util.Date(System.currentTimeMillis() + 10000000))
           sessionRepository.createSession(
-              discussion.uid, "Vanish Night", game.uid, futureDate, testLocation, account.uid)
+              discussion.uid,
+              "Vanish Night",
+              game.uid,
+              game.name,
+              futureDate,
+              testLocation,
+              account.uid)
           compose.waitUntil { sessionCard(discussion.uid).isDisplayed() }
 
           sessionRepository.deleteSession(discussion.uid)
@@ -141,7 +159,13 @@ class SessionsOverviewScreenTest : FirestoreTests() {
               discussionRepository.createDiscussion("Past Session", "Old times", account.uid)
           val game = gameRepository.getGameById(testGameId)
           sessionRepository.createSession(
-              discussion.uid, "Past Night", game.uid, pastDate, testLocation, account.uid)
+              discussion.uid,
+              "Past Night",
+              game.uid,
+              game.name,
+              pastDate,
+              testLocation,
+              account.uid)
 
           compose.onNodeWithTag(SessionsOverviewScreenTestTags.TEST_TAG_HISTORY).performClick()
           compose.waitUntil(4000) { compose.onNodeWithText("Past Night").isDisplayed() }
@@ -170,7 +194,13 @@ class SessionsOverviewScreenTest : FirestoreTests() {
 
           val pastDate = Timestamp(java.util.Date(System.currentTimeMillis() - (90 * 60 * 1000L)))
           sessionRepository.createSession(
-              discussion.uid, "Archive Night", game.uid, pastDate, testLocation, account.uid)
+              discussion.uid,
+              "Archive Night",
+              game.uid,
+              game.name,
+              pastDate,
+              testLocation,
+              account.uid)
 
           compose.waitUntil(2000) {
             compose.onNodeWithText("Automatically archives in", substring = true).isDisplayed()
@@ -228,6 +258,7 @@ class SessionsOverviewScreenTest : FirestoreTests() {
               discussion.uid,
               "User Night",
               game.uid,
+              game.name,
               withinTwoHours,
               testLocation,
               otherUid,
@@ -251,7 +282,13 @@ class SessionsOverviewScreenTest : FirestoreTests() {
           val futureDate =
               Timestamp(java.util.Date(System.currentTimeMillis() + (3 * 60 * 60 * 1000L)))
           sessionRepository.createSession(
-              discussion.uid, "Future Night", game.uid, futureDate, testLocation, account.uid)
+              discussion.uid,
+              "Future Night",
+              game.uid,
+              game.name,
+              futureDate,
+              testLocation,
+              account.uid)
 
           compose.waitUntil(2000) { sessionCard(discussion.uid).isDisplayed() }
 

--- a/app/src/androidTest/java/com/github/meeplemeet/utils/FirestoreTests.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/utils/FirestoreTests.kt
@@ -139,8 +139,6 @@ open class FirestoreTests {
 
   @Before
   fun testsSetup() {
-    RepositoryProvider.games = FirestoreGameRepository()
-
     InstrumentationRegistry.getInstrumentation().runOnMainSync {
       UiBehaviorConfig.hideBottomBarWhenInputFocused = false
       UiBehaviorConfig.clearFocusOnKeyboardHide = false

--- a/app/src/main/java/com/github/meeplemeet/MainActivity.kt
+++ b/app/src/main/java/com/github/meeplemeet/MainActivity.kt
@@ -43,6 +43,7 @@ import com.github.meeplemeet.model.offline.OfflineModeManager
 import com.github.meeplemeet.model.posts.PostRepository
 import com.github.meeplemeet.model.sessions.SessionRepository
 import com.github.meeplemeet.model.shared.game.CloudBggGameRepository
+import com.github.meeplemeet.model.shared.game.FirestoreGameRepository
 import com.github.meeplemeet.model.shared.game.GameRepository
 import com.github.meeplemeet.model.shared.location.LocationRepository
 import com.github.meeplemeet.model.shared.location.NominatimLocationRepository
@@ -144,7 +145,13 @@ object RepositoryProvider {
   val sessions: SessionRepository by lazy { SessionRepository() }
 
   /** Lazily initialized repository for board game data operations. */
-  var games: GameRepository = CloudBggGameRepository()
+  val games: GameRepository by lazy {
+    if (BuildConfig.DEBUG) {
+      FirestoreGameRepository()
+    } else {
+      CloudBggGameRepository()
+    }
+  }
 
   /** Lazily initialized repository for location operations. */
   val locations: LocationRepository by lazy { NominatimLocationRepository() }

--- a/app/src/main/java/com/github/meeplemeet/model/map/MarkerPreviewRepository.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/map/MarkerPreviewRepository.kt
@@ -3,7 +3,6 @@ package com.github.meeplemeet.model.map
 import com.github.meeplemeet.RepositoryProvider
 import com.github.meeplemeet.model.discussions.DiscussionRepository
 import com.github.meeplemeet.model.map.MarkerPreview.*
-import com.github.meeplemeet.model.shared.game.GameRepository
 import com.github.meeplemeet.model.shops.OpeningHours
 import com.github.meeplemeet.model.shops.ShopRepository
 import com.github.meeplemeet.model.space_renter.SpaceRenterRepository
@@ -29,7 +28,6 @@ class MarkerPreviewRepository(
     private val shopRepository: ShopRepository = RepositoryProvider.shops,
     private val discussionRepository: DiscussionRepository = RepositoryProvider.discussions,
     private val spaceRenterRepository: SpaceRenterRepository = RepositoryProvider.spaceRenters,
-    private val gameRepository: GameRepository = RepositoryProvider.games
 ) {
 
   /**
@@ -70,11 +68,10 @@ class MarkerPreviewRepository(
             async {
               val session = discussionRepository.getDiscussion(pin.uid).session
               session?.let {
-                val gameName = gameRepository.getGameById(it.gameId).name
                 SessionMarkerPreview(
                     title = it.name,
                     address = it.location.name,
-                    game = gameName,
+                    game = it.gameName,
                     date = formatTimeStamp(it.date))
               }
             }
@@ -128,7 +125,7 @@ class MarkerPreviewRepository(
           SessionMarkerPreview(
               title = it.name,
               address = it.location.name,
-              game = gameRepository.getGameById(it.gameId).name,
+              game = it.gameName,
               date = formatTimeStamp(it.date))
         }
       }

--- a/app/src/main/java/com/github/meeplemeet/model/sessions/CreateSessionViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/sessions/CreateSessionViewModel.kt
@@ -64,6 +64,7 @@ open class CreateSessionViewModel(
       discussion: Discussion,
       name: String,
       gameId: String,
+      gameName: String,
       date: Timestamp,
       location: Location,
       vararg participants: Account
@@ -85,6 +86,7 @@ open class CreateSessionViewModel(
           discussion.uid,
           name,
           gameId,
+          gameName,
           date,
           location,
           requester.uid,

--- a/app/src/main/java/com/github/meeplemeet/model/sessions/Session.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/sessions/Session.kt
@@ -11,7 +11,8 @@ import kotlinx.serialization.Serializable
  * complete game information.
  *
  * @property name The name or title of the session
- * @property gameId The if of the complete game object associated with this session
+ * @property gameId The id of the complete game object associated with this session
+ * @property gameName The name of the game as a shortcut for easy load
  * @property date The scheduled date and time of the session
  * @property location The physical or virtual location where the session will take place
  * @property participants List of participant IDs (typically user IDs) who are part of this session
@@ -21,6 +22,7 @@ import kotlinx.serialization.Serializable
 data class Session(
     val name: String = "",
     val gameId: String = "",
+    val gameName: String = "",
     val date: Timestamp = Timestamp.now(),
     val location: Location = Location(),
     val participants: List<String> = emptyList(),

--- a/app/src/main/java/com/github/meeplemeet/model/sessions/SessionEditViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/sessions/SessionEditViewModel.kt
@@ -56,16 +56,20 @@ class SessionEditViewModel(
    * @param discussion The discussion containing the session
    * @param name Optional new session name
    * @param gameId Optional new game ID
+   * @param gameName Optional new game name
    * @param date Optional new scheduled date and time
    * @param location Optional new location
    * @param participants Optional new list of participant IDs
    * @throws PermissionDeniedException if requester is not a discussion admin
+   * @throws IllegalArgumentException if if only one of {@code gameId} or {@code gameName} is
+   *   provided
    */
   fun updateSession(
       requester: Account,
       discussion: Discussion,
       name: String? = null,
       gameId: String? = null,
+      gameName: String? = null,
       date: Timestamp? = null,
       location: Location? = null,
       participants: List<String>? = null,
@@ -79,6 +83,7 @@ class SessionEditViewModel(
           discussionId = discussion.uid,
           name = name,
           gameId = gameId,
+          gameName = gameName,
           date = date,
           location = location,
           newParticipantList = participants,

--- a/app/src/main/java/com/github/meeplemeet/model/sessions/SessionOverviewViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/sessions/SessionOverviewViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.viewModelScope
 import com.github.meeplemeet.RepositoryProvider
 import com.github.meeplemeet.model.discussions.DiscussionRepository
 import com.github.meeplemeet.model.images.ImageRepository
-import com.github.meeplemeet.model.shared.game.GameRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.*
@@ -13,12 +12,10 @@ import kotlinx.coroutines.launch
 
 class SessionOverviewViewModel(
     private val sessionRepository: SessionRepository = RepositoryProvider.sessions,
-    private val gameRepository: GameRepository = RepositoryProvider.games,
     private val imageRepository: ImageRepository = RepositoryProvider.images,
     private val discussionRepository: DiscussionRepository = RepositoryProvider.discussions
 ) : CreateSessionViewModel() {
-  suspend fun getGameNameByGameId(gameId: String): String? =
-      kotlin.runCatching { gameRepository.getGameById(gameId).name }.getOrNull()
+
   /**
    * Live map of discussion-id → Session for the given user. Emits a new map on every Firestore
    * change.

--- a/app/src/main/java/com/github/meeplemeet/model/sessions/SessionViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/sessions/SessionViewModel.kt
@@ -54,19 +54,22 @@ class SessionViewModel(
    * @param date Optional new scheduled date and time
    * @param location Optional new location
    * @throws PermissionDeniedException if requester is not a discussion admin
+   * @throws IllegalArgumentException if if only one of {@code gameId} or {@code gameName} is
+   *   provided
    */
   fun updateSession(
       requester: Account,
       discussion: Discussion,
       name: String? = null,
       gameId: String? = null,
+      gameName: String? = null,
       date: Timestamp? = null,
       location: Location? = null
   ) {
     if (!isAdmin(requester, discussion)) throw PermissionDeniedException(ERROR_ADMIN_PERMISSION)
 
     viewModelScope.launch {
-      sessionRepository.updateSession(discussion.uid, name, gameId, date, location, null)
+      sessionRepository.updateSession(discussion.uid, name, gameId, gameName, date, location, null)
     }
   }
 
@@ -97,7 +100,8 @@ class SessionViewModel(
           (user.notificationSettings == NotificationSettings.FRIENDS_ONLY &&
               changeRequester.relationships[user.uid] == RelationshipStatus.FRIEND)) {
         val updatedParticipants = (currentParticipants + user.uid).toSet().toList()
-        sessionRepository.updateSession(discussion.uid, null, null, null, null, updatedParticipants)
+        sessionRepository.updateSession(
+            discussion.uid, null, null, null, null, null, updatedParticipants)
       } else {
         accountRepository.sendJoinSessionNotification(changeRequester.uid, user.uid, discussion)
       }
@@ -132,7 +136,8 @@ class SessionViewModel(
         // No admin in the new participant list, delete the session instead
         sessionRepository.deleteSession(discussion.uid)
       } else {
-        sessionRepository.updateSession(discussion.uid, null, null, null, null, updatedParticipants)
+        sessionRepository.updateSession(
+            discussion.uid, null, null, null, null, null, updatedParticipants)
       }
     }
   }

--- a/app/src/main/java/com/github/meeplemeet/ui/account/NotificationsTab.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/NotificationsTab.kt
@@ -911,33 +911,31 @@ fun NotificationSheet(
 
               val session = disc.session
               if (session != null) {
-                viewModel.getGame(session.gameId) { game ->
-                  val dateTime =
-                      session.date
-                          .toDate()
-                          .toInstant()
-                          .atZone(ZoneId.systemDefault())
-                          .toLocalDateTime()
+                val dateTime =
+                    session.date
+                        .toDate()
+                        .toInstant()
+                        .atZone(ZoneId.systemDefault())
+                        .toLocalDateTime()
 
-                  val dateLabel =
-                      dateTime.format(
-                          DateTimeFormatter.ofPattern(
-                              NotificationsTabUi.NotificationSheet.Content.SESSION_DATE_PATTERN))
-                  val timeLabel =
-                      dateTime.format(
-                          DateTimeFormatter.ofPattern(
-                              NotificationsTabUi.NotificationSheet.Content.SESSION_TIME_PATTERN))
+                val dateLabel =
+                    dateTime.format(
+                        DateTimeFormatter.ofPattern(
+                            NotificationsTabUi.NotificationSheet.Content.SESSION_DATE_PATTERN))
+                val timeLabel =
+                    dateTime.format(
+                        DateTimeFormatter.ofPattern(
+                            NotificationsTabUi.NotificationSheet.Content.SESSION_TIME_PATTERN))
 
-                  loadedData =
-                      NotificationPopupData.Session(
-                          title = session.name,
-                          participants = session.participants.size,
-                          dateLabel = dateLabel,
-                          description =
-                              NotificationsTabUi.NotificationSheet.Content.sessionDescription(
-                                  game.name, timeLabel, session.location.name),
-                          icon = avatar)
-                }
+                loadedData =
+                    NotificationPopupData.Session(
+                        title = session.name,
+                        participants = session.participants.size,
+                        dateLabel = dateLabel,
+                        description =
+                            NotificationsTabUi.NotificationSheet.Content.sessionDescription(
+                                session.gameName, timeLabel, session.location.name),
+                        icon = avatar)
               }
             })
       }

--- a/app/src/main/java/com/github/meeplemeet/ui/components/SessionDetailsCard.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/SessionDetailsCard.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import coil.compose.rememberAsyncImagePainter
 import com.github.meeplemeet.model.sessions.Session
 import com.github.meeplemeet.model.sessions.SessionOverviewViewModel
-import com.github.meeplemeet.ui.sessions.LABEL_UNKNOWN_GAME
 import com.github.meeplemeet.ui.theme.AppColors
 import com.github.meeplemeet.ui.theme.Dimensions
 import java.text.SimpleDateFormat
@@ -60,13 +59,7 @@ fun SessionDetailsCard(
     }
   }
 
-  val gameName by
-      produceState(key1 = session.gameId, initialValue = session.gameId) {
-        val resolved =
-            if (session.gameId == LABEL_UNKNOWN_GAME) null
-            else viewModel.getGameNameByGameId(session.gameId)
-        value = resolved ?: "No game selected"
-      }
+  val gameName = session.gameName.takeIf { it.isNotBlank() } ?: "No game selected"
 
   Box(
       modifier =

--- a/app/src/main/java/com/github/meeplemeet/ui/sessions/CreateSessionScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/sessions/CreateSessionScreen.kt
@@ -248,6 +248,7 @@ fun CreateSessionScreen(
                                     selectedGameId.ifBlank {
                                       form.proposedGameString.ifBlank { LABEL_UNKNOWN_GAME }
                                     },
+                                gameName = "Temp game name",
                                 date = toTimestamp(form.date, form.time),
                                 location = locationUi.selectedLocation ?: Location(),
                                 *form.participants.toTypedArray())

--- a/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionEditScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionEditScreen.kt
@@ -327,6 +327,7 @@ fun SessionEditScreen(
                                     discussion = discussion,
                                     name = updated.title,
                                     gameId = finalGameId,
+                                    gameName = "Temp game name (edit)",
                                     date = toTimestamp(updated.date, updated.time),
                                     location = locationUi.selectedLocation ?: session.location,
                                     participants = finalParticipantIds,

--- a/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionsOverviewScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionsOverviewScreen.kt
@@ -501,16 +501,7 @@ fun SessionCard(
                 }
               }
 
-          val gameName by
-              produceState(
-                  key1 = session.gameId,
-                  initialValue = session.gameId // fallback: show id while loading
-                  ) {
-                    val name =
-                        if (session.gameId == LABEL_UNKNOWN_GAME) null
-                        else viewModel.getGameNameByGameId(session.gameId)
-                    value = name ?: "No game selected" // suspend call
-              }
+          val gameName = session.gameName.takeIf { it.isNotBlank() } ?: "No game selected"
 
           SessionOverCard(
               session = session,


### PR DESCRIPTION
This PR removes unnecessary fetches for resolving a game's name.  
All screens now use the `gameName` field from `Session` directly.

### UI & ViewModel
- Replace `GameRepository` calls with `session.gameName`
- Update:
  - SessionsOverviewScreen/ViewModel
  - NotificationsTab/ViewModel
  - MarkerPreviewRepository

### Tests
- Refactor tests impacted by the new `gameName` flow
- Remove mocks for name lookup via repository

### Performance
- Fewer Firestore / CloudFunction calls
- Faster UI load for "overview" screens that only need a game name

### Breaking Change
- Firebase session documents now require a `gameName` field
- Sessions will need to be wipe from firebase

### Testing procedure
- Overwrite the `games` repository in `MainActivity.RepositoryProvider` with the CloudBgg implementation  
- Comment out the `init` block in the `CloudBggGameRepository` file  
- Create a new session  
- Open a notification for a session → load should be instantaneous  
- Open a session preview in the map → load should be instantaneous  
- Navigate to the overview screen → game name load should be instantaneous  

_Reformulated with Copilot._