### PR TITLE
Top bar search

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/ui/DiscussionsOverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/DiscussionsOverviewScreenTest.kt
@@ -314,7 +314,7 @@ class DiscussionsOverviewScreenTest : FirestoreTests() {
   fun search_functionality() = runBlocking {
     compose.setContent {
       CompositionLocalProvider(LocalNavigationVM provides navVM) {
-        AppTheme { DiscussionsOverviewScreen(account = me, navigation = nav) }
+        AppTheme { DiscussionsOverviewScreen(account = me, verified = true, navigation = nav) }
       }
     }
 

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/DiscussionsOverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/DiscussionsOverviewScreenTest.kt
@@ -5,7 +5,11 @@ package com.github.meeplemeet.ui
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextClearance
+import androidx.compose.ui.test.performTextInput
 import androidx.test.platform.app.InstrumentationRegistry
 import com.github.meeplemeet.model.account.Account
 import com.github.meeplemeet.model.account.RelationshipStatus
@@ -303,6 +307,63 @@ class DiscussionsOverviewScreenTest : FirestoreTests() {
     checkpoint("Non-blocked messages still display") {
       compose.onNodeWithText("Catan Crew").assertIsDisplayed()
       compose.onNodeWithText("You: Bring snacks", substring = true).assertIsDisplayed()
+    }
+  }
+
+  @Test
+  fun search_functionality() = runBlocking {
+    compose.setContent {
+      CompositionLocalProvider(LocalNavigationVM provides navVM) {
+        AppTheme { DiscussionsOverviewScreen(account = me, navigation = nav) }
+      }
+    }
+
+    checkpoint("Search bar is displayed") {
+      compose
+          .onNodeWithTag(
+              com.github.meeplemeet.ui.discussions.DiscussionOverviewTestTags.SEARCH_TEXT_FIELD)
+          .assertExists()
+          .assertIsDisplayed()
+    }
+
+    checkpoint("Search filters discussions by name") {
+      compose
+          .onNodeWithTag(
+              com.github.meeplemeet.ui.discussions.DiscussionOverviewTestTags.SEARCH_TEXT_FIELD)
+          .performTextInput("Catan")
+      compose.waitForIdle()
+
+      compose.onNodeWithText("Catan Crew").assertIsDisplayed()
+      compose.onNodeWithText("Gloomhaven").assertDoesNotExist()
+      compose.onNodeWithText("Weekend Plan").assertDoesNotExist()
+    }
+
+    checkpoint("Search is case-insensitive") {
+      compose
+          .onNodeWithTag(
+              com.github.meeplemeet.ui.discussions.DiscussionOverviewTestTags.SEARCH_TEXT_FIELD)
+          .performTextClearance()
+      compose
+          .onNodeWithTag(
+              com.github.meeplemeet.ui.discussions.DiscussionOverviewTestTags.SEARCH_TEXT_FIELD)
+          .performTextInput("gloom")
+      compose.waitForIdle()
+
+      compose.onNodeWithText("Gloomhaven").assertIsDisplayed()
+      compose.onNodeWithText("Catan Crew").assertDoesNotExist()
+    }
+
+    checkpoint("Clear button works") {
+      compose
+          .onNodeWithTag(
+              com.github.meeplemeet.ui.discussions.DiscussionOverviewTestTags.SEARCH_CLEAR)
+          .assertExists()
+          .performClick()
+      compose.waitForIdle()
+
+      compose.onNodeWithText("Catan Crew").assertIsDisplayed()
+      compose.onNodeWithText("Gloomhaven").assertIsDisplayed()
+      compose.onNodeWithText("Weekend Plan").assertIsDisplayed()
     }
   }
 }

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/DiscussionsOverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/DiscussionsOverviewScreenTest.kt
@@ -4,6 +4,7 @@ package com.github.meeplemeet.ui
 
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -22,6 +23,7 @@ import com.github.meeplemeet.ui.navigation.NavigationActions
 import com.github.meeplemeet.ui.theme.AppTheme
 import com.github.meeplemeet.utils.Checkpoint
 import com.github.meeplemeet.utils.FirestoreTests
+import com.github.meeplemeet.utils.noretry
 import com.google.firebase.Timestamp
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
@@ -284,6 +286,7 @@ class DiscussionsOverviewScreenTest : FirestoreTests() {
   }
 
   @Test
+  @noretry
   fun blockedSender_hidesMessagePreview() = runBlocking {
     // Block Bob
     val meWithBlockedBob =
@@ -299,7 +302,7 @@ class DiscussionsOverviewScreenTest : FirestoreTests() {
 
     checkpoint("Blocked sender shows hidden message") {
       compose.waitForIdle()
-      compose.onNodeWithText("Gloomhaven").assertIsDisplayed()
+      compose.waitUntil { compose.onNodeWithText("Gloomhaven").isDisplayed() }
       compose.onNodeWithText("Hidden: blocked sender", substring = true).assertIsDisplayed()
       compose.onNodeWithText("Bob: Ready at 7?", substring = true).assertDoesNotExist()
     }

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/PostsOverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/PostsOverviewScreenTest.kt
@@ -81,7 +81,10 @@ class PostsOverviewScreenTest : FirestoreTests() {
 
     compose.setContent {
       CompositionLocalProvider(LocalNavigationVM provides navVM) {
-        AppTheme { PostsOverviewScreen(viewModel = viewModel, navigation = nav, account = account) }
+        AppTheme {
+          PostsOverviewScreen(
+              viewModel = viewModel, verified = true, navigation = nav, account = account)
+        }
       }
     }
   }

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/PostsOverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/PostsOverviewScreenTest.kt
@@ -1,0 +1,139 @@
+// Test file for PostsOverviewScreen search functionality
+package com.github.meeplemeet.ui
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.isDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextClearance
+import androidx.compose.ui.test.performTextInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.meeplemeet.model.account.Account
+import com.github.meeplemeet.model.navigation.LocalNavigationVM
+import com.github.meeplemeet.model.navigation.NavigationViewModel
+import com.github.meeplemeet.model.posts.Post
+import com.github.meeplemeet.model.posts.PostOverviewViewModel
+import com.github.meeplemeet.ui.navigation.NavigationActions
+import com.github.meeplemeet.ui.posts.FeedsOverviewTestTags
+import com.github.meeplemeet.ui.posts.PostsOverviewScreen
+import com.github.meeplemeet.ui.theme.AppTheme
+import com.github.meeplemeet.utils.Checkpoint
+import com.github.meeplemeet.utils.FirestoreTests
+import io.mockk.mockk
+import java.util.UUID
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PostsOverviewScreenTest : FirestoreTests() {
+
+  @get:Rule val compose = createComposeRule()
+  @get:Rule val ck = Checkpoint.Rule()
+
+  private fun checkpoint(name: String, block: () -> Unit) = ck.ck(name, block)
+
+  private lateinit var viewModel: PostOverviewViewModel
+  private lateinit var nav: NavigationActions
+  private lateinit var navVM: NavigationViewModel
+  private lateinit var account: Account
+
+  private lateinit var post1: Post
+  private lateinit var post2: Post
+  private lateinit var post3: Post
+
+  @Before
+  fun setup() = runBlocking {
+    viewModel = PostOverviewViewModel()
+    nav = mockk(relaxed = true)
+    navVM = NavigationViewModel()
+
+    val uid = "uid_" + UUID.randomUUID().toString().take(8)
+    account = accountRepository.createAccount(uid, "Tester", "test@x.com", null)
+
+    // Create test posts
+    post1 =
+        postRepository.createPost(
+            authorId = account.uid,
+            title = "Catan Strategy Guide",
+            content = "Best strategies for Catan",
+            tags = listOf("strategy", "catan"))
+
+    post2 =
+        postRepository.createPost(
+            authorId = account.uid,
+            title = "Gloomhaven Tips",
+            content = "Tips for Gloomhaven players",
+            tags = listOf("tips", "gloomhaven"))
+
+    post3 =
+        postRepository.createPost(
+            authorId = account.uid,
+            title = "Board Game Night",
+            content = "Planning a board game night",
+            tags = listOf("planning"))
+
+    compose.setContent {
+      CompositionLocalProvider(LocalNavigationVM provides navVM) {
+        AppTheme { PostsOverviewScreen(viewModel = viewModel, navigation = nav, account = account) }
+      }
+    }
+  }
+
+  @After
+  fun cleanup() = runBlocking {
+    try {
+      postRepository.deletePost(post1.id)
+      postRepository.deletePost(post2.id)
+      postRepository.deletePost(post3.id)
+      accountRepository.deleteAccount(account.uid)
+    } catch (_: Exception) {
+      // Ignore cleanup errors
+    }
+  }
+
+  @Test
+  fun search_functionality() = runBlocking {
+    checkpoint("Search bar is displayed") {
+      compose
+          .onNodeWithTag(FeedsOverviewTestTags.SEARCH_TEXT_FIELD)
+          .assertExists()
+          .assertIsDisplayed()
+    }
+
+    checkpoint("Search filters posts by title") {
+      compose.waitUntil(2000) { compose.onNodeWithText("Catan Strategy Guide").isDisplayed() }
+
+      compose.onNodeWithTag(FeedsOverviewTestTags.SEARCH_TEXT_FIELD).performTextInput("Catan")
+      compose.waitForIdle()
+
+      compose.onNodeWithText("Catan Strategy Guide").assertIsDisplayed()
+      compose.onNodeWithText("Gloomhaven Tips").assertDoesNotExist()
+      compose.onNodeWithText("Board Game Night").assertDoesNotExist()
+    }
+
+    checkpoint("Search is case-insensitive for posts") {
+      compose.onNodeWithTag(FeedsOverviewTestTags.SEARCH_TEXT_FIELD).performTextClearance()
+      compose.onNodeWithTag(FeedsOverviewTestTags.SEARCH_TEXT_FIELD).performTextInput("gloom")
+      compose.waitForIdle()
+
+      compose.onNodeWithText("Gloomhaven Tips").assertIsDisplayed()
+      compose.onNodeWithText("Catan Strategy Guide").assertDoesNotExist()
+    }
+
+    checkpoint("Clear button works for posts") {
+      compose.onNodeWithTag(FeedsOverviewTestTags.SEARCH_CLEAR).assertExists().performClick()
+      compose.waitForIdle()
+
+      compose.onNodeWithText("Catan Strategy Guide").assertIsDisplayed()
+      compose.onNodeWithText("Gloomhaven Tips").assertIsDisplayed()
+      compose.onNodeWithText("Board Game Night").assertIsDisplayed()
+    }
+  }
+}

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/SessionsOverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/SessionsOverviewScreenTest.kt
@@ -19,6 +19,7 @@ import com.github.meeplemeet.ui.theme.AppTheme
 import com.github.meeplemeet.ui.theme.ThemeMode
 import com.github.meeplemeet.utils.Checkpoint
 import com.github.meeplemeet.utils.FirestoreTests
+import com.github.meeplemeet.utils.noretry
 import com.google.firebase.Timestamp
 import io.mockk.mockk
 import java.util.UUID
@@ -78,6 +79,7 @@ class SessionsOverviewScreenTest : FirestoreTests() {
   }
 
   @Test
+  @noretry
   fun full_smoke_all_cases() {
     runBlocking {
 
@@ -184,6 +186,7 @@ class SessionsOverviewScreenTest : FirestoreTests() {
   }
 
   @Test
+  @noretry
   fun archive_flow_comprehensive() {
     runBlocking {
       /* 1. Archive with confirmation (no photo) --------------------------------- */
@@ -204,7 +207,10 @@ class SessionsOverviewScreenTest : FirestoreTests() {
               account.uid)
 
           compose.waitUntil(2000) {
-            compose.onNodeWithText("Automatically archives in", substring = true).isDisplayed()
+            compose
+                .onAllNodesWithText("Automatically archives in", substring = true)
+                .get(0)
+                .isDisplayed()
           }
 
           sessionCard(discussion.uid).assertIsDisplayed()
@@ -309,51 +315,71 @@ class SessionsOverviewScreenTest : FirestoreTests() {
           .assertExists()
           .assertIsDisplayed()
     }
+    runBlocking {
+      val discussion1 = discussionRepository.createDiscussion("Chess Club", "Chess", account.uid)
+      val discussion2 = discussionRepository.createDiscussion("Poker Night", "Cards", account.uid)
 
-    checkpoint("Search filters active sessions by name") {
-      runBlocking {
-        val discussion1 = discussionRepository.createDiscussion("Chess Club", "Chess", account.uid)
-        val discussion2 = discussionRepository.createDiscussion("Poker Night", "Cards", account.uid)
-        val game = gameRepository.getGameById(testGameId)
-        val futureDate = Timestamp(java.util.Date(System.currentTimeMillis() + 86400000))
+      checkpoint("Search filters active sessions by name") {
+        runBlocking {
+          val game = gameRepository.getGameById(testGameId)
+          val futureDate = Timestamp(java.util.Date(System.currentTimeMillis() + 86400000))
 
-        sessionRepository.createSession(
-            discussion1.uid, "Chess Tournament", game.uid, futureDate, testLocation, account.uid)
-        sessionRepository.createSession(
-            discussion2.uid, "Poker Game", game.uid, futureDate, testLocation, account.uid)
+          sessionRepository.createSession(
+              discussion1.uid,
+              "Chess Tournament",
+              game.uid,
+              gameName = "Chess",
+              futureDate,
+              testLocation,
+              account.uid)
+          sessionRepository.createSession(
+              discussion2.uid,
+              "Poker Game",
+              game.uid,
+              gameName = "Cards",
+              futureDate,
+              testLocation,
+              account.uid)
 
-        compose.waitUntil(2000) { compose.onNodeWithText("Chess Tournament").isDisplayed() }
+          compose.waitUntil(2000) { compose.onNodeWithText("Chess Tournament").isDisplayed() }
 
+          compose
+              .onNodeWithTag(SessionsOverviewScreenTestTags.SEARCH_TEXT_FIELD)
+              .performTextInput("Chess")
+          compose.waitForIdle()
+
+          compose.onNodeWithText("Chess Tournament").assertIsDisplayed()
+          compose.onNodeWithText("Poker Game").assertDoesNotExist()
+        }
+      }
+
+      checkpoint("Search is case-insensitive for sessions") {
         compose
             .onNodeWithTag(SessionsOverviewScreenTestTags.SEARCH_TEXT_FIELD)
-            .performTextInput("Chess")
+            .performTextClearance()
+        compose
+            .onNodeWithTag(SessionsOverviewScreenTestTags.SEARCH_TEXT_FIELD)
+            .performTextInput("poker")
         compose.waitForIdle()
 
-        compose.onNodeWithText("Chess Tournament").assertIsDisplayed()
-        compose.onNodeWithText("Poker Game").assertDoesNotExist()
+        compose.onNodeWithText("Poker Game").assertIsDisplayed()
+        compose.onNodeWithText("Chess Tournament").assertDoesNotExist()
       }
-    }
 
-    checkpoint("Search is case-insensitive for sessions") {
-      compose.onNodeWithTag(SessionsOverviewScreenTestTags.SEARCH_TEXT_FIELD).performTextClearance()
-      compose
-          .onNodeWithTag(SessionsOverviewScreenTestTags.SEARCH_TEXT_FIELD)
-          .performTextInput("poker")
-      compose.waitForIdle()
+      checkpoint("Clear button works for sessions") {
+        runBlocking {
+          compose
+              .onNodeWithTag(SessionsOverviewScreenTestTags.SEARCH_CLEAR)
+              .assertExists()
+              .performClick()
+          compose.waitForIdle()
 
-      compose.onNodeWithText("Poker Game").assertIsDisplayed()
-      compose.onNodeWithText("Chess Tournament").assertDoesNotExist()
-    }
-
-    checkpoint("Clear button works for sessions") {
-      compose
-          .onNodeWithTag(SessionsOverviewScreenTestTags.SEARCH_CLEAR)
-          .assertExists()
-          .performClick()
-      compose.waitForIdle()
-
-      compose.onNodeWithText("Chess Tournament").assertIsDisplayed()
-      compose.onNodeWithText("Poker Game").assertIsDisplayed()
+          compose.onNodeWithText("Chess Tournament").assertIsDisplayed()
+          compose.onNodeWithText("Poker Game").assertIsDisplayed()
+          sessionRepository.deleteSession(discussion1.uid)
+          sessionRepository.deleteSession(discussion2.uid)
+        }
+      }
     }
   }
 

--- a/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionsOverviewScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionsOverviewScreen.kt
@@ -24,17 +24,13 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ChatBubbleOutline
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
-import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -46,7 +42,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
@@ -144,38 +140,18 @@ fun DiscussionsOverviewScreen(
         .forEach { OfflineModeManager.loadDiscussion(it.uid, context) {} }
   }
 
+  val focusManager = androidx.compose.ui.platform.LocalFocusManager.current
+
   Scaffold(
-      floatingActionButton = {
-        if (verified)
-            FloatingActionButton(
-                onClick = onClickAddDiscussion,
-                contentColor = MessagingColors.messagingSurface,
-                containerColor = MessagingColors.whatsappGreen,
-                modifier = Modifier.testTag(DiscussionOverviewTestTags.ADD_DISCUSSION_BUTTON),
-                shape = CircleShape) {
-                  Icon(
-                      Icons.Default.Add,
-                      contentDescription = "Create",
-                      modifier = Modifier.size(Dimensions.IconSize.large))
-                }
-      },
       topBar = {
-        Column(Modifier.fillMaxWidth()) {
-          CenterAlignedTopAppBar(
-              title = {
-                Text(
-                    text = MeepleMeetScreen.DiscussionsOverview.title,
-                    style = MaterialTheme.typography.titleLarge,
-                    fontSize = Dimensions.TextSize.heading,
-                    fontWeight = FontWeight.SemiBold,
-                    color = MaterialTheme.colorScheme.onPrimary,
-                    modifier = Modifier.testTag(NavigationTestTags.SCREEN_TITLE))
-              })
-          DiscussionSearchBar(
-              query = searchQuery,
-              onQueryChange = { searchQuery = it },
-              onClearQuery = { searchQuery = "" })
-        }
+        DiscussionsTopBar(
+            title = MeepleMeetScreen.DiscussionsOverview.title,
+            showAddButton = verified,
+            onAddDiscussionClick = onClickAddDiscussion,
+            query = searchQuery,
+            onQueryChange = { searchQuery = it },
+            onClearQuery = { searchQuery = "" },
+            focusManager = focusManager)
       },
       bottomBar = {
         BottomBarWithVerification(
@@ -185,15 +161,32 @@ fun DiscussionsOverviewScreen(
             onVerifyClick = { navigation.navigateTo(MeepleMeetScreen.Profile) })
       }) { innerPadding ->
         if (discussionPreviewsSorted.isEmpty()) {
-          Box(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
-            EmptyDiscussionsListText()
-          }
+          Box(
+              modifier =
+                  Modifier.fillMaxSize().padding(innerPadding).clickable(
+                      indication = null,
+                      interactionSource =
+                          remember {
+                            androidx.compose.foundation.interaction.MutableInteractionSource()
+                          }) {
+                        focusManager.clearFocus()
+                      }) {
+                EmptyDiscussionsListText()
+              }
         } else {
           LazyColumn(
               modifier =
                   Modifier.fillMaxSize()
                       .background(MaterialTheme.colorScheme.background)
-                      .padding(innerPadding)) {
+                      .padding(innerPadding)
+                      .clickable(
+                          indication = null,
+                          interactionSource =
+                              remember {
+                                androidx.compose.foundation.interaction.MutableInteractionSource()
+                              }) {
+                            focusManager.clearFocus()
+                          }) {
                 items(discussionPreviewsSorted, key = { it.uid }) { preview ->
                   val discussion = offline.discussions[preview.uid]?.first
                   val discussionName = discussion?.name ?: DEFAULT_DISCUSSION_NAME
@@ -404,63 +397,117 @@ fun RelativeTimestampText(timestamp: Timestamp, modifier: Modifier) {
 }
 
 /**
- * Composable function for the discussion search bar.
+ * Top bar for the discussions overview screen, styled to match ChatsTopBar.
  *
+ * @param title The title text shown in the top bar.
+ * @param showAddButton Whether to show the add discussion button.
+ * @param onAddDiscussionClick Callback when the add discussion button is clicked.
  * @param query The current search query.
  * @param onQueryChange Callback when the search query changes.
  * @param onClearQuery Callback to clear the search query.
+ * @param focusManager FocusManager to handle clearing focus.
  */
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun DiscussionSearchBar(
+fun DiscussionsTopBar(
+    title: String,
+    showAddButton: Boolean,
+    onAddDiscussionClick: () -> Unit,
     query: String,
     onQueryChange: (String) -> Unit,
-    onClearQuery: () -> Unit
+    onClearQuery: () -> Unit,
+    focusManager: FocusManager
 ) {
-  TextField(
-      value = query,
-      onValueChange = onQueryChange,
+  Column(
       modifier =
           Modifier.fillMaxWidth()
-              .height(Dimensions.ContainerSize.timeFieldHeight)
-              .testTag(DiscussionOverviewTestTags.SEARCH_TEXT_FIELD),
-      placeholder = {
-        Text(
-            "Search discussions...",
-            style = MaterialTheme.typography.bodyMedium,
-        )
-      },
-      singleLine = true,
-      leadingIcon = {
-        Icon(
-            imageVector = Icons.Default.Search,
-            contentDescription = "Search",
-        )
-      },
-      trailingIcon = {
-        if (query.isNotEmpty()) {
-          IconButton(
-              onClick = onClearQuery,
-              modifier = Modifier.testTag(DiscussionOverviewTestTags.SEARCH_CLEAR),
-          ) {
-            Icon(
-                imageVector = Icons.Default.Close,
-                contentDescription = "Clear search",
-            )
-          }
-        }
-      },
-      textStyle = MaterialTheme.typography.bodyMedium,
-      colors =
-          TextFieldDefaults.colors(
-              focusedTextColor = AppColors.textIcons,
-              unfocusedTextColor = AppColors.textIcons,
-              focusedContainerColor = AppColors.divider,
-              unfocusedContainerColor = AppColors.divider,
-              disabledContainerColor = AppColors.divider,
-              focusedIndicatorColor = Color.Transparent,
-              unfocusedIndicatorColor = Color.Transparent,
-              disabledIndicatorColor = Color.Transparent,
-          ),
-  )
+              .background(AppColors.primary)
+              .clickable(
+                  indication = null,
+                  interactionSource =
+                      remember {
+                        androidx.compose.foundation.interaction.MutableInteractionSource()
+                      }) {
+                    focusManager.clearFocus()
+                  }
+              .padding(
+                  horizontal = Dimensions.Padding.extraLarge,
+                  vertical = Dimensions.Spacing.large)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically) {
+              Text(
+                  text = title,
+                  color = AppColors.textIcons,
+                  fontSize = Dimensions.TextSize.extraLarge,
+                  fontWeight = FontWeight.Bold,
+                  modifier = Modifier.testTag(NavigationTestTags.SCREEN_TITLE))
+
+              if (showAddButton)
+                  IconButton(
+                      onClick = onAddDiscussionClick,
+                      modifier =
+                          Modifier.background(MessagingColors.whatsappGreen, CircleShape)
+                              .size(Dimensions.AvatarSize.small)
+                              .testTag(DiscussionOverviewTestTags.ADD_DISCUSSION_BUTTON)) {
+                        Icon(
+                            imageVector = Icons.Default.Add,
+                            contentDescription = "New discussion",
+                            tint = AppColors.textIcons)
+                      }
+            }
+
+        Spacer(modifier = Modifier.height(Dimensions.Spacing.large))
+
+        androidx.compose.foundation.text.BasicTextField(
+            value = query,
+            onValueChange = onQueryChange,
+            modifier =
+                Modifier.fillMaxWidth()
+                    .height(Dimensions.ContainerSize.searchFieldHeight)
+                    .background(
+                        AppColors.secondary,
+                        androidx.compose.foundation.shape.RoundedCornerShape(
+                            Dimensions.CornerRadius.round))
+                    .testTag(DiscussionOverviewTestTags.SEARCH_TEXT_FIELD),
+            singleLine = true,
+            textStyle =
+                androidx.compose.ui.text.TextStyle(
+                    color = AppColors.textIcons, fontSize = Dimensions.TextSize.subtitle),
+            cursorBrush = androidx.compose.ui.graphics.SolidColor(AppColors.textIcons),
+            decorationBox = { innerTextField ->
+              Row(
+                  modifier = Modifier.fillMaxSize().padding(horizontal = Dimensions.Padding.medium),
+                  verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Icons.Default.Search,
+                        contentDescription = "Search",
+                        tint = AppColors.textIconsFade,
+                        modifier = Modifier.size(Dimensions.IconSize.standard))
+                    Spacer(modifier = Modifier.width(Dimensions.Spacing.small))
+                    Box(modifier = Modifier.weight(1f)) {
+                      if (query.isEmpty()) {
+                        Text(
+                            text = "Search",
+                            color = AppColors.textIconsFade,
+                            fontSize = Dimensions.TextSize.subtitle)
+                      }
+                      innerTextField()
+                    }
+                    if (query.isNotEmpty()) {
+                      IconButton(
+                          onClick = onClearQuery,
+                          modifier =
+                              Modifier.size(Dimensions.IconSize.large)
+                                  .testTag(DiscussionOverviewTestTags.SEARCH_CLEAR)) {
+                            Icon(
+                                imageVector = Icons.Default.Close,
+                                contentDescription = "Clear search",
+                                tint = AppColors.textIconsFade,
+                                modifier = Modifier.size(Dimensions.IconSize.standard))
+                          }
+                    }
+                  }
+            })
+      }
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionsOverviewScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionsOverviewScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ChatBubbleOutline
@@ -444,7 +445,7 @@ fun DiscussionsTopBar(
 
         Spacer(modifier = Modifier.height(Dimensions.Spacing.large))
 
-        androidx.compose.foundation.text.BasicTextField(
+        BasicTextField(
             value = query,
             onValueChange = onQueryChange,
             modifier =

--- a/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionsOverviewScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionsOverviewScreen.kt
@@ -413,14 +413,7 @@ fun DiscussionsTopBar(
       modifier =
           Modifier.fillMaxWidth()
               .background(AppColors.primary)
-              .clickable(
-                  indication = null,
-                  interactionSource =
-                      remember {
-                        androidx.compose.foundation.interaction.MutableInteractionSource()
-                      }) {
-                    focusManager.clearFocus()
-                  }
+              .pointerInput(Unit) { detectTapGestures(onTap = { focusManager.clearFocus() }) }
               .padding(
                   horizontal = Dimensions.Padding.extraLarge,
                   vertical = Dimensions.Spacing.large)) {

--- a/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionsOverviewScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionsOverviewScreen.kt
@@ -5,6 +5,7 @@ package com.github.meeplemeet.ui.discussions
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -43,6 +44,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusManager
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
@@ -163,14 +165,9 @@ fun DiscussionsOverviewScreen(
         if (discussionPreviewsSorted.isEmpty()) {
           Box(
               modifier =
-                  Modifier.fillMaxSize().padding(innerPadding).clickable(
-                      indication = null,
-                      interactionSource =
-                          remember {
-                            androidx.compose.foundation.interaction.MutableInteractionSource()
-                          }) {
-                        focusManager.clearFocus()
-                      }) {
+                  Modifier.fillMaxSize().padding(innerPadding).pointerInput(Unit) {
+                    detectTapGestures(onTap = { focusManager.clearFocus() })
+                  }) {
                 EmptyDiscussionsListText()
               }
         } else {
@@ -179,14 +176,9 @@ fun DiscussionsOverviewScreen(
                   Modifier.fillMaxSize()
                       .background(MaterialTheme.colorScheme.background)
                       .padding(innerPadding)
-                      .clickable(
-                          indication = null,
-                          interactionSource =
-                              remember {
-                                androidx.compose.foundation.interaction.MutableInteractionSource()
-                              }) {
-                            focusManager.clearFocus()
-                          }) {
+                      .pointerInput(Unit) {
+                        detectTapGestures(onTap = { focusManager.clearFocus() })
+                      }) {
                 items(discussionPreviewsSorted, key = { it.uid }) { preview ->
                   val discussion = offline.discussions[preview.uid]?.first
                   val discussionName = discussion?.name ?: DEFAULT_DISCUSSION_NAME

--- a/app/src/main/java/com/github/meeplemeet/ui/posts/PostsOverviewScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/posts/PostsOverviewScreen.kt
@@ -367,14 +367,7 @@ fun PostsTopBar(
       modifier =
           Modifier.fillMaxWidth()
               .background(AppColors.primary)
-              .clickable(
-                  indication = null,
-                  interactionSource =
-                      remember {
-                        androidx.compose.foundation.interaction.MutableInteractionSource()
-                      }) {
-                    focusManager.clearFocus()
-                  }
+              .pointerInput(Unit) { detectTapGestures(onTap = { focusManager.clearFocus() }) }
               .padding(
                   horizontal = Dimensions.Padding.extraLarge,
                   vertical = Dimensions.Spacing.large)) {

--- a/app/src/main/java/com/github/meeplemeet/ui/posts/PostsOverviewScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/posts/PostsOverviewScreen.kt
@@ -7,6 +7,7 @@ package com.github.meeplemeet.ui.posts
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -27,6 +28,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusManager
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
@@ -125,27 +127,17 @@ fun PostsOverviewScreen(
         if (postsSorted.isEmpty()) {
           Box(
               modifier =
-                  Modifier.fillMaxSize().padding(innerPadding).clickable(
-                      indication = null,
-                      interactionSource =
-                          remember {
-                            androidx.compose.foundation.interaction.MutableInteractionSource()
-                          }) {
-                        focusManager.clearFocus()
-                      }) {
+                  Modifier.fillMaxSize().padding(innerPadding).pointerInput(Unit) {
+                    detectTapGestures(onTap = { focusManager.clearFocus() })
+                  }) {
                 EmptyFeedListText()
               }
         } else {
           LazyColumn(
               modifier =
-                  Modifier.fillMaxSize().padding(innerPadding).clickable(
-                      indication = null,
-                      interactionSource =
-                          remember {
-                            androidx.compose.foundation.interaction.MutableInteractionSource()
-                          }) {
-                        focusManager.clearFocus()
-                      },
+                  Modifier.fillMaxSize().padding(innerPadding).pointerInput(Unit) {
+                    detectTapGestures(onTap = { focusManager.clearFocus() })
+                  },
               verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.none)) {
                 items(postsSorted, key = { it.id }) { post ->
                   if (account.relationships[post.authorId] == RelationshipStatus.BLOCKED)

--- a/app/src/main/java/com/github/meeplemeet/ui/posts/PostsOverviewScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/posts/PostsOverviewScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Article
 import androidx.compose.material.icons.filled.Add
@@ -398,7 +399,7 @@ fun PostsTopBar(
 
         Spacer(modifier = Modifier.height(Dimensions.Spacing.large))
 
-        androidx.compose.foundation.text.BasicTextField(
+        BasicTextField(
             value = query,
             onValueChange = onQueryChange,
             modifier =

--- a/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionsOverviewScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionsOverviewScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Article
 import androidx.compose.material.icons.filled.Close
@@ -790,7 +791,7 @@ fun SessionsTopBar(
 
           Spacer(modifier = Modifier.height(Dimensions.Spacing.large))
 
-          androidx.compose.foundation.text.BasicTextField(
+          BasicTextField(
               value = query,
               onValueChange = onQueryChange,
               modifier =

--- a/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionsOverviewScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionsOverviewScreen.kt
@@ -777,14 +777,7 @@ fun SessionsTopBar(
         modifier =
             Modifier.fillMaxWidth()
                 .background(AppColors.primary)
-                .clickable(
-                    indication = null,
-                    interactionSource =
-                        remember {
-                          androidx.compose.foundation.interaction.MutableInteractionSource()
-                        }) {
-                      focusManager.clearFocus()
-                    }
+                .pointerInput(Unit) { detectTapGestures(onTap = { focusManager.clearFocus() }) }
                 .padding(
                     horizontal = Dimensions.Padding.extraLarge,
                     vertical = Dimensions.Spacing.large)) {

--- a/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionsOverviewScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/sessions/SessionsOverviewScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.draggable
 import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.layout.Arrangement
@@ -60,6 +61,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
@@ -188,14 +190,9 @@ fun SessionsOverviewScreen(
         }) { innerPadding ->
           Box(
               modifier =
-                  Modifier.fillMaxSize().padding(innerPadding).clickable(
-                      indication = null,
-                      interactionSource =
-                          remember {
-                            androidx.compose.foundation.interaction.MutableInteractionSource()
-                          }) {
-                        focusManager.clearFocus()
-                      }) {
+                  Modifier.fillMaxSize().padding(innerPadding).pointerInput(Unit) {
+                    detectTapGestures(onTap = { focusManager.clearFocus() })
+                  }) {
                 when {
                   showHistory -> {
                     val filteredArchived =

--- a/app/src/main/java/com/github/meeplemeet/ui/theme/Dimensions.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/theme/Dimensions.kt
@@ -161,6 +161,7 @@ object Dimensions {
     val pageImageSize: Dp = 300.dp
     val mapHeight: Dp = 300.dp
     val dividerHorizontalPadding: Dp = 30.dp
+    val searchFieldHeight: Dp = 40.dp
   }
 
   // Map-specific dimensions


### PR DESCRIPTION
## Add Search Bars to Overview Screens

### Summary
Added search functionality to DiscussionsOverview, PostsOverview, and SessionsOverview screens to allow users to filter content by title/name.

### Changes

#### UI Implementation
- **DiscussionsOverviewScreen**: Added search bar to filter discussions by name
- **PostsOverviewScreen**: Added search bar to filter posts by title
- **SessionsOverviewScreen**: Added search bar to filter sessions by name (works on both "Next sessions" and "History" tabs)

#### Features
- Case-insensitive search
- Real-time filtering as user types
- Clear button appears when search query is not empty
<img width="331" height="690" alt="image" src="https://github.com/user-attachments/assets/56ffbc40-8725-49fa-9a4c-252adc17cbb4" />