### PR TITLE
Feat/account info popup

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/ui/DiscussionScreenIntegrationTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/DiscussionScreenIntegrationTest.kt
@@ -55,13 +55,18 @@ class DiscussionScreenIntegrationTest : FirestoreTests() {
             photoUrl = null)
 
     // Create a test discussion    // Create initial account with a long description
-    val longDescription = "Start " + "A very long description that should definitely overflow because it repeats many times. ".repeat(10) + " End"
-    otherUser = accountRepository.createAccount(
+    val longDescription =
+        "Start " +
+            "A very long description that should definitely overflow because it repeats many times. "
+                .repeat(10) +
+            " End"
+    otherUser =
+        accountRepository.createAccount(
             userHandle = "otheruser_${Random.nextInt(1000000)}",
             name = "Bob",
             email = "bob@test.com",
             photoUrl = null)
-      accountRepository.setAccountDescription(otherUser.uid, longDescription)
+    accountRepository.setAccountDescription(otherUser.uid, longDescription)
     testDiscussion =
         discussionRepository.createDiscussion(
             name = "Test Discussion",
@@ -771,11 +776,11 @@ class DiscussionScreenIntegrationTest : FirestoreTests() {
 
         // Assert overflow "Show more" is displayed for our long description
         composeTestRule.onNodeWithText("Show more").assertExists()
-        
+
         // Assert expansion works
         composeTestRule.onNodeWithText("Show more").performClick()
         composeTestRule.onNodeWithText("Show less").assertExists()
-        
+
         // Collapse again
         composeTestRule.onNodeWithText("Show less").performClick()
         composeTestRule.onNodeWithText("Show more").assertExists()
@@ -908,8 +913,8 @@ class DiscussionScreenIntegrationTest : FirestoreTests() {
         }
       }
 
-          // removes)
-        }
+      // removes)
+    }
 
     // Cleanup photo discussions
     runBlocking {

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/DiscussionScreenIntegrationTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/DiscussionScreenIntegrationTest.kt
@@ -54,14 +54,14 @@ class DiscussionScreenIntegrationTest : FirestoreTests() {
             email = "alice@test.com",
             photoUrl = null)
 
-    otherUser =
-        accountRepository.createAccount(
+    // Create a test discussion    // Create initial account with a long description
+    val longDescription = "Start " + "A very long description that should definitely overflow because it repeats many times. ".repeat(10) + " End"
+    otherUser = accountRepository.createAccount(
             userHandle = "otheruser_${Random.nextInt(1000000)}",
             name = "Bob",
             email = "bob@test.com",
             photoUrl = null)
-
-    // Create a test discussion with messages
+      accountRepository.setAccountDescription(otherUser.uid, longDescription)
     testDiscussion =
         discussionRepository.createDiscussion(
             name = "Test Discussion",
@@ -763,10 +763,22 @@ class DiscussionScreenIntegrationTest : FirestoreTests() {
             .assertExists()
 
         // Assert description is displayed
+        // Assert description is displayed
         composeTestRule
             .onNodeWithTag(
                 CommonComponentsTestTags.USER_PROFILE_POPUP_DESCRIPTION, useUnmergedTree = true)
             .assertExists()
+
+        // Assert overflow "Show more" is displayed for our long description
+        composeTestRule.onNodeWithText("Show more").assertExists()
+        
+        // Assert expansion works
+        composeTestRule.onNodeWithText("Show more").performClick()
+        composeTestRule.onNodeWithText("Show less").assertExists()
+        
+        // Collapse again
+        composeTestRule.onNodeWithText("Show less").performClick()
+        composeTestRule.onNodeWithText("Show more").assertExists()
       }
 
       checkpoint("Assert UserProfilePopup buttons are clickable") {
@@ -895,7 +907,9 @@ class DiscussionScreenIntegrationTest : FirestoreTests() {
           // removes)
         }
       }
-    }
+
+          // removes)
+        }
 
     // Cleanup photo discussions
     runBlocking {

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/DiscussionScreenIntegrationTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/DiscussionScreenIntegrationTest.kt
@@ -829,12 +829,12 @@ class DiscussionScreenIntegrationTest : FirestoreTests() {
 
         // Assert button changes after sending request
         composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithText("Request Sent").assertExists()
+        composeTestRule.onNodeWithText("Cancel request").assertExists()
         composeTestRule
             .onNodeWithTag(
                 CommonComponentsTestTags.USER_PROFILE_POPUP_SEND_REQUEST_BUTTON,
                 useUnmergedTree = true)
-            .assertIsNotEnabled()
+            .assertIsEnabled()
 
         // 2. Click Block
         composeTestRule
@@ -898,7 +898,7 @@ class DiscussionScreenIntegrationTest : FirestoreTests() {
             .performClick()
 
         // 4. Verify Snackbar
-        composeTestRule.onNodeWithText("${otherUser.name} removed from Friends.").assertExists()
+        composeTestRule.onNodeWithText("${otherUser.name} removed from friends.").assertExists()
 
         // 5. Verify Backend State (Relationship removed)
         composeTestRule.waitUntil(5_000) {

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/DiscussionScreenIntegrationTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/DiscussionScreenIntegrationTest.kt
@@ -892,7 +892,7 @@ class DiscussionScreenIntegrationTest : FirestoreTests() {
               rel ==
                   RelationshipStatus
                       .PENDING // Depending on how remove friend is implemented (usually completely
-                               // removes)
+          // removes)
         }
       }
     }

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/PostScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/PostScreenTest.kt
@@ -115,8 +115,8 @@ class PostScreenTest : FirestoreTests() {
             account = marco,
             postId = postIdState.value,
             verified = true,
-            postViewModel = postVM,
-            accountViewModel = postVM,
+            viewModel = postVM,
+            online = true,
             onBack = { backCount++ })
       }
     }
@@ -232,8 +232,8 @@ class PostScreenTest : FirestoreTests() {
         PostScreen(
             account = marcoWithBlockedDany,
             postId = postId,
-            postViewModel = postVM,
-            accountViewModel = postVM,
+            viewModel = postVM,
+            online = true,
             verified = true,
             onBack = {})
       }

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/PostScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/PostScreenTest.kt
@@ -4,7 +4,7 @@ package com.github.meeplemeet.ui
 
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.assertHasClickAction
-import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
@@ -406,12 +406,12 @@ class PostScreenTest : FirestoreTests() {
       currentUserState.value = currentUserState.value.copy(relationships = sentRelationships)
       compose.waitForIdle()
 
-      compose.onNodeWithText("Request Sent").assertExists()
+      compose.onNodeWithText("Cancel request").assertExists()
       compose
           .onNodeWithTag(
               CommonComponentsTestTags.USER_PROFILE_POPUP_SEND_REQUEST_BUTTON,
               useUnmergedTree = true)
-          .assertIsNotEnabled()
+          .assertIsEnabled()
 
       // 2. Block User
       compose

--- a/app/src/main/java/com/github/meeplemeet/MainActivity.kt
+++ b/app/src/main/java/com/github/meeplemeet/MainActivity.kt
@@ -390,6 +390,7 @@ fun MeepleMeetApp(
                           if (it.session != null) MeepleMeetScreen.SessionViewer
                           else MeepleMeetScreen.CreateSession)
                     },
+                    online = online,
                     onVerifyClick = { navigationActions.navigateTo(MeepleMeetScreen.Profile) })
             else navigationActions.navigateTo(MeepleMeetScreen.DiscussionsOverview)
           } else LoadingScreen()
@@ -464,6 +465,7 @@ fun MeepleMeetApp(
               postId = postId,
               verified = uiState.isEmailVerified,
               onBack = { navigationActions.goBack() },
+              online = online,
               onVerifyClick = { navigationActions.navigateTo(MeepleMeetScreen.Profile) })
         }
 

--- a/app/src/main/java/com/github/meeplemeet/model/account/AccountViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/AccountViewModel.kt
@@ -151,22 +151,18 @@ interface AccountViewModel : UserProfilePopupActions {
     }
   }
 
-    override fun onBlock(curr: Account, account: Account) {
-        scope.launch {
-            RepositoryProvider.accounts.blockUser(curr.uid, account.uid)
-        }
-    }
+  override fun onBlock(curr: Account, account: Account) {
+    scope.launch { RepositoryProvider.accounts.blockUser(curr.uid, account.uid) }
+  }
 
-    override fun onSendFriendRequest(curr: Account, account: Account) {
-        scope.launch {
-            RepositoryProvider.accounts.sendFriendRequest(curr, account.uid)
-            RepositoryProvider.accounts.sendFriendRequestNotification(curr.uid, account)
-        }
+  override fun onSendFriendRequest(curr: Account, account: Account) {
+    scope.launch {
+      RepositoryProvider.accounts.sendFriendRequest(curr, account.uid)
+      RepositoryProvider.accounts.sendFriendRequestNotification(curr.uid, account)
     }
+  }
 
-    override fun onRemoveFriend(curr: Account, account: Account) {
-        scope.launch {
-            RepositoryProvider.accounts.resetRelationship(curr.uid, account.uid)
-        }
-    }
+  override fun onRemoveFriend(curr: Account, account: Account) {
+    scope.launch { RepositoryProvider.accounts.resetRelationship(curr.uid, account.uid) }
+  }
 }

--- a/app/src/main/java/com/github/meeplemeet/model/account/AccountViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/AccountViewModel.kt
@@ -162,6 +162,10 @@ interface AccountViewModel : UserProfilePopupActions {
     }
   }
 
+  override fun onCancel(curr: Account, other: Account) {
+    scope.launch { RepositoryProvider.accounts.resetRelationship(curr.uid, other.uid) }
+  }
+
   override fun onRemoveFriend(curr: Account, other: Account) {
     scope.launch { RepositoryProvider.accounts.resetRelationship(curr.uid, other.uid) }
   }

--- a/app/src/main/java/com/github/meeplemeet/model/account/AccountViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/AccountViewModel.kt
@@ -16,7 +16,7 @@ const val BLANK_ACCOUNT_ID_ERROR = "Account id cannot be blank"
  * repository. It uses coroutines to perform asynchronous operations and requires implementing
  * classes to provide a CoroutineScope.
  */
-interface AccountViewModel {
+interface AccountViewModel : UserProfilePopupActions {
   /** The CoroutineScope used for launching coroutines. */
   val scope: CoroutineScope
 
@@ -150,4 +150,23 @@ interface AccountViewModel {
       RepositoryProvider.accounts.deleteAccount(account.uid)
     }
   }
+
+    override fun onBlock(curr: Account, account: Account) {
+        scope.launch {
+            RepositoryProvider.accounts.blockUser(curr.uid, account.uid)
+        }
+    }
+
+    override fun onSendFriendRequest(curr: Account, account: Account) {
+        scope.launch {
+            RepositoryProvider.accounts.sendFriendRequest(curr, account.uid)
+            RepositoryProvider.accounts.sendFriendRequestNotification(curr.uid, account)
+        }
+    }
+
+    override fun onRemoveFriend(curr: Account, account: Account) {
+        scope.launch {
+            RepositoryProvider.accounts.resetRelationship(curr.uid, account.uid)
+        }
+    }
 }

--- a/app/src/main/java/com/github/meeplemeet/model/account/AccountViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/AccountViewModel.kt
@@ -151,18 +151,18 @@ interface AccountViewModel : UserProfilePopupActions {
     }
   }
 
-  override fun onBlock(curr: Account, account: Account) {
-    scope.launch { RepositoryProvider.accounts.blockUser(curr.uid, account.uid) }
+  override fun onBlock(curr: Account, other: Account) {
+    scope.launch { RepositoryProvider.accounts.blockUser(curr.uid, other.uid) }
   }
 
-  override fun onSendFriendRequest(curr: Account, account: Account) {
+  override fun onSendFriendRequest(curr: Account, other: Account) {
     scope.launch {
-      RepositoryProvider.accounts.sendFriendRequest(curr, account.uid)
-      RepositoryProvider.accounts.sendFriendRequestNotification(curr.uid, account)
+      RepositoryProvider.accounts.sendFriendRequest(curr, other.uid)
+      RepositoryProvider.accounts.sendFriendRequestNotification(other.uid, curr)
     }
   }
 
-  override fun onRemoveFriend(curr: Account, account: Account) {
-    scope.launch { RepositoryProvider.accounts.resetRelationship(curr.uid, account.uid) }
+  override fun onRemoveFriend(curr: Account, other: Account) {
+    scope.launch { RepositoryProvider.accounts.resetRelationship(curr.uid, other.uid) }
   }
 }

--- a/app/src/main/java/com/github/meeplemeet/model/account/FriendsScreenViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/FriendsScreenViewModel.kt
@@ -27,7 +27,7 @@ class FriendsScreenViewModel(
     private val accountRepository: AccountRepository = RepositoryProvider.accounts,
     handlesRepository: HandlesRepository = RepositoryProvider.handles,
     private val imageRepository: ImageRepository = RepositoryProvider.images,
-) : CreateAccountViewModel(handlesRepository) {
+) : CreateAccountViewModel(handlesRepository), UserProfilePopupActions {
 
   private fun executeNotification(account: Account, notification: Notification) {
     if (notification.receiverId != account.uid) return
@@ -102,6 +102,10 @@ class FriendsScreenViewModel(
    * @param account The account sending the friend request
    * @param other The account receiving the friend request
    */
+  override fun onSendFriendRequest(curr: Account, other: Account) {
+    sendFriendRequest(curr, other)
+  }
+
   fun sendFriendRequest(account: Account, other: Account) {
     scope.launch {
       val otherLoaded = accountRepository.getAccountWithRelationships(other.uid)
@@ -128,6 +132,10 @@ class FriendsScreenViewModel(
    * @param account The account performing the block action
    * @param other The account being blocked
    */
+  override fun onBlock(curr: Account, other: Account) {
+    blockUser(curr, other)
+  }
+
   fun blockUser(account: Account, other: Account) {
     if (account.uid == other.uid || account.relationships[other.uid] == RelationshipStatus.BLOCKED)
         return
@@ -148,6 +156,10 @@ class FriendsScreenViewModel(
    * @param account The account canceling the sent friend request
    * @param other The account to whom the friend request was sent
    */
+  override fun onCancel(curr: Account, other: Account) {
+    rejectFriendRequest(curr, other)
+  }
+
   fun rejectFriendRequest(account: Account, other: Account) {
     if (sameOrBlocked(account, other)) return
 
@@ -167,6 +179,10 @@ class FriendsScreenViewModel(
    * @param account The account removing the friendship
    * @param friend The friend to be removed
    */
+  override fun onRemoveFriend(curr: Account, other: Account) {
+    removeFriend(curr, other)
+  }
+
   fun removeFriend(account: Account, friend: Account) {
     if (sameOrBlocked(account, friend)) return
 

--- a/app/src/main/java/com/github/meeplemeet/model/account/UserPopupActions.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/UserPopupActions.kt
@@ -1,7 +1,9 @@
 package com.github.meeplemeet.model.account
 
 interface UserProfilePopupActions {
-    fun onBlock(curr: Account, account: Account)
-    fun onSendFriendRequest(curr: Account, account: Account)
-    fun onRemoveFriend(curr: Account, account: Account)
+  fun onBlock(curr: Account, account: Account)
+
+  fun onSendFriendRequest(curr: Account, account: Account)
+
+  fun onRemoveFriend(curr: Account, account: Account)
 }

--- a/app/src/main/java/com/github/meeplemeet/model/account/UserPopupActions.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/UserPopupActions.kt
@@ -1,9 +1,9 @@
 package com.github.meeplemeet.model.account
 
 interface UserProfilePopupActions {
-  fun onBlock(curr: Account, account: Account)
+  fun onBlock(curr: Account, other: Account)
 
-  fun onSendFriendRequest(curr: Account, account: Account)
+  fun onSendFriendRequest(curr: Account, other: Account)
 
-  fun onRemoveFriend(curr: Account, account: Account)
+  fun onRemoveFriend(curr: Account, other: Account)
 }

--- a/app/src/main/java/com/github/meeplemeet/model/account/UserPopupActions.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/UserPopupActions.kt
@@ -1,0 +1,7 @@
+package com.github.meeplemeet.model.account
+
+interface UserProfilePopupActions {
+    fun onBlock(curr: Account, account: Account)
+    fun onSendFriendRequest(curr: Account, account: Account)
+    fun onRemoveFriend(curr: Account, account: Account)
+}

--- a/app/src/main/java/com/github/meeplemeet/model/account/UserPopupActions.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/account/UserPopupActions.kt
@@ -6,4 +6,6 @@ interface UserProfilePopupActions {
   fun onSendFriendRequest(curr: Account, other: Account)
 
   fun onRemoveFriend(curr: Account, other: Account)
+
+  fun onCancel(curr: Account, other: Account)
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/account/FriendsScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/FriendsScreen.kt
@@ -76,6 +76,7 @@ import com.github.meeplemeet.model.account.FriendsScreenViewModel
 import com.github.meeplemeet.model.account.RelationshipStatus
 import com.github.meeplemeet.ui.FocusableInputField
 import com.github.meeplemeet.ui.UiBehaviorConfig
+import com.github.meeplemeet.ui.components.UserProfilePopup
 import com.github.meeplemeet.ui.navigation.BottomBarWithVerification
 import com.github.meeplemeet.ui.navigation.MeepleMeetScreen
 import com.github.meeplemeet.ui.navigation.NavigationActions
@@ -453,6 +454,28 @@ private fun FriendsManagementContent(
 ) {
   val isSearching = searchQuery.isNotBlank()
 
+  // --- Popup state & actions ---
+  var showPopup by remember { mutableStateOf(false) }
+  var selectedUser by remember { mutableStateOf<Account?>(null) }
+
+  if (showPopup && selectedUser != null) {
+    val user = selectedUser!!
+    val isFriend = account.relationships[user.uid] == RelationshipStatus.FRIEND
+    UserProfilePopup(
+        visible = showPopup,
+        curr = account,
+        target = user,
+        isFriend = isFriend,
+        online = true,
+        onDismiss = { showPopup = false },
+        actions = viewModel)
+  }
+
+  val onAvatarClick: (Account) -> Unit = { user ->
+    selectedUser = user
+    showPopup = true
+  }
+
   if (isSearching) {
     FriendsSearchResultsDropdown(
         currentAccount = account,
@@ -461,6 +484,7 @@ private fun FriendsManagementContent(
         onAddFriend = { other -> viewModel.sendFriendRequest(account, other) },
         onRemoveFriend = { other -> viewModel.removeFriend(account, other) },
         onCancelRequest = { other -> viewModel.rejectFriendRequest(account, other) },
+        onAvatarClick = onAvatarClick,
         onClearFocus = onClearFocus,
     )
   } else {
@@ -471,6 +495,7 @@ private fun FriendsManagementContent(
             friends = lists.friends,
             onBlockToggle = { friend -> toggleBlock(account, friend, viewModel) },
             onRemoveFriend = { friend -> viewModel.removeFriend(account, friend) },
+            onAvatarClick = onAvatarClick,
             onClearFocus = onClearFocus,
         )
       }
@@ -480,6 +505,7 @@ private fun FriendsManagementContent(
             sentRequests = lists.sentRequests,
             onBlockToggle = { other -> toggleBlock(account, other, viewModel) },
             onCancelRequest = { other -> viewModel.rejectFriendRequest(account, other) },
+            onAvatarClick = onAvatarClick,
             onClearFocus = onClearFocus,
         )
       }
@@ -487,6 +513,7 @@ private fun FriendsManagementContent(
         BlockedUsersList(
             blockedUsers = lists.blockedUsers,
             onUnblock = { other -> viewModel.unblockUser(account, other) },
+            onAvatarClick = onAvatarClick,
             onClearFocus = onClearFocus,
         )
       }
@@ -710,6 +737,7 @@ private fun RelationshipUserRow(
     onBlockClick: () -> Unit,
     onSecondaryActionClick: () -> Unit,
     showSecondaryAction: Boolean = true,
+    onAvatarClick: () -> Unit = {},
 ) {
   val (itemPrefix, blockButtonPrefix, actionButtonPrefix) = prefixesFor(context)
 
@@ -729,7 +757,8 @@ private fun RelationshipUserRow(
         account = user,
         modifier =
             Modifier.size(FriendsManagementDefaults.Avatar.SIZE)
-                .testTag("${FriendsManagementTestTags.AVATAR_PREFIX}${user.uid}"),
+                .testTag("${FriendsManagementTestTags.AVATAR_PREFIX}${user.uid}")
+                .clickable { onAvatarClick() },
     )
 
     Spacer(Modifier.width(FriendsManagementDefaults.Layout.ITEM_AVATAR_NAME_SPACING))
@@ -954,6 +983,7 @@ private fun FriendsList(
     friends: List<Account>,
     onBlockToggle: (Account) -> Unit,
     onRemoveFriend: (Account) -> Unit,
+    onAvatarClick: (Account) -> Unit,
     onClearFocus: () -> Unit = {},
 ) {
   FriendsListContainer(
@@ -971,6 +1001,7 @@ private fun FriendsList(
         context = UserRowContext.FRIEND_LIST,
         onBlockClick = { onBlockToggle(friend) },
         onSecondaryActionClick = { onRemoveFriend(friend) },
+        onAvatarClick = { onAvatarClick(friend) },
     )
   }
 }
@@ -990,6 +1021,7 @@ private fun SentRequestsList(
     sentRequests: List<Account>,
     onBlockToggle: (Account) -> Unit,
     onCancelRequest: (Account) -> Unit,
+    onAvatarClick: (Account) -> Unit,
     onClearFocus: () -> Unit = {},
 ) {
   FriendsListContainer(
@@ -1007,6 +1039,7 @@ private fun SentRequestsList(
         context = UserRowContext.FRIEND_LIST,
         onBlockClick = { onBlockToggle(other) },
         onSecondaryActionClick = { onCancelRequest(other) },
+        onAvatarClick = { onAvatarClick(other) },
     )
   }
 }
@@ -1022,6 +1055,7 @@ private fun SentRequestsList(
 private fun BlockedUsersList(
     blockedUsers: List<Account>,
     onUnblock: (Account) -> Unit,
+    onAvatarClick: (Account) -> Unit,
     onClearFocus: () -> Unit = {},
 ) {
   FriendsListContainer(
@@ -1037,6 +1071,7 @@ private fun BlockedUsersList(
         onBlockClick = { onUnblock(other) },
         onSecondaryActionClick = {},
         showSecondaryAction = false,
+        onAvatarClick = { onAvatarClick(other) },
     )
   }
 }
@@ -1151,6 +1186,7 @@ private fun FriendsSearchResultsDropdown(
     onAddFriend: (Account) -> Unit,
     onRemoveFriend: (Account) -> Unit,
     onCancelRequest: (Account) -> Unit,
+    onAvatarClick: (Account) -> Unit,
     onClearFocus: () -> Unit = {},
 ) {
   val visibleResults =
@@ -1211,6 +1247,7 @@ private fun FriendsSearchResultsDropdown(
               }
             },
             showSecondaryAction = secondaryAction != null,
+            onAvatarClick = { onAvatarClick(other) },
         )
       }
     }

--- a/app/src/main/java/com/github/meeplemeet/ui/components/CommonComponents.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/CommonComponents.kt
@@ -603,6 +603,7 @@ fun UserProfilePopup(
     curr: Account,
     target: Account,
     isFriend: Boolean,
+    online: Boolean,
     onDismiss: () -> Unit,
     actions: UserProfilePopupActions
 ) {
@@ -715,8 +716,11 @@ fun UserProfilePopup(
                               snackbarMessage = "Blocked ${target.name} successfully."
                             },
                             modifier = Modifier.weight(0.7f),
+                            enabled = online,
                             colors =
-                                ButtonDefaults.buttonColors(containerColor = AppColors.primary),
+                                ButtonDefaults.buttonColors(
+                                    containerColor = AppColors.negative,
+                                    contentColor = AppColors.textIcons),
                             shape = RoundedCornerShape(Dimensions.CornerRadius.medium),
                             contentPadding =
                                 PaddingValues(vertical = Dimensions.Spacing.extraLarge)) {
@@ -740,9 +744,10 @@ fun UserProfilePopup(
                                 snackbarMessage = "Friend request sent to ${target.name}."
                               },
                               modifier = Modifier.weight(1f),
+                              enabled = online,
                               colors =
                                   ButtonDefaults.buttonColors(
-                                      containerColor = AppColors.primary,
+                                      containerColor = AppColors.affirmative,
                                       contentColor = AppColors.textIcons),
                               shape = RoundedCornerShape(Dimensions.CornerRadius.medium),
                               contentPadding =
@@ -765,6 +770,7 @@ fun UserProfilePopup(
                                 snackbarMessage = "${target.name} removed from Friends."
                               },
                               modifier = Modifier.weight(1f),
+                              enabled = online,
                               colors =
                                   ButtonDefaults.buttonColors(
                                       containerColor = AppColors.primary,

--- a/app/src/main/java/com/github/meeplemeet/ui/components/CommonComponents.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/CommonComponents.kt
@@ -582,6 +582,21 @@ fun ConfirmationDialog(
   }
 }
 
+/**
+ * Displays a popup dialog showing another user's profile information with action buttons.
+ *
+ * This composable presents a dialog containing the target user's profile details including their
+ * name, handle, avatar, and description. It provides interactive buttons to block the user or
+ * manage friendship status (send friend request or remove friend).
+ *
+ * @param visible Whether the popup dialog should be displayed. If false, nothing is rendered.
+ * @param curr The current user's account performing the action.
+ * @param target The target user whose profile is being displayed.
+ * @param isFriend Whether the target user is currently a friend of the current user.
+ * @param onDismiss Callback invoked when the dialog should be dismissed.
+ * @param actions Implementation of [UserProfilePopupActions] providing block and friend management
+ *   functionality.
+ */
 @Composable
 fun UserProfilePopup(
     visible: Boolean,
@@ -650,7 +665,8 @@ fun UserProfilePopup(
                               painter = rememberAsyncImagePainter(target.photoUrl),
                               contentDescription = "User's avatar",
                               contentScale = ContentScale.Crop,
-                              modifier = Modifier.size(Dimensions.IconSize.massive).clip(CircleShape))
+                              modifier =
+                                  Modifier.size(Dimensions.IconSize.massive).clip(CircleShape))
                         }
                       }
 
@@ -664,7 +680,10 @@ fun UserProfilePopup(
                   Text(
                       text = description,
                       color = AppColors.textIcons,
-                      modifier = Modifier.padding(bottom = Dimensions.Spacing.medium, top = Dimensions.Spacing.extraLarge),
+                      modifier =
+                          Modifier.padding(
+                              bottom = Dimensions.Spacing.medium,
+                              top = Dimensions.Spacing.extraLarge),
                       fontSize = Dimensions.TextSize.subtitle,
                       maxLines = if (isExpanded) maxLinesExpanded else maxLinesNotExpanded,
                       overflow = TextOverflow.Ellipsis,
@@ -675,10 +694,14 @@ fun UserProfilePopup(
                   if (showShowMore || isExpanded) {
                     Text(
                         text = if (isExpanded) "Show less" else "Show more",
-                        color = AppColors.textIcons.copy(alpha = Dimensions.Alpha.dialogIconTranslucent),
+                        color =
+                            AppColors.textIcons.copy(
+                                alpha = Dimensions.Alpha.dialogIconTranslucent),
                         fontSize = Dimensions.TextSize.standard,
                         modifier =
-                            Modifier.padding(top = Dimensions.Spacing.small).clickable { isExpanded = !isExpanded })
+                            Modifier.padding(top = Dimensions.Spacing.small).clickable {
+                              isExpanded = !isExpanded
+                            })
                   }
 
                   // Action buttons
@@ -695,14 +718,18 @@ fun UserProfilePopup(
                             colors =
                                 ButtonDefaults.buttonColors(containerColor = AppColors.primary),
                             shape = RoundedCornerShape(Dimensions.CornerRadius.medium),
-                            contentPadding = PaddingValues(vertical = Dimensions.Spacing.extraLarge)) {
+                            contentPadding =
+                                PaddingValues(vertical = Dimensions.Spacing.extraLarge)) {
                               Icon(
                                   imageVector = Icons.Default.Block,
                                   contentDescription = "Block",
                                   tint = AppColors.textIcons,
                                   modifier = Modifier.size(Dimensions.IconSize.standard))
                               Spacer(modifier = Modifier.width(Dimensions.Spacing.medium))
-                              Text(text = "Block", color = AppColors.textIcons, fontSize = Dimensions.TextSize.subtitle)
+                              Text(
+                                  text = "Block",
+                                  color = AppColors.textIcons,
+                                  fontSize = Dimensions.TextSize.subtitle)
                             }
 
                         // Send friend request button
@@ -718,7 +745,8 @@ fun UserProfilePopup(
                                       containerColor = AppColors.primary,
                                       contentColor = AppColors.textIcons),
                               shape = RoundedCornerShape(Dimensions.CornerRadius.medium),
-                              contentPadding = PaddingValues(vertical = Dimensions.Spacing.extraLarge)) {
+                              contentPadding =
+                                  PaddingValues(vertical = Dimensions.Spacing.extraLarge)) {
                                 Icon(
                                     imageVector = Icons.Default.PersonAdd,
                                     contentDescription = "Send friend request",
@@ -742,7 +770,8 @@ fun UserProfilePopup(
                                       containerColor = AppColors.primary,
                                       contentColor = AppColors.textIcons),
                               shape = RoundedCornerShape(Dimensions.CornerRadius.medium),
-                              contentPadding = PaddingValues(vertical = Dimensions.Spacing.extraLarge)) {
+                              contentPadding =
+                                  PaddingValues(vertical = Dimensions.Spacing.extraLarge)) {
                                 Icon(
                                     imageVector = Icons.Default.PersonRemove,
                                     contentDescription = "Remove friend",
@@ -762,7 +791,10 @@ fun UserProfilePopup(
           // Snackbar
           SnackbarHost(
               hostState = snackbarHostState,
-              modifier = Modifier.align(Alignment.BottomCenter).padding(Dimensions.Spacing.extraLarge).offset(y = SNACKBAR_OFFSET),
+              modifier =
+                  Modifier.align(Alignment.BottomCenter)
+                      .padding(Dimensions.Spacing.extraLarge)
+                      .offset(y = SNACKBAR_OFFSET),
               snackbar = { data ->
                 Snackbar(
                     snackbarData = data,

--- a/app/src/main/java/com/github/meeplemeet/ui/components/CommonComponents.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/CommonComponents.kt
@@ -72,7 +72,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.core.content.ContextCompat
@@ -107,6 +106,7 @@ object CommonComponentsTestTags {
 
 // The default size for the image carousel.
 val CAROUSEL_SIZE = 260.dp
+val SNACKBAR_OFFSET = 50.dp
 
 // The label for the "Add Picture" action.
 const val ADD_PICTURE = "Add Picture"
@@ -608,10 +608,10 @@ fun UserProfilePopup(
       properties = DialogProperties(usePlatformDefaultWidth = false)) {
         Box {
           Card(
-              modifier = Modifier.fillMaxWidth().padding(10.dp),
-              shape = RoundedCornerShape(16.dp),
+              modifier = Modifier.fillMaxWidth().padding(Dimensions.Spacing.extraMedium),
+              shape = RoundedCornerShape(Dimensions.CornerRadius.extraLarge),
               colors = CardDefaults.cardColors(containerColor = AppColors.secondary)) {
-                Column(modifier = Modifier.fillMaxWidth().padding(24.dp)) {
+                Column(modifier = Modifier.fillMaxWidth().padding(Dimensions.Spacing.xxLarge)) {
                   Row(
                       modifier = Modifier.fillMaxWidth(),
                       horizontalArrangement = Arrangement.SpaceBetween,
@@ -620,22 +620,22 @@ fun UserProfilePopup(
                           Text(
                               text = target.name,
                               color = AppColors.textIcons,
-                              fontSize = 24.sp,
+                              fontSize = Dimensions.TextSize.large,
                               fontWeight = FontWeight.Bold,
                           )
 
                           Text(
                               text = "@" + target.handle,
                               color = AppColors.textIcons,
-                              fontSize = 18.sp,
-                              modifier = Modifier.padding(top = 8.dp))
+                              fontSize = Dimensions.TextSize.heading,
+                              modifier = Modifier.padding(top = Dimensions.Spacing.medium))
                         }
 
                         // Profile image
                         if (target.photoUrl.isNullOrBlank()) {
                           Box(
                               modifier =
-                                  Modifier.size(90.dp)
+                                  Modifier.size(Dimensions.IconSize.massive)
                                       .clip(CircleShape)
                                       .background(AppColors.textIconsFade),
                               contentAlignment = Alignment.Center) {
@@ -650,7 +650,7 @@ fun UserProfilePopup(
                               painter = rememberAsyncImagePainter(target.photoUrl),
                               contentDescription = "User's avatar",
                               contentScale = ContentScale.Crop,
-                              modifier = Modifier.size(90.dp).clip(CircleShape))
+                              modifier = Modifier.size(Dimensions.IconSize.massive).clip(CircleShape))
                         }
                       }
 
@@ -664,8 +664,8 @@ fun UserProfilePopup(
                   Text(
                       text = description,
                       color = AppColors.textIcons,
-                      modifier = Modifier.padding(bottom = 4.dp),
-                      fontSize = 16.sp,
+                      modifier = Modifier.padding(bottom = Dimensions.Spacing.medium, top = Dimensions.Spacing.extraLarge),
+                      fontSize = Dimensions.TextSize.subtitle,
                       maxLines = if (isExpanded) maxLinesExpanded else maxLinesNotExpanded,
                       overflow = TextOverflow.Ellipsis,
                       onTextLayout = { textLayoutResult ->
@@ -675,16 +675,16 @@ fun UserProfilePopup(
                   if (showShowMore || isExpanded) {
                     Text(
                         text = if (isExpanded) "Show less" else "Show more",
-                        color = AppColors.textIcons.copy(alpha = 0.7f),
-                        fontSize = 14.sp,
+                        color = AppColors.textIcons.copy(alpha = Dimensions.Alpha.dialogIconTranslucent),
+                        fontSize = Dimensions.TextSize.standard,
                         modifier =
-                            Modifier.padding(top = 4.dp).clickable { isExpanded = !isExpanded })
+                            Modifier.padding(top = Dimensions.Spacing.small).clickable { isExpanded = !isExpanded })
                   }
 
                   // Action buttons
                   Row(
                       modifier = Modifier.fillMaxWidth(),
-                      horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                      horizontalArrangement = Arrangement.spacedBy(Dimensions.Spacing.extraLarge)) {
                         // Block button
                         Button(
                             onClick = {
@@ -694,15 +694,15 @@ fun UserProfilePopup(
                             modifier = Modifier.weight(0.7f),
                             colors =
                                 ButtonDefaults.buttonColors(containerColor = AppColors.primary),
-                            shape = RoundedCornerShape(8.dp),
-                            contentPadding = PaddingValues(vertical = 16.dp)) {
+                            shape = RoundedCornerShape(Dimensions.CornerRadius.medium),
+                            contentPadding = PaddingValues(vertical = Dimensions.Spacing.extraLarge)) {
                               Icon(
                                   imageVector = Icons.Default.Block,
                                   contentDescription = "Block",
                                   tint = AppColors.textIcons,
-                                  modifier = Modifier.size(20.dp))
-                              Spacer(modifier = Modifier.width(8.dp))
-                              Text(text = "Block", color = AppColors.textIcons, fontSize = 16.sp)
+                                  modifier = Modifier.size(Dimensions.IconSize.standard))
+                              Spacer(modifier = Modifier.width(Dimensions.Spacing.medium))
+                              Text(text = "Block", color = AppColors.textIcons, fontSize = Dimensions.TextSize.subtitle)
                             }
 
                         // Send friend request button
@@ -717,18 +717,18 @@ fun UserProfilePopup(
                                   ButtonDefaults.buttonColors(
                                       containerColor = AppColors.primary,
                                       contentColor = AppColors.textIcons),
-                              shape = RoundedCornerShape(8.dp),
-                              contentPadding = PaddingValues(vertical = 16.dp)) {
+                              shape = RoundedCornerShape(Dimensions.CornerRadius.medium),
+                              contentPadding = PaddingValues(vertical = Dimensions.Spacing.extraLarge)) {
                                 Icon(
                                     imageVector = Icons.Default.PersonAdd,
                                     contentDescription = "Send friend request",
                                     tint = AppColors.textIcons,
-                                    modifier = Modifier.size(20.dp))
-                                Spacer(modifier = Modifier.width(8.dp))
+                                    modifier = Modifier.size(Dimensions.IconSize.standard))
+                                Spacer(modifier = Modifier.width(Dimensions.Spacing.medium))
                                 Text(
                                     text = "Send friend request",
                                     color = AppColors.textIcons,
-                                    fontSize = 16.sp)
+                                    fontSize = Dimensions.TextSize.subtitle)
                               }
                         } else {
                           Button(
@@ -741,18 +741,18 @@ fun UserProfilePopup(
                                   ButtonDefaults.buttonColors(
                                       containerColor = AppColors.primary,
                                       contentColor = AppColors.textIcons),
-                              shape = RoundedCornerShape(8.dp),
-                              contentPadding = PaddingValues(vertical = 16.dp)) {
+                              shape = RoundedCornerShape(Dimensions.CornerRadius.medium),
+                              contentPadding = PaddingValues(vertical = Dimensions.Spacing.extraLarge)) {
                                 Icon(
                                     imageVector = Icons.Default.PersonRemove,
                                     contentDescription = "Remove friend",
                                     tint = AppColors.textIcons,
-                                    modifier = Modifier.size(20.dp))
-                                Spacer(modifier = Modifier.width(8.dp))
+                                    modifier = Modifier.size(Dimensions.IconSize.standard))
+                                Spacer(modifier = Modifier.width(Dimensions.Spacing.medium))
                                 Text(
                                     text = "Remove friend",
                                     color = AppColors.textIcons,
-                                    fontSize = 16.sp)
+                                    fontSize = Dimensions.TextSize.subtitle)
                               }
                         }
                       }
@@ -762,7 +762,7 @@ fun UserProfilePopup(
           // Snackbar
           SnackbarHost(
               hostState = snackbarHostState,
-              modifier = Modifier.align(Alignment.BottomCenter).padding(16.dp).offset(y = 50.dp),
+              modifier = Modifier.align(Alignment.BottomCenter).padding(Dimensions.Spacing.extraLarge).offset(y = SNACKBAR_OFFSET),
               snackbar = { data ->
                 Snackbar(
                     snackbarData = data,

--- a/app/src/main/java/com/github/meeplemeet/ui/components/CommonComponents.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/CommonComponents.kt
@@ -68,9 +68,12 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
@@ -729,7 +732,15 @@ fun UserProfilePopup(
                         Button(
                             onClick = {
                               actions.onBlock(curr, target)
-                              snackbarMessage = "Blocked ${target.name} successfully."
+                              snackbarMessage =
+                                  buildAnnotatedString {
+                                        append("Blocked ")
+                                        withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
+                                          append(target.name)
+                                        }
+                                        append(" successfully.")
+                                      }
+                                      .toString()
                             },
                             modifier =
                                 Modifier.weight(0.7f)
@@ -763,7 +774,26 @@ fun UserProfilePopup(
                               onClick = {
                                 if (!isRequestSent) {
                                   actions.onSendFriendRequest(curr, target)
-                                  snackbarMessage = "Friend request sent to ${target.name}."
+                                  snackbarMessage =
+                                      buildAnnotatedString {
+                                            append("Friend request sent to")
+                                            withStyle(
+                                                style = SpanStyle(fontWeight = FontWeight.Bold)) {
+                                                  append(target.name)
+                                                }
+                                          }
+                                          .toString()
+                                } else {
+                                  actions.onCancel(curr, target)
+                                  snackbarMessage =
+                                      buildAnnotatedString {
+                                            append("Successfully canceled friend request to ")
+                                            withStyle(
+                                                style = SpanStyle(fontWeight = FontWeight.Bold)) {
+                                                  append(target.name)
+                                                }
+                                          }
+                                          .toString()
                                 }
                               },
                               modifier =
@@ -771,7 +801,7 @@ fun UserProfilePopup(
                                       .testTag(
                                           CommonComponentsTestTags
                                               .USER_PROFILE_POPUP_SEND_REQUEST_BUTTON),
-                              enabled = online && !isRequestSent,
+                              enabled = online,
                               colors =
                                   ButtonDefaults.buttonColors(
                                       containerColor =
@@ -790,14 +820,14 @@ fun UserProfilePopup(
                                         if (isRequestSent) Icons.Default.Person
                                         else Icons.Default.PersonAdd,
                                     contentDescription =
-                                        if (isRequestSent) "Request Sent"
+                                        if (isRequestSent) "Cancel request"
                                         else "Send friend request",
                                     tint = AppColors.textIcons,
                                     modifier = Modifier.size(Dimensions.IconSize.standard))
                                 Spacer(modifier = Modifier.width(Dimensions.Spacing.medium))
                                 Text(
                                     text =
-                                        if (isRequestSent) "Request Sent"
+                                        if (isRequestSent) "Cancel request"
                                         else "Send friend request",
                                     color = AppColors.textIcons,
                                     fontSize = Dimensions.TextSize.subtitle)
@@ -806,7 +836,15 @@ fun UserProfilePopup(
                           Button(
                               onClick = {
                                 actions.onRemoveFriend(curr, target)
-                                snackbarMessage = "${target.name} removed from Friends."
+                                snackbarMessage =
+                                    buildAnnotatedString {
+                                          withStyle(
+                                              style = SpanStyle(fontWeight = FontWeight.Bold)) {
+                                                append(target.name)
+                                              }
+                                          append(" removed from friends")
+                                        }
+                                        .toString()
                               },
                               modifier =
                                   Modifier.weight(1f)

--- a/app/src/main/java/com/github/meeplemeet/ui/components/CommonComponents.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/CommonComponents.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -47,9 +48,14 @@ import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -74,6 +80,7 @@ import coil.compose.AsyncImage
 import coil.compose.rememberAsyncImagePainter
 import com.github.meeplemeet.R
 import com.github.meeplemeet.model.account.Account
+import com.github.meeplemeet.model.account.UserProfilePopupActions
 import com.github.meeplemeet.model.images.ImageFileUtils
 import com.github.meeplemeet.ui.discussions.UITestTags
 import com.github.meeplemeet.ui.theme.AppColors
@@ -181,7 +188,9 @@ fun ImageCarousel(
       modifier = modifier.testTag(CommonComponentsTestTags.IMAGE_CAROUSEL),
       horizontalAlignment = Alignment.CenterHorizontally) {
         ElevatedCard(
-            modifier = Modifier.fillMaxWidth().height(CAROUSEL_SIZE),
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(CAROUSEL_SIZE),
             colors =
                 CardColors(
                     containerColor = AppColors.secondary,
@@ -195,7 +204,8 @@ fun ImageCarousel(
                     canAddMoreImages) {
                   Box(
                       modifier =
-                          Modifier.fillMaxSize()
+                          Modifier
+                              .fillMaxSize()
                               .padding(Dimensions.Padding.giant)
                               .testTag(CommonComponentsTestTags.CAROUSEL_ADD_BUTTON)
                               .clickable { if (canAddMoreImages) showImageSourceMenu = true },
@@ -218,7 +228,8 @@ fun ImageCarousel(
                         contentDescription = "Discussion Profile Picture",
                         contentScale = ContentScale.Fit,
                         modifier =
-                            Modifier.fillMaxSize()
+                            Modifier
+                                .fillMaxSize()
                                 .clickable { showImageSourceMenu = true }
                                 .testTag(CommonComponentsTestTags.CAROUSEL_IMAGE),
                         placeholder =
@@ -227,7 +238,8 @@ fun ImageCarousel(
                     if (page < photoCollectionUrl.size && editable) {
                       Box(
                           modifier =
-                              Modifier.align(Alignment.TopEnd)
+                              Modifier
+                                  .align(Alignment.TopEnd)
                                   .padding(Dimensions.Padding.medium)
                                   .size(Dimensions.IconSize.extraLarge)
                                   .clip(CircleShape)
@@ -260,14 +272,17 @@ fun ImageCarousel(
 
                   Box(
                       modifier =
-                          Modifier.padding(Dimensions.Padding.small)
+                          Modifier
+                              .padding(Dimensions.Padding.small)
                               .size(
                                   if (selected) Dimensions.Padding.extraMedium
-                                  else Dimensions.Padding.medium)
+                                  else Dimensions.Padding.medium
+                              )
                               .clip(CircleShape)
                               .background(
                                   if (selected) MaterialTheme.colorScheme.primary
-                                  else MaterialTheme.colorScheme.surfaceVariant)
+                                  else MaterialTheme.colorScheme.surfaceVariant
+                              )
                               .testTag(CommonComponentsTestTags.DOT))
                 }
               }
@@ -323,13 +338,19 @@ fun PhotoDialogTopBar(
                       listOf(
                           AppColors.primary.copy(alpha = Dimensions.Alpha.dialogOverlayDark),
                           AppColors.primary.copy(
-                              alpha = Dimensions.Alpha.dialogOverlayTransparent))))) {
+                              alpha = Dimensions.Alpha.dialogOverlayTransparent
+                          )
+                      )
+                  )
+              )) {
         Row(
             modifier =
-                Modifier.fillMaxWidth()
+                Modifier
+                    .fillMaxWidth()
                     .padding(
                         horizontal = Dimensions.Padding.extraLarge,
-                        vertical = Dimensions.Spacing.medium),
+                        vertical = Dimensions.Spacing.medium
+                    ),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween) {
               IconButton(
@@ -346,7 +367,8 @@ fun PhotoDialogTopBar(
                   color = AppColors.textIcons,
                   style = MaterialTheme.typography.titleMedium,
                   modifier =
-                      Modifier.weight(Dimensions.Weight.full)
+                      Modifier
+                          .weight(Dimensions.Weight.full)
                           .padding(horizontal = Dimensions.Spacing.large)
                           .testTag(UITestTags.PROFILE_PICTURE_DIALOG_TITLE),
                   textAlign = TextAlign.Center)
@@ -369,13 +391,18 @@ fun PhotoDialogBottomBar(
     onTakePhoto: () -> Unit,
     onChooseFromGallery: () -> Unit
 ) {
-  Box(modifier = modifier.fillMaxWidth().navigationBarsPadding().background(AppColors.primary)) {
+  Box(modifier = modifier
+      .fillMaxWidth()
+      .navigationBarsPadding()
+      .background(AppColors.primary)) {
     Row(
         modifier =
-            Modifier.fillMaxWidth()
+            Modifier
+                .fillMaxWidth()
                 .padding(
                     horizontal = Dimensions.Padding.extraLarge,
-                    vertical = Dimensions.Spacing.extraLarge),
+                    vertical = Dimensions.Spacing.extraLarge
+                ),
         horizontalArrangement =
             Arrangement.spacedBy(Dimensions.Spacing.large, Alignment.CenterHorizontally),
         verticalAlignment = Alignment.CenterVertically) {
@@ -385,7 +412,9 @@ fun PhotoDialogBottomBar(
                   ButtonDefaults.buttonColors(
                       containerColor = AppColors.textIcons.copy(alpha = 0.2f),
                       contentColor = AppColors.textIconsFade),
-              modifier = Modifier.weight(1f).testTag(UITestTags.PROFILE_PICTURE_CAMERA_OPTION)) {
+              modifier = Modifier
+                  .weight(1f)
+                  .testTag(UITestTags.PROFILE_PICTURE_CAMERA_OPTION)) {
                 Icon(
                     imageVector = Icons.Default.PhotoCamera,
                     contentDescription = "Take Photo",
@@ -403,7 +432,9 @@ fun PhotoDialogBottomBar(
                   ButtonDefaults.buttonColors(
                       containerColor = AppColors.textIcons.copy(alpha = 0.2f),
                       contentColor = AppColors.textIconsFade),
-              modifier = Modifier.weight(1f).testTag(UITestTags.PROFILE_PICTURE_GALLERY_OPTION)) {
+              modifier = Modifier
+                  .weight(1f)
+                  .testTag(UITestTags.PROFILE_PICTURE_GALLERY_OPTION)) {
                 Icon(
                     imageVector = Icons.Default.Image,
                     contentDescription = "Choose from Gallery",
@@ -445,7 +476,8 @@ fun GalleryDialog(
           DialogProperties(usePlatformDefaultWidth = false, decorFitsSystemWindows = false)) {
         Box(
             modifier =
-                Modifier.fillMaxSize()
+                Modifier
+                    .fillMaxSize()
                     .background(AppColors.primary)
                     .testTag(CommonComponentsTestTags.GALLERY_DIALOG_ROOT)) {
               // Image or default icon
@@ -454,10 +486,14 @@ fun GalleryDialog(
                     model = galleryPictureUrl!![pageNumber],
                     contentDescription = "Discussion Profile Picture",
                     contentScale = ContentScale.Fit,
-                    modifier = Modifier.fillMaxSize().combinedClickable(onClick = { onDismiss() }))
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .combinedClickable(onClick = { onDismiss() }))
               } else {
                 Box(
-                    modifier = Modifier.fillMaxSize().clickable { onDismiss() },
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .clickable { onDismiss() },
                     contentAlignment = Alignment.Center) {
                       Icon(
                           imageVector = Icons.Default.AddAPhoto,
@@ -578,102 +614,128 @@ fun ConfirmationDialog(
 @Composable
 fun UserProfilePopup(
     visible: Boolean,
-    account: Account,
+    curr: Account,
+    target: Account,
     isFriend: Boolean,
     onDismiss: () -> Unit,
-    onBlock: () -> Unit = {},
-    onSendFriendRequest: () -> Unit = {}
+    actions: UserProfilePopupActions
 ) {
-  if (!visible) return
+    if (!visible) return
 
-  Dialog(
-      onDismissRequest = onDismiss,
-      properties = DialogProperties(usePlatformDefaultWidth = false)) {
-        Card(
-            modifier = Modifier.fillMaxWidth().padding(10.dp),
-            shape = RoundedCornerShape(16.dp),
-            colors = CardDefaults.cardColors(containerColor = AppColors.secondary)) {
-              Column(modifier = Modifier.fillMaxWidth().padding(24.dp)) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.Top) {
-                      Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            text = account.name,
-                            color = AppColors.textIcons,
-                            fontSize = 24.sp,
-                            fontWeight = FontWeight.Bold,
-                        )
+    var snackbarMessage by remember { mutableStateOf<String?>(null) }
+    val snackbarHostState = remember { SnackbarHostState() }
 
-                        Text(
-                            text = "@" + account.handle,
-                            color = AppColors.textIcons,
-                            fontSize = 18.sp,
-                            modifier = Modifier.padding(top = 8.dp))
-                      }
+    LaunchedEffect(snackbarMessage) {
+        snackbarMessage?.let { message ->
+            snackbarHostState.showSnackbar(
+                message = message,
+                duration = SnackbarDuration.Short
+            )
+            snackbarMessage = null
+        }
+    }
 
-                      // Profile image
-                      if (account.photoUrl.isNullOrBlank()) {
-                        Box(
-                            modifier =
-                                Modifier.size(90.dp)
-                                    .clip(CircleShape)
-                                    .background(AppColors.textIconsFade),
-                            contentAlignment = Alignment.Center) {
-                              Icon(
-                                  imageVector = Icons.Default.Person,
-                                  contentDescription = "No avatar for display",
-                                  tint = AppColors.divider,
-                                  modifier = Modifier.size(Dimensions.IconSize.giant))
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false)) {
+        Box {
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(10.dp),
+                shape = RoundedCornerShape(16.dp),
+                colors = CardDefaults.cardColors(containerColor = AppColors.secondary)) {
+                Column(modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(24.dp)) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.Top) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = target.name,
+                                color = AppColors.textIcons,
+                                fontSize = 24.sp,
+                                fontWeight = FontWeight.Bold,
+                            )
+
+                            Text(
+                                text = "@" + target.handle,
+                                color = AppColors.textIcons,
+                                fontSize = 18.sp,
+                                modifier = Modifier.padding(top = 8.dp))
+                        }
+
+                        // Profile image
+                        if (target.photoUrl.isNullOrBlank()) {
+                            Box(
+                                modifier =
+                                    Modifier
+                                        .size(90.dp)
+                                        .clip(CircleShape)
+                                        .background(AppColors.textIconsFade),
+                                contentAlignment = Alignment.Center) {
+                                Icon(
+                                    imageVector = Icons.Default.Person,
+                                    contentDescription = "No avatar for display",
+                                    tint = AppColors.divider,
+                                    modifier = Modifier.size(Dimensions.IconSize.giant))
                             }
-                      } else {
-                        Image(
-                            painter = rememberAsyncImagePainter(account.photoUrl),
-                            contentDescription = "User's avatar",
-                            contentScale = ContentScale.Crop,
-                            modifier = Modifier.size(90.dp).clip(CircleShape))
-                      }
+                        } else {
+                            Image(
+                                painter = rememberAsyncImagePainter(target.photoUrl),
+                                contentDescription = "User's avatar",
+                                contentScale = ContentScale.Crop,
+                                modifier = Modifier
+                                    .size(90.dp)
+                                    .clip(CircleShape))
+                        }
                     }
 
-                var isExpanded by remember { mutableStateOf(false) }
-                var showShowMore by remember { mutableStateOf(false) }
-                val maxLinesNotExpanded = 3
-                val maxLinesExpanded = 5
-                val description = account.description ?: "This user does not have a description."
+                    var isExpanded by remember { mutableStateOf(false) }
+                    var showShowMore by remember { mutableStateOf(false) }
+                    val maxLinesNotExpanded = 3
+                    val maxLinesExpanded = 5
+                    val description = target.description ?: "This user does not have a description."
 
-                // Bio
-                Text(
-                    text = description,
-                    color = AppColors.textIcons,
-                    modifier = Modifier.padding(bottom = 4.dp),
-                    fontSize = 16.sp,
-                    maxLines = if (isExpanded) maxLinesExpanded else maxLinesNotExpanded,
-                    overflow = TextOverflow.Ellipsis,
-                    onTextLayout = { textLayoutResult ->
-                      showShowMore = textLayoutResult.hasVisualOverflow
-                    })
+                    // Bio
+                    Text(
+                        text = description,
+                        color = AppColors.textIcons,
+                        modifier = Modifier.padding(bottom = 4.dp),
+                        fontSize = 16.sp,
+                        maxLines = if (isExpanded) maxLinesExpanded else maxLinesNotExpanded,
+                        overflow = TextOverflow.Ellipsis,
+                        onTextLayout = { textLayoutResult ->
+                            showShowMore = textLayoutResult.hasVisualOverflow
+                        })
 
-                if (showShowMore || isExpanded) {
-                  Text(
-                      text = if (isExpanded) "Show less" else "Show more",
-                      color = AppColors.textIcons.copy(alpha = 0.7f),
-                      fontSize = 14.sp,
-                      modifier =
-                          Modifier.padding(top = 4.dp).clickable { isExpanded = !isExpanded })
-                }
+                    if (showShowMore || isExpanded) {
+                        Text(
+                            text = if (isExpanded) "Show less" else "Show more",
+                            color = AppColors.textIcons.copy(alpha = 0.7f),
+                            fontSize = 14.sp,
+                            modifier =
+                                Modifier
+                                    .padding(top = 4.dp)
+                                    .clickable { isExpanded = !isExpanded })
+                    }
 
-                // Action buttons
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(16.dp)) {
-                      // Block button
-                      Button(
-                          onClick = onBlock,
-                          modifier = Modifier.weight(1f),
-                          colors = ButtonDefaults.buttonColors(containerColor = AppColors.primary),
-                          shape = RoundedCornerShape(8.dp),
-                          contentPadding = PaddingValues(vertical = 16.dp)) {
+                    // Action buttons
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                        // Block button
+                        Button(
+                            onClick = {
+                                (actions::onBlock)(curr, target)
+                                snackbarMessage = "Blocked ${target.name} successfully."
+                            },
+                            modifier = Modifier.weight(0.7f),
+                            colors = ButtonDefaults.buttonColors(containerColor = AppColors.primary),
+                            shape = RoundedCornerShape(8.dp),
+                            contentPadding = PaddingValues(vertical = 16.dp)) {
                             Icon(
                                 imageVector = Icons.Default.Block,
                                 contentDescription = "Block",
@@ -681,54 +743,77 @@ fun UserProfilePopup(
                                 modifier = Modifier.size(20.dp))
                             Spacer(modifier = Modifier.width(8.dp))
                             Text(text = "Block", color = AppColors.textIcons, fontSize = 16.sp)
-                          }
+                        }
 
-                      // Send friend request button
-                      if (isFriend) {
-                        Button(
-                            onClick = onSendFriendRequest,
-                            modifier = Modifier.weight(1f),
-                            colors =
-                                ButtonDefaults.buttonColors(
-                                    containerColor = AppColors.primary,
-                                    contentColor = AppColors.textIcons),
-                            shape = RoundedCornerShape(8.dp),
-                            contentPadding = PaddingValues(vertical = 16.dp)) {
-                              Icon(
-                                  imageVector = Icons.Default.PersonAdd,
-                                  contentDescription = "Send friend request",
-                                  tint = AppColors.textIcons,
-                                  modifier = Modifier.size(20.dp))
-                              Spacer(modifier = Modifier.width(8.dp))
-                              Text(
-                                  text = "Send friend request",
-                                  color = AppColors.textIcons,
-                                  fontSize = 16.sp)
+                        // Send friend request button
+                        if (!isFriend) {
+                            Button(
+                                onClick = {
+                                    (actions::onSendFriendRequest)(curr, target)
+                                    snackbarMessage = "Friend request sent to ${target.name}."
+                                },
+                                modifier = Modifier.weight(1f),
+                                colors =
+                                    ButtonDefaults.buttonColors(
+                                        containerColor = AppColors.primary,
+                                        contentColor = AppColors.textIcons),
+                                shape = RoundedCornerShape(8.dp),
+                                contentPadding = PaddingValues(vertical = 16.dp)) {
+                                Icon(
+                                    imageVector = Icons.Default.PersonAdd,
+                                    contentDescription = "Send friend request",
+                                    tint = AppColors.textIcons,
+                                    modifier = Modifier.size(20.dp))
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Text(
+                                    text = "Send friend request",
+                                    color = AppColors.textIcons,
+                                    fontSize = 16.sp)
                             }
-                      } else {
-                        Button(
-                            onClick = onBlock,
-                            modifier = Modifier.weight(1f),
-                            colors =
-                                ButtonDefaults.buttonColors(
-                                    containerColor = AppColors.primary,
-                                    contentColor = AppColors.textIcons),
-                            shape = RoundedCornerShape(8.dp),
-                            contentPadding = PaddingValues(vertical = 16.dp)) {
-                              Icon(
-                                  imageVector = Icons.Default.PersonRemove,
-                                  contentDescription = "Remove friend",
-                                  tint = AppColors.textIcons,
-                                  modifier = Modifier.size(20.dp))
-                              Spacer(modifier = Modifier.width(8.dp))
-                              Text(
-                                  text = "Remove friend",
-                                  color = AppColors.textIcons,
-                                  fontSize = 16.sp)
+                        } else {
+                            Button(
+                                onClick = {
+                                    (actions::onRemoveFriend)(curr, target)
+                                    snackbarMessage = "${target.name} removed from Friends."
+                                },
+                                modifier = Modifier.weight(1f),
+                                colors =
+                                    ButtonDefaults.buttonColors(
+                                        containerColor = AppColors.primary,
+                                        contentColor = AppColors.textIcons),
+                                shape = RoundedCornerShape(8.dp),
+                                contentPadding = PaddingValues(vertical = 16.dp)) {
+                                Icon(
+                                    imageVector = Icons.Default.PersonRemove,
+                                    contentDescription = "Remove friend",
+                                    tint = AppColors.textIcons,
+                                    modifier = Modifier.size(20.dp))
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Text(
+                                    text = "Remove friend",
+                                    color = AppColors.textIcons,
+                                    fontSize = 16.sp)
                             }
-                      }
+                        }
                     }
-              }
+                }
             }
-      }
+
+            // Snackbar
+            SnackbarHost(
+                hostState = snackbarHostState,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(16.dp)
+                    .offset(y = 50.dp),
+                snackbar = { data ->
+                    Snackbar(
+                        snackbarData = data,
+                        containerColor = AppColors.primary,
+                        contentColor = AppColors.textIcons
+                    )
+                }
+            )
+        }
+    }
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/components/CommonComponents.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/CommonComponents.kt
@@ -188,9 +188,7 @@ fun ImageCarousel(
       modifier = modifier.testTag(CommonComponentsTestTags.IMAGE_CAROUSEL),
       horizontalAlignment = Alignment.CenterHorizontally) {
         ElevatedCard(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(CAROUSEL_SIZE),
+            modifier = Modifier.fillMaxWidth().height(CAROUSEL_SIZE),
             colors =
                 CardColors(
                     containerColor = AppColors.secondary,
@@ -204,8 +202,7 @@ fun ImageCarousel(
                     canAddMoreImages) {
                   Box(
                       modifier =
-                          Modifier
-                              .fillMaxSize()
+                          Modifier.fillMaxSize()
                               .padding(Dimensions.Padding.giant)
                               .testTag(CommonComponentsTestTags.CAROUSEL_ADD_BUTTON)
                               .clickable { if (canAddMoreImages) showImageSourceMenu = true },
@@ -228,8 +225,7 @@ fun ImageCarousel(
                         contentDescription = "Discussion Profile Picture",
                         contentScale = ContentScale.Fit,
                         modifier =
-                            Modifier
-                                .fillMaxSize()
+                            Modifier.fillMaxSize()
                                 .clickable { showImageSourceMenu = true }
                                 .testTag(CommonComponentsTestTags.CAROUSEL_IMAGE),
                         placeholder =
@@ -238,8 +234,7 @@ fun ImageCarousel(
                     if (page < photoCollectionUrl.size && editable) {
                       Box(
                           modifier =
-                              Modifier
-                                  .align(Alignment.TopEnd)
+                              Modifier.align(Alignment.TopEnd)
                                   .padding(Dimensions.Padding.medium)
                                   .size(Dimensions.IconSize.extraLarge)
                                   .clip(CircleShape)
@@ -272,17 +267,14 @@ fun ImageCarousel(
 
                   Box(
                       modifier =
-                          Modifier
-                              .padding(Dimensions.Padding.small)
+                          Modifier.padding(Dimensions.Padding.small)
                               .size(
                                   if (selected) Dimensions.Padding.extraMedium
-                                  else Dimensions.Padding.medium
-                              )
+                                  else Dimensions.Padding.medium)
                               .clip(CircleShape)
                               .background(
                                   if (selected) MaterialTheme.colorScheme.primary
-                                  else MaterialTheme.colorScheme.surfaceVariant
-                              )
+                                  else MaterialTheme.colorScheme.surfaceVariant)
                               .testTag(CommonComponentsTestTags.DOT))
                 }
               }
@@ -338,19 +330,13 @@ fun PhotoDialogTopBar(
                       listOf(
                           AppColors.primary.copy(alpha = Dimensions.Alpha.dialogOverlayDark),
                           AppColors.primary.copy(
-                              alpha = Dimensions.Alpha.dialogOverlayTransparent
-                          )
-                      )
-                  )
-              )) {
+                              alpha = Dimensions.Alpha.dialogOverlayTransparent))))) {
         Row(
             modifier =
-                Modifier
-                    .fillMaxWidth()
+                Modifier.fillMaxWidth()
                     .padding(
                         horizontal = Dimensions.Padding.extraLarge,
-                        vertical = Dimensions.Spacing.medium
-                    ),
+                        vertical = Dimensions.Spacing.medium),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween) {
               IconButton(
@@ -367,8 +353,7 @@ fun PhotoDialogTopBar(
                   color = AppColors.textIcons,
                   style = MaterialTheme.typography.titleMedium,
                   modifier =
-                      Modifier
-                          .weight(Dimensions.Weight.full)
+                      Modifier.weight(Dimensions.Weight.full)
                           .padding(horizontal = Dimensions.Spacing.large)
                           .testTag(UITestTags.PROFILE_PICTURE_DIALOG_TITLE),
                   textAlign = TextAlign.Center)
@@ -391,18 +376,13 @@ fun PhotoDialogBottomBar(
     onTakePhoto: () -> Unit,
     onChooseFromGallery: () -> Unit
 ) {
-  Box(modifier = modifier
-      .fillMaxWidth()
-      .navigationBarsPadding()
-      .background(AppColors.primary)) {
+  Box(modifier = modifier.fillMaxWidth().navigationBarsPadding().background(AppColors.primary)) {
     Row(
         modifier =
-            Modifier
-                .fillMaxWidth()
+            Modifier.fillMaxWidth()
                 .padding(
                     horizontal = Dimensions.Padding.extraLarge,
-                    vertical = Dimensions.Spacing.extraLarge
-                ),
+                    vertical = Dimensions.Spacing.extraLarge),
         horizontalArrangement =
             Arrangement.spacedBy(Dimensions.Spacing.large, Alignment.CenterHorizontally),
         verticalAlignment = Alignment.CenterVertically) {
@@ -412,9 +392,7 @@ fun PhotoDialogBottomBar(
                   ButtonDefaults.buttonColors(
                       containerColor = AppColors.textIcons.copy(alpha = 0.2f),
                       contentColor = AppColors.textIconsFade),
-              modifier = Modifier
-                  .weight(1f)
-                  .testTag(UITestTags.PROFILE_PICTURE_CAMERA_OPTION)) {
+              modifier = Modifier.weight(1f).testTag(UITestTags.PROFILE_PICTURE_CAMERA_OPTION)) {
                 Icon(
                     imageVector = Icons.Default.PhotoCamera,
                     contentDescription = "Take Photo",
@@ -432,9 +410,7 @@ fun PhotoDialogBottomBar(
                   ButtonDefaults.buttonColors(
                       containerColor = AppColors.textIcons.copy(alpha = 0.2f),
                       contentColor = AppColors.textIconsFade),
-              modifier = Modifier
-                  .weight(1f)
-                  .testTag(UITestTags.PROFILE_PICTURE_GALLERY_OPTION)) {
+              modifier = Modifier.weight(1f).testTag(UITestTags.PROFILE_PICTURE_GALLERY_OPTION)) {
                 Icon(
                     imageVector = Icons.Default.Image,
                     contentDescription = "Choose from Gallery",
@@ -476,8 +452,7 @@ fun GalleryDialog(
           DialogProperties(usePlatformDefaultWidth = false, decorFitsSystemWindows = false)) {
         Box(
             modifier =
-                Modifier
-                    .fillMaxSize()
+                Modifier.fillMaxSize()
                     .background(AppColors.primary)
                     .testTag(CommonComponentsTestTags.GALLERY_DIALOG_ROOT)) {
               // Image or default icon
@@ -486,14 +461,10 @@ fun GalleryDialog(
                     model = galleryPictureUrl!![pageNumber],
                     contentDescription = "Discussion Profile Picture",
                     contentScale = ContentScale.Fit,
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .combinedClickable(onClick = { onDismiss() }))
+                    modifier = Modifier.fillMaxSize().combinedClickable(onClick = { onDismiss() }))
               } else {
                 Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .clickable { onDismiss() },
+                    modifier = Modifier.fillMaxSize().clickable { onDismiss() },
                     contentAlignment = Alignment.Center) {
                       Icon(
                           imageVector = Icons.Default.AddAPhoto,
@@ -620,145 +591,134 @@ fun UserProfilePopup(
     onDismiss: () -> Unit,
     actions: UserProfilePopupActions
 ) {
-    if (!visible) return
+  if (!visible) return
 
-    var snackbarMessage by remember { mutableStateOf<String?>(null) }
-    val snackbarHostState = remember { SnackbarHostState() }
+  var snackbarMessage by remember { mutableStateOf<String?>(null) }
+  val snackbarHostState = remember { SnackbarHostState() }
 
-    LaunchedEffect(snackbarMessage) {
-        snackbarMessage?.let { message ->
-            snackbarHostState.showSnackbar(
-                message = message,
-                duration = SnackbarDuration.Short
-            )
-            snackbarMessage = null
-        }
+  LaunchedEffect(snackbarMessage) {
+    snackbarMessage?.let { message ->
+      snackbarHostState.showSnackbar(message = message, duration = SnackbarDuration.Short)
+      snackbarMessage = null
     }
+  }
 
-    Dialog(
-        onDismissRequest = onDismiss,
-        properties = DialogProperties(usePlatformDefaultWidth = false)) {
+  Dialog(
+      onDismissRequest = onDismiss,
+      properties = DialogProperties(usePlatformDefaultWidth = false)) {
         Box {
-            Card(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(10.dp),
-                shape = RoundedCornerShape(16.dp),
-                colors = CardDefaults.cardColors(containerColor = AppColors.secondary)) {
-                Column(modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(24.dp)) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.Top) {
+          Card(
+              modifier = Modifier.fillMaxWidth().padding(10.dp),
+              shape = RoundedCornerShape(16.dp),
+              colors = CardDefaults.cardColors(containerColor = AppColors.secondary)) {
+                Column(modifier = Modifier.fillMaxWidth().padding(24.dp)) {
+                  Row(
+                      modifier = Modifier.fillMaxWidth(),
+                      horizontalArrangement = Arrangement.SpaceBetween,
+                      verticalAlignment = Alignment.Top) {
                         Column(modifier = Modifier.weight(1f)) {
-                            Text(
-                                text = target.name,
-                                color = AppColors.textIcons,
-                                fontSize = 24.sp,
-                                fontWeight = FontWeight.Bold,
-                            )
+                          Text(
+                              text = target.name,
+                              color = AppColors.textIcons,
+                              fontSize = 24.sp,
+                              fontWeight = FontWeight.Bold,
+                          )
 
-                            Text(
-                                text = "@" + target.handle,
-                                color = AppColors.textIcons,
-                                fontSize = 18.sp,
-                                modifier = Modifier.padding(top = 8.dp))
+                          Text(
+                              text = "@" + target.handle,
+                              color = AppColors.textIcons,
+                              fontSize = 18.sp,
+                              modifier = Modifier.padding(top = 8.dp))
                         }
 
                         // Profile image
                         if (target.photoUrl.isNullOrBlank()) {
-                            Box(
-                                modifier =
-                                    Modifier
-                                        .size(90.dp)
-                                        .clip(CircleShape)
-                                        .background(AppColors.textIconsFade),
-                                contentAlignment = Alignment.Center) {
+                          Box(
+                              modifier =
+                                  Modifier.size(90.dp)
+                                      .clip(CircleShape)
+                                      .background(AppColors.textIconsFade),
+                              contentAlignment = Alignment.Center) {
                                 Icon(
                                     imageVector = Icons.Default.Person,
                                     contentDescription = "No avatar for display",
                                     tint = AppColors.divider,
                                     modifier = Modifier.size(Dimensions.IconSize.giant))
-                            }
+                              }
                         } else {
-                            Image(
-                                painter = rememberAsyncImagePainter(target.photoUrl),
-                                contentDescription = "User's avatar",
-                                contentScale = ContentScale.Crop,
-                                modifier = Modifier
-                                    .size(90.dp)
-                                    .clip(CircleShape))
+                          Image(
+                              painter = rememberAsyncImagePainter(target.photoUrl),
+                              contentDescription = "User's avatar",
+                              contentScale = ContentScale.Crop,
+                              modifier = Modifier.size(90.dp).clip(CircleShape))
                         }
-                    }
+                      }
 
-                    var isExpanded by remember { mutableStateOf(false) }
-                    var showShowMore by remember { mutableStateOf(false) }
-                    val maxLinesNotExpanded = 3
-                    val maxLinesExpanded = 5
-                    val description = target.description ?: "This user does not have a description."
+                  var isExpanded by remember { mutableStateOf(false) }
+                  var showShowMore by remember { mutableStateOf(false) }
+                  val maxLinesNotExpanded = 3
+                  val maxLinesExpanded = 5
+                  val description = target.description ?: "This user does not have a description."
 
-                    // Bio
+                  // Bio
+                  Text(
+                      text = description,
+                      color = AppColors.textIcons,
+                      modifier = Modifier.padding(bottom = 4.dp),
+                      fontSize = 16.sp,
+                      maxLines = if (isExpanded) maxLinesExpanded else maxLinesNotExpanded,
+                      overflow = TextOverflow.Ellipsis,
+                      onTextLayout = { textLayoutResult ->
+                        showShowMore = textLayoutResult.hasVisualOverflow
+                      })
+
+                  if (showShowMore || isExpanded) {
                     Text(
-                        text = description,
-                        color = AppColors.textIcons,
-                        modifier = Modifier.padding(bottom = 4.dp),
-                        fontSize = 16.sp,
-                        maxLines = if (isExpanded) maxLinesExpanded else maxLinesNotExpanded,
-                        overflow = TextOverflow.Ellipsis,
-                        onTextLayout = { textLayoutResult ->
-                            showShowMore = textLayoutResult.hasVisualOverflow
-                        })
+                        text = if (isExpanded) "Show less" else "Show more",
+                        color = AppColors.textIcons.copy(alpha = 0.7f),
+                        fontSize = 14.sp,
+                        modifier =
+                            Modifier.padding(top = 4.dp).clickable { isExpanded = !isExpanded })
+                  }
 
-                    if (showShowMore || isExpanded) {
-                        Text(
-                            text = if (isExpanded) "Show less" else "Show more",
-                            color = AppColors.textIcons.copy(alpha = 0.7f),
-                            fontSize = 14.sp,
-                            modifier =
-                                Modifier
-                                    .padding(top = 4.dp)
-                                    .clickable { isExpanded = !isExpanded })
-                    }
-
-                    // Action buttons
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                  // Action buttons
+                  Row(
+                      modifier = Modifier.fillMaxWidth(),
+                      horizontalArrangement = Arrangement.spacedBy(16.dp)) {
                         // Block button
                         Button(
                             onClick = {
-                                (actions::onBlock)(curr, target)
-                                snackbarMessage = "Blocked ${target.name} successfully."
+                              (actions::onBlock)(curr, target)
+                              snackbarMessage = "Blocked ${target.name} successfully."
                             },
                             modifier = Modifier.weight(0.7f),
-                            colors = ButtonDefaults.buttonColors(containerColor = AppColors.primary),
+                            colors =
+                                ButtonDefaults.buttonColors(containerColor = AppColors.primary),
                             shape = RoundedCornerShape(8.dp),
                             contentPadding = PaddingValues(vertical = 16.dp)) {
-                            Icon(
-                                imageVector = Icons.Default.Block,
-                                contentDescription = "Block",
-                                tint = AppColors.textIcons,
-                                modifier = Modifier.size(20.dp))
-                            Spacer(modifier = Modifier.width(8.dp))
-                            Text(text = "Block", color = AppColors.textIcons, fontSize = 16.sp)
-                        }
+                              Icon(
+                                  imageVector = Icons.Default.Block,
+                                  contentDescription = "Block",
+                                  tint = AppColors.textIcons,
+                                  modifier = Modifier.size(20.dp))
+                              Spacer(modifier = Modifier.width(8.dp))
+                              Text(text = "Block", color = AppColors.textIcons, fontSize = 16.sp)
+                            }
 
                         // Send friend request button
                         if (!isFriend) {
-                            Button(
-                                onClick = {
-                                    (actions::onSendFriendRequest)(curr, target)
-                                    snackbarMessage = "Friend request sent to ${target.name}."
-                                },
-                                modifier = Modifier.weight(1f),
-                                colors =
-                                    ButtonDefaults.buttonColors(
-                                        containerColor = AppColors.primary,
-                                        contentColor = AppColors.textIcons),
-                                shape = RoundedCornerShape(8.dp),
-                                contentPadding = PaddingValues(vertical = 16.dp)) {
+                          Button(
+                              onClick = {
+                                (actions::onSendFriendRequest)(curr, target)
+                                snackbarMessage = "Friend request sent to ${target.name}."
+                              },
+                              modifier = Modifier.weight(1f),
+                              colors =
+                                  ButtonDefaults.buttonColors(
+                                      containerColor = AppColors.primary,
+                                      contentColor = AppColors.textIcons),
+                              shape = RoundedCornerShape(8.dp),
+                              contentPadding = PaddingValues(vertical = 16.dp)) {
                                 Icon(
                                     imageVector = Icons.Default.PersonAdd,
                                     contentDescription = "Send friend request",
@@ -769,20 +729,20 @@ fun UserProfilePopup(
                                     text = "Send friend request",
                                     color = AppColors.textIcons,
                                     fontSize = 16.sp)
-                            }
+                              }
                         } else {
-                            Button(
-                                onClick = {
-                                    (actions::onRemoveFriend)(curr, target)
-                                    snackbarMessage = "${target.name} removed from Friends."
-                                },
-                                modifier = Modifier.weight(1f),
-                                colors =
-                                    ButtonDefaults.buttonColors(
-                                        containerColor = AppColors.primary,
-                                        contentColor = AppColors.textIcons),
-                                shape = RoundedCornerShape(8.dp),
-                                contentPadding = PaddingValues(vertical = 16.dp)) {
+                          Button(
+                              onClick = {
+                                (actions::onRemoveFriend)(curr, target)
+                                snackbarMessage = "${target.name} removed from Friends."
+                              },
+                              modifier = Modifier.weight(1f),
+                              colors =
+                                  ButtonDefaults.buttonColors(
+                                      containerColor = AppColors.primary,
+                                      contentColor = AppColors.textIcons),
+                              shape = RoundedCornerShape(8.dp),
+                              contentPadding = PaddingValues(vertical = 16.dp)) {
                                 Icon(
                                     imageVector = Icons.Default.PersonRemove,
                                     contentDescription = "Remove friend",
@@ -793,27 +753,22 @@ fun UserProfilePopup(
                                     text = "Remove friend",
                                     color = AppColors.textIcons,
                                     fontSize = 16.sp)
-                            }
+                              }
                         }
-                    }
+                      }
                 }
-            }
+              }
 
-            // Snackbar
-            SnackbarHost(
-                hostState = snackbarHostState,
-                modifier = Modifier
-                    .align(Alignment.BottomCenter)
-                    .padding(16.dp)
-                    .offset(y = 50.dp),
-                snackbar = { data ->
-                    Snackbar(
-                        snackbarData = data,
-                        containerColor = AppColors.primary,
-                        contentColor = AppColors.textIcons
-                    )
-                }
-            )
+          // Snackbar
+          SnackbarHost(
+              hostState = snackbarHostState,
+              modifier = Modifier.align(Alignment.BottomCenter).padding(16.dp).offset(y = 50.dp),
+              snackbar = { data ->
+                Snackbar(
+                    snackbarData = data,
+                    containerColor = AppColors.primary,
+                    contentColor = AppColors.textIcons)
+              })
         }
-    }
+      }
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/components/CommonComponents.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/CommonComponents.kt
@@ -102,6 +102,13 @@ object CommonComponentsTestTags {
   const val CONFIRMATION_DIALOG_MESSAGE = "ConfirmationDialogMessage"
   const val CONFIRMATION_DIALOG_CONFIRM = "ConfirmationDialogConfirm"
   const val CONFIRMATION_DIALOG_CANCEL = "ConfirmationDialogCancel"
+  const val USER_PROFILE_POPUP_DESCRIPTION = "UserProfilePopupDescription"
+  const val USER_PROFILE_POPUP_HANDLE = "UserProfilePopupHandle"
+  const val USER_PROFILE_POPUP_USERNAME = "UserProfilePopupUsername"
+  const val USER_PROFILE_POPUP_AVATAR = "UserProfilePopupAvatar"
+  const val USER_PROFILE_POPUP_BLOCK_BUTTON = "UserProfilePopupBlockButton"
+  const val USER_PROFILE_POPUP_SEND_REQUEST_BUTTON = "UserProfilePopupSendRequestButton"
+  const val USER_PROFILE_POPUP_REMOVE_FRIEND_BUTTON = "UserProfilePopupRemoveFriendButton"
 }
 
 // The default size for the image carousel.
@@ -638,13 +645,17 @@ fun UserProfilePopup(
                               color = AppColors.textIcons,
                               fontSize = Dimensions.TextSize.large,
                               fontWeight = FontWeight.Bold,
-                          )
+                              modifier =
+                                  Modifier.testTag(
+                                      CommonComponentsTestTags.USER_PROFILE_POPUP_USERNAME))
 
                           Text(
                               text = "@" + target.handle,
                               color = AppColors.textIcons,
                               fontSize = Dimensions.TextSize.heading,
-                              modifier = Modifier.padding(top = Dimensions.Spacing.medium))
+                              modifier =
+                                  Modifier.padding(top = Dimensions.Spacing.medium)
+                                      .testTag(CommonComponentsTestTags.USER_PROFILE_POPUP_HANDLE))
                         }
 
                         // Profile image
@@ -653,7 +664,8 @@ fun UserProfilePopup(
                               modifier =
                                   Modifier.size(Dimensions.IconSize.massive)
                                       .clip(CircleShape)
-                                      .background(AppColors.textIconsFade),
+                                      .background(AppColors.textIconsFade)
+                                      .testTag(CommonComponentsTestTags.USER_PROFILE_POPUP_AVATAR),
                               contentAlignment = Alignment.Center) {
                                 Icon(
                                     imageVector = Icons.Default.Person,
@@ -667,7 +679,9 @@ fun UserProfilePopup(
                               contentDescription = "User's avatar",
                               contentScale = ContentScale.Crop,
                               modifier =
-                                  Modifier.size(Dimensions.IconSize.massive).clip(CircleShape))
+                                  Modifier.size(Dimensions.IconSize.massive)
+                                      .clip(CircleShape)
+                                      .testTag(CommonComponentsTestTags.USER_PROFILE_POPUP_AVATAR))
                         }
                       }
 
@@ -683,8 +697,9 @@ fun UserProfilePopup(
                       color = AppColors.textIcons,
                       modifier =
                           Modifier.padding(
-                              bottom = Dimensions.Spacing.medium,
-                              top = Dimensions.Spacing.extraLarge),
+                                  bottom = Dimensions.Spacing.medium,
+                                  top = Dimensions.Spacing.extraLarge)
+                              .testTag(CommonComponentsTestTags.USER_PROFILE_POPUP_DESCRIPTION),
                       fontSize = Dimensions.TextSize.subtitle,
                       maxLines = if (isExpanded) maxLinesExpanded else maxLinesNotExpanded,
                       overflow = TextOverflow.Ellipsis,
@@ -715,7 +730,10 @@ fun UserProfilePopup(
                               (actions::onBlock)(curr, target)
                               snackbarMessage = "Blocked ${target.name} successfully."
                             },
-                            modifier = Modifier.weight(0.7f),
+                            modifier =
+                                Modifier.weight(0.7f)
+                                    .testTag(
+                                        CommonComponentsTestTags.USER_PROFILE_POPUP_BLOCK_BUTTON),
                             enabled = online,
                             colors =
                                 ButtonDefaults.buttonColors(
@@ -743,7 +761,11 @@ fun UserProfilePopup(
                                 (actions::onSendFriendRequest)(curr, target)
                                 snackbarMessage = "Friend request sent to ${target.name}."
                               },
-                              modifier = Modifier.weight(1f),
+                              modifier =
+                                  Modifier.weight(1f)
+                                      .testTag(
+                                          CommonComponentsTestTags
+                                              .USER_PROFILE_POPUP_SEND_REQUEST_BUTTON),
                               enabled = online,
                               colors =
                                   ButtonDefaults.buttonColors(
@@ -769,7 +791,11 @@ fun UserProfilePopup(
                                 (actions::onRemoveFriend)(curr, target)
                                 snackbarMessage = "${target.name} removed from Friends."
                               },
-                              modifier = Modifier.weight(1f),
+                              modifier =
+                                  Modifier.weight(1f)
+                                      .testTag(
+                                          CommonComponentsTestTags
+                                              .USER_PROFILE_POPUP_REMOVE_FRIEND_BUTTON),
                               enabled = online,
                               colors =
                                   ButtonDefaults.buttonColors(

--- a/app/src/main/java/com/github/meeplemeet/ui/components/CommonComponents.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/CommonComponents.kt
@@ -79,6 +79,7 @@ import coil.compose.AsyncImage
 import coil.compose.rememberAsyncImagePainter
 import com.github.meeplemeet.R
 import com.github.meeplemeet.model.account.Account
+import com.github.meeplemeet.model.account.RelationshipStatus
 import com.github.meeplemeet.model.account.UserProfilePopupActions
 import com.github.meeplemeet.model.images.ImageFileUtils
 import com.github.meeplemeet.ui.discussions.UITestTags
@@ -727,7 +728,7 @@ fun UserProfilePopup(
                         // Block button
                         Button(
                             onClick = {
-                              (actions::onBlock)(curr, target)
+                              actions.onBlock(curr, target)
                               snackbarMessage = "Blocked ${target.name} successfully."
                             },
                             modifier =
@@ -756,39 +757,55 @@ fun UserProfilePopup(
 
                         // Send friend request button
                         if (!isFriend) {
+                          val isRequestSent =
+                              curr.relationships[target.uid] == RelationshipStatus.SENT
                           Button(
                               onClick = {
-                                (actions::onSendFriendRequest)(curr, target)
-                                snackbarMessage = "Friend request sent to ${target.name}."
+                                if (!isRequestSent) {
+                                  actions.onSendFriendRequest(curr, target)
+                                  snackbarMessage = "Friend request sent to ${target.name}."
+                                }
                               },
                               modifier =
                                   Modifier.weight(1f)
                                       .testTag(
                                           CommonComponentsTestTags
                                               .USER_PROFILE_POPUP_SEND_REQUEST_BUTTON),
-                              enabled = online,
+                              enabled = online && !isRequestSent,
                               colors =
                                   ButtonDefaults.buttonColors(
-                                      containerColor = AppColors.affirmative,
-                                      contentColor = AppColors.textIcons),
+                                      containerColor =
+                                          if (isRequestSent) AppColors.neutral
+                                          else AppColors.affirmative,
+                                      contentColor = AppColors.textIcons,
+                                      disabledContainerColor =
+                                          if (isRequestSent) AppColors.neutral
+                                          else ButtonDefaults.buttonColors().disabledContainerColor,
+                                      disabledContentColor = AppColors.textIcons),
                               shape = RoundedCornerShape(Dimensions.CornerRadius.medium),
                               contentPadding =
                                   PaddingValues(vertical = Dimensions.Spacing.extraLarge)) {
                                 Icon(
-                                    imageVector = Icons.Default.PersonAdd,
-                                    contentDescription = "Send friend request",
+                                    imageVector =
+                                        if (isRequestSent) Icons.Default.Person
+                                        else Icons.Default.PersonAdd,
+                                    contentDescription =
+                                        if (isRequestSent) "Request Sent"
+                                        else "Send friend request",
                                     tint = AppColors.textIcons,
                                     modifier = Modifier.size(Dimensions.IconSize.standard))
                                 Spacer(modifier = Modifier.width(Dimensions.Spacing.medium))
                                 Text(
-                                    text = "Send friend request",
+                                    text =
+                                        if (isRequestSent) "Request Sent"
+                                        else "Send friend request",
                                     color = AppColors.textIcons,
                                     fontSize = Dimensions.TextSize.subtitle)
                               }
                         } else {
                           Button(
                               onClick = {
-                                (actions::onRemoveFriend)(curr, target)
+                                actions.onRemoveFriend(curr, target)
                                 snackbarMessage = "${target.name} removed from Friends."
                               },
                               modifier =

--- a/app/src/main/java/com/github/meeplemeet/ui/components/CommonComponents.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/CommonComponents.kt
@@ -68,12 +68,9 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
@@ -732,15 +729,7 @@ fun UserProfilePopup(
                         Button(
                             onClick = {
                               actions.onBlock(curr, target)
-                              snackbarMessage =
-                                  buildAnnotatedString {
-                                        append("Blocked ")
-                                        withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
-                                          append(target.name)
-                                        }
-                                        append(" successfully.")
-                                      }
-                                      .toString()
+                              snackbarMessage = "Blocked ${target.name} successfully."
                             },
                             modifier =
                                 Modifier.weight(0.7f)
@@ -774,26 +763,11 @@ fun UserProfilePopup(
                               onClick = {
                                 if (!isRequestSent) {
                                   actions.onSendFriendRequest(curr, target)
-                                  snackbarMessage =
-                                      buildAnnotatedString {
-                                            append("Friend request sent to")
-                                            withStyle(
-                                                style = SpanStyle(fontWeight = FontWeight.Bold)) {
-                                                  append(target.name)
-                                                }
-                                          }
-                                          .toString()
+                                  snackbarMessage = "Friend request sent to ${target.name}."
                                 } else {
                                   actions.onCancel(curr, target)
                                   snackbarMessage =
-                                      buildAnnotatedString {
-                                            append("Successfully canceled friend request to ")
-                                            withStyle(
-                                                style = SpanStyle(fontWeight = FontWeight.Bold)) {
-                                                  append(target.name)
-                                                }
-                                          }
-                                          .toString()
+                                      "Successfully canceled friend request to ${target.name}."
                                 }
                               },
                               modifier =
@@ -836,15 +810,7 @@ fun UserProfilePopup(
                           Button(
                               onClick = {
                                 actions.onRemoveFriend(curr, target)
-                                snackbarMessage =
-                                    buildAnnotatedString {
-                                          withStyle(
-                                              style = SpanStyle(fontWeight = FontWeight.Bold)) {
-                                                append(target.name)
-                                              }
-                                          append(" removed from friends")
-                                        }
-                                        .toString()
+                                snackbarMessage = "${target.name} removed from friends."
                               },
                               modifier =
                                   Modifier.weight(1f)

--- a/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionCommons.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionCommons.kt
@@ -2,6 +2,7 @@
 package com.github.meeplemeet.ui.discussions
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
@@ -37,17 +38,22 @@ fun ProfilePicture(
     profilePictureUrl: String?,
     size: Dp,
     backgroundColor: androidx.compose.ui.graphics.Color = AppColors.neutral,
+    onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-  Box(modifier = modifier.size(size).clip(CircleShape).background(backgroundColor, CircleShape)) {
-    if (profilePictureUrl != null) {
-      AsyncImage(
-          model = profilePictureUrl,
-          contentDescription = "Profile Picture",
-          modifier = Modifier.fillMaxSize(),
-          contentScale = ContentScale.Crop)
-    }
-  }
+  Box(
+      modifier =
+          modifier.size(size).clip(CircleShape).background(backgroundColor, CircleShape).clickable {
+            onClick()
+          }) {
+        if (profilePictureUrl != null) {
+          AsyncImage(
+              model = profilePictureUrl,
+              contentDescription = "Profile Picture",
+              modifier = Modifier.fillMaxSize(),
+              contentScale = ContentScale.Crop)
+        }
+      }
 }
 
 /** Formats a date as "Today", "Yesterday" or "MMM dd, yyyy". */

--- a/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionCommons.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionCommons.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.Dp
@@ -40,9 +41,9 @@ object DiscussionCommons {
 fun ProfilePicture(
     profilePictureUrl: String?,
     size: Dp,
-    backgroundColor: androidx.compose.ui.graphics.Color = AppColors.neutral,
-    onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    backgroundColor: Color = AppColors.neutral,
+    onClick: () -> Unit,
     testTag: String = ""
 ) {
   Box(

--- a/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionCommons.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionCommons.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.Dp
 import coil.compose.AsyncImage
 import com.github.meeplemeet.ui.theme.AppColors
@@ -31,7 +32,9 @@ object DiscussionCommons {
  * @param profilePictureUrl Optional URL to the profile picture
  * @param size Size of the circular profile picture
  * @param backgroundColor Background color when no image is provided
+ * @param onClick Callback when the profile picture is clicked
  * @param modifier Optional modifier
+ * @param testTag Optional test tag for UI testing
  */
 @Composable
 fun ProfilePicture(
@@ -39,13 +42,17 @@ fun ProfilePicture(
     size: Dp,
     backgroundColor: androidx.compose.ui.graphics.Color = AppColors.neutral,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    testTag: String = ""
 ) {
   Box(
       modifier =
-          modifier.size(size).clip(CircleShape).background(backgroundColor, CircleShape).clickable {
-            onClick()
-          }) {
+          modifier
+              .size(size)
+              .clip(CircleShape)
+              .background(backgroundColor, CircleShape)
+              .clickable { onClick() }
+              .let { if (testTag.isNotEmpty()) it.testTag(testTag) else it }) {
         if (profilePictureUrl != null) {
           AsyncImage(
               model = profilePictureUrl,

--- a/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionScreen.kt
@@ -126,6 +126,7 @@ object DiscussionTestTags {
   const val MESSAGE_OPTIONS_CARD = "message_options_card"
   const val MESSAGE_EDIT_BUTTON = "message_options_edit"
   const val MESSAGE_DELETE_BUTTON = "message_options_delete"
+  const val MESSAGE_PROFILE_PICTURE = "message_profile_picture"
 
   fun pollVoteButton(msgIndex: Int, optIndex: Int) = "poll_msg${msgIndex}_opt${optIndex}_vote"
 
@@ -960,7 +961,8 @@ private fun MessageProfilePicture(
         profilePictureUrl = profilePictureUrl,
         size = Dimensions.AvatarSize.small,
         backgroundColor = if (isMine) AppColors.focus else AppColors.neutral,
-        onClick = onClick)
+        onClick = onClick,
+        testTag = if (!isMine) DiscussionTestTags.MESSAGE_PROFILE_PICTURE else "")
   } else {
     Spacer(Modifier.width(Dimensions.AvatarSize.small))
   }

--- a/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionScreen.kt
@@ -214,6 +214,7 @@ fun DiscussionScreen(
     discussion: Discussion,
     verified: Boolean,
     viewModel: DiscussionViewModel = viewModel(),
+    online: Boolean,
     onBack: () -> Unit,
     onOpenDiscussionInfo: (Discussion) -> Unit = {},
     onCreateSessionClick: (Discussion) -> Unit = {},
@@ -932,6 +933,7 @@ fun DiscussionScreen(
         target = selectedAccount,
         isFriend = isFriend,
         onDismiss = { showUserProfilePopup = false },
+        online = online,
         actions = viewModel)
   }
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionsOverviewScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionsOverviewScreen.kt
@@ -294,6 +294,7 @@ fun DiscussionCard(
           ProfilePicture(
               profilePictureUrl = profilePictureUrl,
               size = Dimensions.AvatarSize.extraLarge,
+              onClick = {},
               backgroundColor = AppColors.neutral)
 
           Spacer(modifier = Modifier.width(Dimensions.Spacing.large))

--- a/app/src/main/java/com/github/meeplemeet/ui/posts/PostScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/posts/PostScreen.kt
@@ -617,6 +617,7 @@ private fun PostContent(
     post: Post,
     currentUser: Account,
     verified: Boolean,
+    modifier: Modifier = Modifier,
     onDeletePost: () -> Unit,
     onEditPostBody: () -> Unit,
     onEditPostTitle: () -> Unit,
@@ -624,8 +625,7 @@ private fun PostContent(
     onDeleteComment: (Comment) -> Unit,
     onReplyingStateChanged: (commentId: String, isReplying: Boolean) -> Unit,
     resolveUser: ResolveUser,
-    onProfileClick: (Account) -> Unit = {},
-    modifier: Modifier = Modifier
+    onProfileClick: (Account) -> Unit = {}
 ) {
   val listState = rememberLazyListState()
   val expandedStates = remember { mutableStateMapOf<String, Boolean>() }

--- a/app/src/main/java/com/github/meeplemeet/ui/posts/PostScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/posts/PostScreen.kt
@@ -260,6 +260,7 @@ fun PostScreen(
     account: Account,
     postId: String,
     verified: Boolean,
+    online: Boolean,
     viewModel: PostViewModel = viewModel(),
     onBack: () -> Unit = {},
     onVerifyClick: () -> Unit = {}
@@ -458,6 +459,7 @@ fun PostScreen(
         target = selectedAccount,
         isFriend = isFriend,
         onDismiss = { showUserProfilePopup = false },
+        online = online,
         actions = viewModel)
   }
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/posts/PostScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/posts/PostScreen.kt
@@ -98,13 +98,13 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.meeplemeet.model.account.Account
-import com.github.meeplemeet.model.account.AccountViewModel
 import com.github.meeplemeet.model.account.RelationshipStatus
 import com.github.meeplemeet.model.discussions.EDIT_MAX_THRESHOLD
 import com.github.meeplemeet.model.posts.Comment
 import com.github.meeplemeet.model.posts.Post
 import com.github.meeplemeet.model.posts.PostViewModel
 import com.github.meeplemeet.ui.FocusableInputField
+import com.github.meeplemeet.ui.components.UserProfilePopup
 import com.github.meeplemeet.ui.discussions.CharacterCounter
 import com.github.meeplemeet.ui.discussions.ProfilePicture
 import com.github.meeplemeet.ui.navigation.EmailVerificationBanner
@@ -250,8 +250,9 @@ private fun PostTagsRow(tags: List<String>) {
  * @param account The current user's account information.
  * @param postId The ID of the post to display.
  * @param postViewModel ViewModel for managing post data.
- * @param accountViewModel ViewModel for managing user data.
+ * @param verified Whether the user is verified or not
  * @param onBack Lambda to invoke when the back button is pressed.
+ * @param onVerifyClick Lambda that redirects the user for his account verification
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -259,12 +260,11 @@ fun PostScreen(
     account: Account,
     postId: String,
     verified: Boolean,
-    postViewModel: PostViewModel = viewModel(),
-    accountViewModel: AccountViewModel = postViewModel,
+    viewModel: PostViewModel = viewModel(),
     onBack: () -> Unit = {},
     onVerifyClick: () -> Unit = {}
 ) {
-  val post: Post? by postViewModel.postFlow(postId).collectAsState()
+  val post: Post? by viewModel.postFlow(postId).collectAsState()
 
   val userCache = remember { mutableStateMapOf<String, Account>() }
   val scope = rememberCoroutineScope()
@@ -276,6 +276,10 @@ fun PostScreen(
   var isSending by remember { mutableStateOf(false) }
   var isReplyingToComment by remember { mutableStateOf(false) }
   var editTarget by remember { mutableStateOf<PostEditTarget?>(null) }
+
+  // User profile popup state
+  var showUserProfilePopup by remember { mutableStateOf(false) }
+  var selectedUserForPopup by remember { mutableStateOf<Account?>(null) }
 
   // Track if post was ever loaded to distinguish between loading and deleted states
   var postEverLoaded by remember { mutableStateOf(false) }
@@ -328,7 +332,8 @@ fun PostScreen(
               walk(p.comments)
             }
             .filterNot { it.isBlank() || it in userCache }
-    accountViewModel.getAccounts(toFetch, context) {
+
+    viewModel.getAccounts(toFetch, context) {
       it.forEach { acc -> if (acc != null) userCache[acc.uid] = acc }
     }
   }
@@ -366,13 +371,13 @@ fun PostScreen(
                         val value = topComment.trim()
                         when (target) {
                           PostEditTarget.TITLE ->
-                              postViewModel.editPost(author = account, post = p, newTitle = value)
+                              viewModel.editPost(author = account, post = p, newTitle = value)
                           PostEditTarget.BODY ->
-                              postViewModel.editPost(author = account, post = p, newBody = value)
+                              viewModel.editPost(author = account, post = p, newBody = value)
                         }
                         editTarget = null
                       } else {
-                        postViewModel.addComment(
+                        viewModel.addComment(
                             author = account, post = p, parentId = p.id, text = topComment.trim())
                       }
 
@@ -404,7 +409,7 @@ fun PostScreen(
               onDeletePost = {
                 scope.launch {
                   deleted = true
-                  runCatching { postViewModel.deletePost(account, currentPost) }
+                  runCatching { viewModel.deletePost(account, currentPost) }
                       .onFailure { snackbarHostState.showSnackbar(ERROR_NOT_DELETED_POST) }
                   onBack()
                 }
@@ -419,21 +424,42 @@ fun PostScreen(
               },
               onReply = { parentId, text ->
                 scope.launch {
-                  runCatching { postViewModel.addComment(account, currentPost, parentId, text) }
+                  runCatching { viewModel.addComment(account, currentPost, parentId, text) }
                       .onFailure { snackbarHostState.showSnackbar(ERROR_SEND_REPLY) }
                 }
               },
               onDeleteComment = { comment ->
                 scope.launch {
-                  runCatching { postViewModel.removeComment(account, currentPost, comment) }
+                  runCatching { viewModel.removeComment(account, currentPost, comment) }
                       .onFailure { snackbarHostState.showSnackbar(ERROR_NOT_DELETED_COMMENT) }
                 }
               },
               onReplyingStateChanged = { _, isReplying -> isReplyingToComment = isReplying },
               resolveUser = { uid -> userCache[uid] },
+              onProfileClick = { clickedAccount ->
+                if (clickedAccount.uid != account.uid) {
+                  selectedUserForPopup = clickedAccount
+                  showUserProfilePopup = true
+                }
+              },
               modifier = Modifier.padding(padding))
         }
       }
+
+  // User profile popup
+  if (showUserProfilePopup && selectedUserForPopup != null) {
+    val selectedAccount = selectedUserForPopup!!
+    val currentRelationship = account.relationships[selectedAccount.uid]
+    val isFriend = currentRelationship == RelationshipStatus.FRIEND
+
+    UserProfilePopup(
+        visible = true,
+        curr = account,
+        target = selectedAccount,
+        isFriend = isFriend,
+        onDismiss = { showUserProfilePopup = false },
+        actions = viewModel)
+  }
 }
 
 /* ================================================================
@@ -596,6 +622,7 @@ private fun PostContent(
     onDeleteComment: (Comment) -> Unit,
     onReplyingStateChanged: (commentId: String, isReplying: Boolean) -> Unit,
     resolveUser: ResolveUser,
+    onProfileClick: (Account) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
   val listState = rememberLazyListState()
@@ -624,7 +651,8 @@ private fun PostContent(
               canEdit = canEditPost,
               onDelete = onDeletePost,
               onEditBody = onEditPostBody,
-              onEditTitle = onEditPostTitle)
+              onEditTitle = onEditPostTitle,
+              onProfileClick = onProfileClick)
         }
 
         items(items = post.comments, key = { it.id }, contentType = { "root_comment" }) { root ->
@@ -636,7 +664,8 @@ private fun PostContent(
               onReply = onReply,
               onDelete = onDeleteComment,
               onReplyingStateChanged = onReplyingStateChanged,
-              expandedStates = expandedStates)
+              expandedStates = expandedStates,
+              onProfileClick = onProfileClick)
         }
       }
 }
@@ -660,7 +689,8 @@ private fun PostCard(
     canEdit: Boolean,
     onDelete: () -> Unit,
     onEditBody: () -> Unit,
-    onEditTitle: () -> Unit
+    onEditTitle: () -> Unit,
+    onProfileClick: (Account) -> Unit = {}
 ) {
   val isOwner = post.authorId == currentUser.uid
   val showEdit = canEdit && isOwner
@@ -673,7 +703,7 @@ private fun PostCard(
           Box(modifier = Modifier.fillMaxWidth().testTag(PostTags.postCard(post.id))) {
             Column(modifier = Modifier.fillMaxWidth().padding(Dimensions.Padding.large)) {
               // Header
-              PostHeader(post = post, author = author)
+              PostHeader(post = post, author = author, onProfileClick = onProfileClick)
 
               Spacer(Modifier.height(Dimensions.Padding.large))
 
@@ -807,7 +837,7 @@ private fun PostEditableRow(
  * @param author The author of the post.
  */
 @Composable
-private fun PostHeader(post: Post, author: Account?) {
+private fun PostHeader(post: Post, author: Account?, onProfileClick: (Account) -> Unit = {}) {
   Row(
       modifier = Modifier.fillMaxWidth().testTag(PostTags.POST_HEADER),
       verticalAlignment = Alignment.CenterVertically,
@@ -815,6 +845,7 @@ private fun PostHeader(post: Post, author: Account?) {
         ProfilePicture(
             profilePictureUrl = author?.photoUrl,
             size = Dimensions.AvatarSize.small,
+            onClick = { author?.let { onProfileClick(it) } },
             backgroundColor = MessagingColors.redditOrange,
             modifier = Modifier.clearAndSetSemantics { testTag = PostTags.POST_AVATAR })
         Row(
@@ -863,7 +894,8 @@ private fun ThreadCard(
     onReply: (parentId: String, text: String) -> Unit,
     onDelete: (Comment) -> Unit,
     onReplyingStateChanged: (commentId: String, isReplying: Boolean) -> Unit,
-    expandedStates: MutableMap<String, Boolean>
+    expandedStates: MutableMap<String, Boolean>,
+    onProfileClick: (Account) -> Unit = {}
 ) {
   val expanded = expandedStates[root.id] ?: false
 
@@ -896,7 +928,8 @@ private fun ThreadCard(
                     },
                     onDelete = { onDelete(root) },
                     onReplyingStateChanged = onReplyingStateChanged,
-                    onCardClick = { expandedStates[root.id] = !expanded })
+                    onCardClick = { expandedStates[root.id] = !expanded },
+                    onProfileClick = onProfileClick)
 
                 AnimatedVisibility(
                     visible = expanded, enter = expandVertically(), exit = shrinkVertically()) {
@@ -912,7 +945,8 @@ private fun ThreadCard(
                             onReplyingStateChanged = onReplyingStateChanged,
                             expandedStates = expandedStates,
                             depth = 1,
-                            gutterColor = MessagingColors.redditOrange)
+                            gutterColor = MessagingColors.redditOrange,
+                            onProfileClick = onProfileClick)
                       }
                     }
               }
@@ -946,7 +980,8 @@ private fun CommentsTree(
     onReplyingStateChanged: (commentId: String, isReplying: Boolean) -> Unit,
     expandedStates: MutableMap<String, Boolean>,
     depth: Int = 0,
-    gutterColor: Color = MaterialTheme.colorScheme.outline
+    gutterColor: Color = MaterialTheme.colorScheme.outline,
+    onProfileClick: (Account) -> Unit = {}
 ) {
   if (depth > 0) {
     Row(Modifier.fillMaxWidth().height(IntrinsicSize.Min).testTag(PostTags.treeDepth(depth))) {
@@ -979,7 +1014,8 @@ private fun CommentsTree(
                   onCardClick =
                       if (c.children.isNotEmpty()) {
                         { expandedStates[c.id] = !expanded }
-                      } else null)
+                      } else null,
+                  onProfileClick = onProfileClick)
 
               if (c.children.isNotEmpty()) {
                 AnimatedVisibility(
@@ -994,7 +1030,8 @@ private fun CommentsTree(
                           onReplyingStateChanged = onReplyingStateChanged,
                           expandedStates = expandedStates,
                           depth = depth + 1,
-                          gutterColor = gutterColor)
+                          gutterColor = gutterColor,
+                          onProfileClick = onProfileClick)
                     }
               }
             }
@@ -1021,7 +1058,8 @@ private fun CommentsTree(
                 onCardClick =
                     if (c.children.isNotEmpty()) {
                       { expandedStates[c.id] = !expanded }
-                    } else null)
+                    } else null,
+                onProfileClick = onProfileClick)
             if (c.children.isNotEmpty()) {
               AnimatedVisibility(
                   visible = expanded, enter = expandVertically(), exit = shrinkVertically()) {
@@ -1035,7 +1073,8 @@ private fun CommentsTree(
                         onReplyingStateChanged = onReplyingStateChanged,
                         expandedStates = expandedStates,
                         depth = 1,
-                        gutterColor = gutterColor)
+                        gutterColor = gutterColor,
+                        onProfileClick = onProfileClick)
                   }
             }
           }
@@ -1102,7 +1141,8 @@ private fun CommentItem(
     onReply: (String) -> Unit,
     onDelete: () -> Unit,
     onReplyingStateChanged: (commentId: String, isReplying: Boolean) -> Unit,
-    onCardClick: (() -> Unit)? = null
+    onCardClick: (() -> Unit)? = null,
+    onProfileClick: (Account) -> Unit = {}
 ) {
   var replying by rememberSaveable(comment.id) { mutableStateOf(false) }
   var replyText by rememberSaveable(comment.id) { mutableStateOf("") }
@@ -1120,6 +1160,7 @@ private fun CommentItem(
           ProfilePicture(
               profilePictureUrl = if (isBlocked) null else author?.photoUrl,
               size = Dimensions.AvatarSize.tiny,
+              onClick = { if (!isBlocked) author?.let { onProfileClick(it) } },
               backgroundColor = MessagingColors.redditOrange,
               modifier = Modifier.clearAndSetSemantics {})
           Text(


### PR DESCRIPTION
## Description
This PR introduces the `UserProfilePopup`, a popup dialog that enables users to view other's profiles and manage relationships. It is currently wired to `DiscussionScreen.kt` and `PostScreen.kt` and can be easily wired into other screens.

### Key Changes

- **Profile Display:** Detailed view showing the user’s avatar, display name, handle (`@handle`), and description.
- **Offline Mode Support:** Disables the social actions. 
- **Social Actions**:
  - Send Friend Request: Initiates a friend request and sends a notification to the user in question.
  - Block: Blocks the target user which causes their messages to be hidden.
  - Remove Friend: Appears only when both users are already friends, allowing removal.
  All of these actions will show a feedback snackbar for about 2 seconds.

Demo: 

https://github.com/user-attachments/assets/fc431ffc-3e40-4556-bb9b-e4cceba7c1bf


