### PR TITLE
Feat/move email verification

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/ui/EmailChangeUITest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/EmailChangeUITest.kt
@@ -41,10 +41,8 @@ class EmailChangeUITest : FirestoreTests() {
     compose.setContent {
       EmailSection(
           email = "test@example.com",
-          isVerified = true,
           onEmailChange = {},
           onFocusChanged = {},
-          onSendVerification = {},
           onChangeEmail = { _, _ -> },
           online = true)
     }
@@ -83,10 +81,8 @@ class EmailChangeUITest : FirestoreTests() {
     compose.setContent {
       EmailSection(
           email = "test@example.com",
-          isVerified = true,
           onEmailChange = {},
           onFocusChanged = {},
-          onSendVerification = {},
           onChangeEmail = { _, _ -> },
           online = true)
     }
@@ -107,10 +103,8 @@ class EmailChangeUITest : FirestoreTests() {
     compose.setContent {
       EmailSection(
           email = "test@example.com",
-          isVerified = true,
           onEmailChange = {},
           onFocusChanged = {},
-          onSendVerification = {},
           onChangeEmail = { _, _ -> },
           online = true)
     }
@@ -134,10 +128,8 @@ class EmailChangeUITest : FirestoreTests() {
     compose.setContent {
       EmailSection(
           email = "test@example.com",
-          isVerified = true,
           onEmailChange = {},
           onFocusChanged = {},
-          onSendVerification = {},
           onChangeEmail = { _, _ -> },
           online = true)
     }
@@ -163,10 +155,8 @@ class EmailChangeUITest : FirestoreTests() {
     compose.setContent {
       EmailSection(
           email = "test@example.com",
-          isVerified = true,
           onEmailChange = {},
           onFocusChanged = {},
-          onSendVerification = {},
           onChangeEmail = { _, _ -> },
           online = true)
     }
@@ -203,10 +193,8 @@ class EmailChangeUITest : FirestoreTests() {
     compose.setContent {
       EmailSection(
           email = "test@example.com",
-          isVerified = true,
           onEmailChange = {},
           onFocusChanged = {},
-          onSendVerification = {},
           onChangeEmail = { _, _ -> },
           errorMsg = errorMsg.value,
           online = true)
@@ -233,10 +221,8 @@ class EmailChangeUITest : FirestoreTests() {
     compose.setContent {
       EmailSection(
           email = "test@example.com",
-          isVerified = true,
           onEmailChange = {},
           onFocusChanged = {},
-          onSendVerification = {},
           onChangeEmail = { _, _ -> },
           successMsg = successMsg.value,
           online = true)
@@ -259,10 +245,8 @@ class EmailChangeUITest : FirestoreTests() {
     compose.setContent {
       EmailSection(
           email = "test@example.com",
-          isVerified = true,
           onEmailChange = {},
           onFocusChanged = {},
-          onSendVerification = {},
           onChangeEmail = { _, _ -> },
           isLoading = isLoading.value,
           online = true)

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/MainTabComposableTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/MainTabComposableTest.kt
@@ -15,6 +15,7 @@ import com.github.meeplemeet.model.shared.location.Location
 import com.github.meeplemeet.model.shops.OpeningHours
 import com.github.meeplemeet.model.shops.TimeSlot
 import com.github.meeplemeet.ui.account.DeleteAccSectionTestTags
+import com.github.meeplemeet.ui.account.EmailVerificationTestTags
 import com.github.meeplemeet.ui.account.MainTab
 import com.github.meeplemeet.ui.account.MainTabTestTags
 import com.github.meeplemeet.ui.account.NotificationsSectionTestTags
@@ -185,8 +186,6 @@ class MainTabComposableTest : FirestoreTests() {
   // =======================
   // EMAIL SECTION
   // =======================
-  private fun ComposeTestRule.emailNotVerifiedLabel() =
-      onTag(PrivateInfoTestTags.EMAIL_NOT_VERIFIED_LABEL)
 
   private fun ComposeTestRule.emailErrorLabel() = onTag(PrivateInfoTestTags.EMAIL_ERROR_LABEL)
 
@@ -477,90 +476,81 @@ class MainTabComposableTest : FirestoreTests() {
       compose.waitForIdle()
     }
 
-    // TODO: Re-enable these tests after fixing rendering issue
     // ---------------------------------------------------------------------
-    if (false)
-        checkpoint("navigate_to_businesses_and_verify") {
-          scrollToTag(ProfileNavigationTestTags.SETTINGS_ROW_BUSINESSES)
-          compose.settingsRowBusinesses().assertExists()
-          compose.settingsRowBusinesses().performClick()
-          compose.waitForIdle()
+    checkpoint("navigate_to_businesses_and_verify") {
+      scrollToTag(ProfileNavigationTestTags.SETTINGS_ROW_BUSINESSES)
+      compose.settingsRowBusinesses().assertExists()
+      compose.settingsRowBusinesses().performClick()
+      compose.waitForIdle()
 
-          compose.rolesTitle().assertExists()
+      compose.rolesTitle().assertExists()
 
-          // Toggle on for the first time == no dialog
-          compose.roleSpaceCheckbox().assertExists().performClick()
-          compose.roleDialog().assertDoesNotExist()
+      // Toggle on for the first time == no dialog
+      compose.roleSpaceCheckbox().assertExists().performClick()
+      compose.roleDialog().assertDoesNotExist()
 
-          // Toggle Off == dialog
-          compose.roleSpaceCheckbox().assertExists().performClick()
-          compose.roleDialog().assertExists()
-          compose.rolesDialogText().assertExists().assertTextContains("spaces", substring = true)
+      // Toggle Off == dialog
+      compose.roleSpaceCheckbox().assertExists().performClick()
+      compose.roleDialog().assertExists()
+      compose.rolesDialogText().assertExists().assertTextContains("spaces", substring = true)
 
-          // Cancel
-          compose.roleDialogCancel().performClick()
-          compose.roleDialog().assertDoesNotExist()
+      // Cancel
+      compose.roleDialogCancel().performClick()
+      compose.roleDialog().assertDoesNotExist()
 
-          // Toggle OFF again → confirm
-          compose.roleSpaceCheckbox().performClick()
-          compose.roleDialog().assertExists()
+      // Toggle OFF again → confirm
+      compose.roleSpaceCheckbox().performClick()
+      compose.roleDialog().assertExists()
 
-          compose.roleDialogConfirm().performClick()
-          compose.roleDialog().assertDoesNotExist()
-          compose.waitForIdle()
+      compose.roleDialogConfirm().performClick()
+      compose.roleDialog().assertDoesNotExist()
+      compose.waitForIdle()
 
-          // Now add the shop owner role and leave the subscaffold. Check that UI is updated right
-          // with
-          // regards to these changes
-          compose.roleShopCheckbox().performClick()
-          compose.roleDialog().assertDoesNotExist()
+      // Now add the shop owner role and leave the subscaffold. Check that UI is updated right
+      // with
+      // regards to these changes
+      compose.roleShopCheckbox().performClick()
+      compose.roleDialog().assertDoesNotExist()
 
-          compose.subPageBackButton().performClick()
-          compose.waitForIdle()
-          compose.publicInfoRoot().assertExists()
+      compose.subPageBackButton().performClick()
+      compose.waitForIdle()
+      compose.publicInfoRoot().assertExists()
 
-          compose.settingsRowBusinesses().performClick()
-          compose.waitForIdle()
-          compose.rolesTitle().assertExists().performClick()
-          compose.roleShopCheckbox().assertExists() // UI updated correctly
+      compose.settingsRowBusinesses().performClick()
+      compose.waitForIdle()
+      compose.rolesTitle().assertExists().performClick()
+      compose.roleShopCheckbox().assertExists() // UI updated correctly
 
-          compose.subPageBackButton().performClick()
-          compose.waitForIdle()
-        }
+      compose.subPageBackButton().performClick()
+      compose.waitForIdle()
+    }
 
     // ---------------------------------------------------------------------
-    if (false)
-        checkpoint("navigate_to_email_and_verify") {
-          scrollToTag(ProfileNavigationTestTags.SETTINGS_ROW_EMAIL)
-          compose.settingsRowEmail().assertExists().performClick()
-          compose.waitForIdle()
+    checkpoint("email_verification") {
+      compose.onNodeWithTag(EmailVerificationTestTags.VERIFICATION_SECTION).assertIsDisplayed()
+      compose
+          .onNodeWithTag(EmailVerificationTestTags.RESEND_MAIL_VERIFICATION_BTN)
+          .assertIsDisplayed()
+          .performClick()
+      compose.waitForIdle()
+      compose.onNodeWithTag(PrivateInfoTestTags.EMAIL_TOAST).assertIsDisplayed()
+      compose
+          .onNodeWithTag(EmailVerificationTestTags.USER_EMAIL)
+          .assertIsDisplayed()
+          .assertTextContains(user.email, ignoreCase = true)
+    }
 
-          compose.emailNotVerifiedLabel().assertExists()
-          inputText(PrivateInfoTestTags.EMAIL_INPUT, "badlyformattedmail")
-          compose.emailErrorLabel().assertExists().assertTextEquals("Invalid Email Format")
+    checkpoint("Delete button user flow") {
+      scrollToTag(DeleteAccSectionTestTags.BUTTON)
 
-          inputText(PrivateInfoTestTags.EMAIL_INPUT, "newmail@example.com")
-          compose.emailSendButton().performClick()
-
-          compose.emailToast().assertExists()
-
-          compose.subPageBackButton().performClick()
-          compose.waitForIdle()
-          compose.publicInfoRoot().assertExists()
-        }
-
-    if (false)
-        checkpoint("Delete button user flow") {
-          scrollToTag(DeleteAccSectionTestTags.BUTTON)
-
-          compose.delAccountBtn().assertExists().performClick()
-          compose.delAccountPopup().assertExists()
-          compose.delAccountPopupCancel().assertExists().performClick()
-          compose.delAccountPopup().assertDoesNotExist()
-          compose.delAccountBtn().performClick()
-          compose.delAccountPopupConfirm().assertExists().performClick()
-          assert(delClicked)
-          compose.waitForIdle()
-        }
+      compose.delAccountBtn().assertExists().performClick()
+      compose.delAccountPopup().assertExists()
+      compose.delAccountPopupCancel().assertExists().performClick()
+      compose.delAccountPopup().assertDoesNotExist()
+      compose.delAccountBtn().performClick()
+      compose.delAccountPopupConfirm().assertExists().performClick()
+      assert(delClicked)
+      compose.waitForIdle()
+    }
   }
 }

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/ProfileScreenTest.kt
@@ -151,42 +151,6 @@ class ProfileScreenTest : FirestoreTests() {
   }
 
   @Test
-  fun testEmailSection_toast() {
-    composeTestRule.setContent {
-      // Isolating EmailSection to test the Toast logic specifically
-      EmailSection(
-          email = "user@example.com",
-          isVerified = false,
-          online = true,
-          onEmailChange = {},
-          onFocusChanged = {},
-          onSendVerification = {}, // Mock callback
-          onChangeEmail = { _, _ -> })
-    }
-
-    checkpoint("Send Verification Shows Toast") {
-      composeTestRule.onNodeWithTag(PrivateInfoTestTags.EMAIL_SEND_BUTTON).performClick()
-
-      // Wait for Toast
-      composeTestRule.waitUntil(2000) {
-        composeTestRule
-            .onAllNodesWithTag(PrivateInfoTestTags.EMAIL_TOAST)
-            .fetchSemanticsNodes()
-            .isNotEmpty()
-      }
-      composeTestRule.onNodeWithText(MainTabUi.PrivateInfo.TOAST_MSG).assertIsDisplayed()
-
-      // Wait for Toast to disappear (duration 1500)
-      composeTestRule.waitUntil(3000) {
-        composeTestRule
-            .onAllNodesWithTag(PrivateInfoTestTags.EMAIL_TOAST)
-            .fetchSemanticsNodes()
-            .isEmpty()
-      }
-    }
-  }
-
-  @Test
   fun testDeleteAccountDialog() {
     val show = mutableStateOf(false)
     composeTestRule.setContent {

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/ProfileScreenTest.kt
@@ -291,18 +291,6 @@ class ProfileScreenTest : FirestoreTests() {
           .isNotEmpty()
     }
     composeTestRule.onNodeWithTag(PrivateInfoTestTags.EMAIL_SECTION).assertIsDisplayed()
-
-    // Verify Email Input displays user email (mocked user has tester@example.com)
-    // Note: The Email page logic fetches currentUser?.email ?: account.email
-    // Since Firebase Auth mock might return null or something else, we check if it displays
-    // *something* or the account email.
-    // In this test setup, `user` is passed to MainTab. The `ProfilePage.Email` block uses
-    // `viewModel.uiState` and `FirebaseProvider.auth.currentUser`.
-    // We should ensure `Auth` is set up or expect `account.email` to be used if currentUser is
-    // null.
-    // However, MainTab uses `account.email` as fallback.
-
-    composeTestRule.onNodeWithTag(PrivateInfoTestTags.EMAIL_INPUT).assertTextContains(user.email)
   }
 
   @Test

--- a/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
@@ -645,7 +645,7 @@ fun MainTabContent(
         Spacer(modifier = Modifier.height(Dimensions.Spacing.xLarge))
 
         // Email verification part
-        val notVerified = uiState.isEmailVerified
+        val notVerified = !uiState.isEmailVerified
         Text(
             text = "Email",
             fontSize = Dimensions.TextSize.heading,

--- a/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
@@ -8,6 +8,7 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -644,6 +645,7 @@ fun MainTabContent(
         Spacer(modifier = Modifier.height(Dimensions.Spacing.xLarge))
 
         // Email verification part
+        val notVerified = uiState.isEmailVerified
         Text(
             text = "Email",
             fontSize = Dimensions.TextSize.heading,
@@ -653,7 +655,11 @@ fun MainTabContent(
             contentAlignment = Alignment.BottomCenter,
             modifier = Modifier.testTag(EmailVerificationTestTags.VERIFICATION_SECTION)) {
               Card(
-                  colors = CardDefaults.cardColors(containerColor = AppColors.neutral),
+                  border = BorderStroke(0.5.dp, AppColors.textIcons),
+                  colors =
+                      CardDefaults.cardColors(
+                          containerColor =
+                              if (notVerified) AppColors.neutral else AppColors.primary),
                   shape = RoundedCornerShape(Dimensions.CornerRadius.medium),
                   modifier = Modifier.fillMaxWidth()) {
                     Box(
@@ -670,7 +676,7 @@ fun MainTabContent(
 
                           IconButton(
                               onClick = {
-                                if (!uiState.isEmailVerified) {
+                                if (notVerified) {
                                   viewModel.sendVerificationEmail()
                                   viewModel.refreshEmailVerificationStatus()
                                   toast = ToastData(message = MainTabUi.PrivateInfo.TOAST_MSG)
@@ -683,10 +689,12 @@ fun MainTabContent(
                                           EmailVerificationTestTags.RESEND_MAIL_VERIFICATION_BTN)) {
                                 Icon(
                                     imageVector =
-                                        if (!uiState.isEmailVerified) Icons.AutoMirrored.Filled.Send
+                                        if (notVerified) Icons.AutoMirrored.Filled.Send
                                         else Icons.Default.Check,
                                     contentDescription = MainTabUi.PrivateInfo.SEND_ICON_DESC,
-                                    tint = AppColors.textIcons,
+                                    tint =
+                                        if (notVerified) AppColors.textIcons
+                                        else AppColors.affirmative,
                                     modifier = Modifier.size(Dimensions.IconSize.large))
                               }
                         }
@@ -780,9 +788,7 @@ fun MainTabContent(
                   })
             }
 
-        if (!uiState.isEmailVerified) {
-          Spacer(modifier = Modifier.height(MainTabUi.PADDING_BOTTOM_SCROLL))
-        }
+        Spacer(modifier = Modifier.height(MainTabUi.PADDING_BOTTOM_SCROLL))
       }
 }
 

--- a/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
@@ -244,7 +244,7 @@ object MainTabUi {
   val OFFSET_X = 4.dp
   val OFFSET_Y = (-4).dp
   val OFFSET_EMAIL = 35.dp
-  val PADDING_BOTTOM_SCROLL = 100.dp
+  val PADDING_BOTTOM_SCROLL = 110.dp
   const val MAX_NOTIF_COUNT = 9
 
   object Misc {

--- a/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
@@ -33,6 +33,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.Cancel
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Email
@@ -640,67 +641,67 @@ fun MainTabContent(
                     onInputFocusChanged = onInputFocusChanged)
               }
         }
-        Spacer(modifier = Modifier.height(Dimensions.Spacing.xxLarge))
+        Spacer(modifier = Modifier.height(Dimensions.Spacing.xLarge))
 
-        if (!uiState.isEmailVerified) {
-          Text(
-              text = "Verify Your Email",
-              fontSize = Dimensions.TextSize.heading,
-              modifier = Modifier.fillMaxWidth().padding(bottom = Dimensions.Padding.medium))
+        // Email verification part
+        Text(
+            text = "Email",
+            fontSize = Dimensions.TextSize.heading,
+            modifier = Modifier.fillMaxWidth().padding(bottom = Dimensions.Padding.medium))
 
-          // The Blue Card
-          Box(
-              contentAlignment = Alignment.BottomCenter,
-              modifier = Modifier.testTag(EmailVerificationTestTags.VERIFICATION_SECTION)) {
-                Card(
-                    colors = CardDefaults.cardColors(containerColor = AppColors.neutral),
-                    shape = RoundedCornerShape(Dimensions.CornerRadius.medium),
-                    modifier = Modifier.fillMaxWidth()) {
-                      Box(
-                          modifier =
-                              Modifier.fillMaxSize().padding(horizontal = Dimensions.Padding.large),
-                          contentAlignment = Alignment.Center) {
-                            // Email Address
-                            Text(
-                                text = userEmail,
-                                color = AppColors.textIcons,
-                                modifier =
-                                    Modifier.align(Alignment.CenterStart)
-                                        .testTag(EmailVerificationTestTags.USER_EMAIL))
+        Box(
+            contentAlignment = Alignment.BottomCenter,
+            modifier = Modifier.testTag(EmailVerificationTestTags.VERIFICATION_SECTION)) {
+              Card(
+                  colors = CardDefaults.cardColors(containerColor = AppColors.neutral),
+                  shape = RoundedCornerShape(Dimensions.CornerRadius.medium),
+                  modifier = Modifier.fillMaxWidth()) {
+                    Box(
+                        modifier =
+                            Modifier.fillMaxSize().padding(horizontal = Dimensions.Padding.large),
+                        contentAlignment = Alignment.Center) {
+                          // Email Address
+                          Text(
+                              text = userEmail,
+                              color = AppColors.textIcons,
+                              modifier =
+                                  Modifier.align(Alignment.CenterStart)
+                                      .testTag(EmailVerificationTestTags.USER_EMAIL))
 
-                            // Send Icon
-                            IconButton(
-                                onClick = {
+                          IconButton(
+                              onClick = {
+                                if (!uiState.isEmailVerified) {
                                   viewModel.sendVerificationEmail()
                                   viewModel.refreshEmailVerificationStatus()
                                   toast = ToastData(message = MainTabUi.PrivateInfo.TOAST_MSG)
-                                },
-                                enabled = online,
-                                modifier =
-                                    Modifier.align(Alignment.CenterEnd)
-                                        .testTag(
-                                            EmailVerificationTestTags
-                                                .RESEND_MAIL_VERIFICATION_BTN)) {
-                                  Icon(
-                                      imageVector = Icons.AutoMirrored.Filled.Send,
-                                      contentDescription = MainTabUi.PrivateInfo.SEND_ICON_DESC,
-                                      tint = AppColors.textIcons,
-                                      modifier = Modifier.size(Dimensions.IconSize.large))
                                 }
-                          }
-                    }
+                              },
+                              enabled = online,
+                              modifier =
+                                  Modifier.align(Alignment.CenterEnd)
+                                      .testTag(
+                                          EmailVerificationTestTags.RESEND_MAIL_VERIFICATION_BTN)) {
+                                Icon(
+                                    imageVector =
+                                        if (!uiState.isEmailVerified) Icons.AutoMirrored.Filled.Send
+                                        else Icons.Default.Check,
+                                    contentDescription = MainTabUi.PrivateInfo.SEND_ICON_DESC,
+                                    tint = AppColors.textIcons,
+                                    modifier = Modifier.size(Dimensions.IconSize.large))
+                              }
+                        }
+                  }
 
-                Box(
-                    modifier =
-                        Modifier.align(Alignment.BottomCenter)
-                            .offset(y = MainTabUi.OFFSET_EMAIL)
-                            .zIndex(1f)) {
-                      ToastHost(toast = toast, onToastFinished = { toast = null })
-                    }
-              }
+              Box(
+                  modifier =
+                      Modifier.align(Alignment.BottomCenter)
+                          .offset(y = MainTabUi.OFFSET_EMAIL)
+                          .zIndex(1f)) {
+                    ToastHost(toast = toast, onToastFinished = { toast = null })
+                  }
+            }
 
-          Spacer(modifier = Modifier.height(Dimensions.Spacing.xxxLarge))
-        }
+        Spacer(modifier = Modifier.height(Dimensions.Spacing.xxxLarge))
 
         Text(
             text = MainTabUi.SettingRows.HEADER,
@@ -1336,26 +1337,6 @@ fun EmailSection(
 
   Box(modifier = Modifier.fillMaxWidth().testTag(PrivateInfoTestTags.EMAIL_SECTION)) {
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
-      Row(
-          modifier = Modifier.fillMaxWidth(),
-          horizontalArrangement = Arrangement.SpaceBetween,
-          verticalAlignment = Alignment.CenterVertically) {
-            FocusableInputField(
-                readOnly = true,
-                label = { Text(text = MainTabUi.PrivateInfo.EMAIL_INPUT_FIELD) },
-                value = email,
-                onValueChange = { new ->
-                  localEmail = new
-                  onEmailChange(new)
-
-                  showErrors = new.isNotBlank()
-                },
-                isError = emailError,
-                modifier =
-                    Modifier.weight(Dimensions.Weight.full)
-                        .testTag(PrivateInfoTestTags.EMAIL_INPUT))
-          }
-
       Row(modifier = Modifier.fillMaxWidth()) {
         if (emailError) {
           Text(
@@ -1368,13 +1349,6 @@ fun EmailSection(
                       .testTag(PrivateInfoTestTags.EMAIL_ERROR_LABEL))
         }
       }
-
-      HorizontalDivider(
-          modifier = Modifier.fillMaxWidth(),
-          thickness = Dimensions.DividerThickness.standard,
-          color = AppColors.textIcons.copy(alpha = 0.5f))
-
-      Spacer(modifier = Modifier.height(Dimensions.Spacing.large))
 
       Text(
           text = MainTabUi.EmailSection.CHANGE_EMAIL_TITLE,

--- a/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
@@ -160,6 +160,12 @@ object PublicInfoTestTags {
   const val BUSINESS_CARD = "businesses_section"
 }
 
+object EmailVerificationTestTags {
+  const val VERIFICATION_SECTION = "verification_section"
+  const val USER_EMAIL = "user_email"
+  const val RESEND_MAIL_VERIFICATION_BTN = "resend_mail_verification_btn"
+}
+
 object PrivateInfoTestTags {
 
   // ------------------------------------------------------------
@@ -449,7 +455,7 @@ fun MainTab(
 
           // Get email from Firebase Auth instead of Firestore account
           // Refresh whenever this page is composed or uiState changes
-          val currentUser = com.github.meeplemeet.FirebaseProvider.auth.currentUser
+          val currentUser = FirebaseProvider.auth.currentUser
           val email = currentUser?.email ?: account.email
           val isVerified = uiState.isEmailVerified
 
@@ -645,49 +651,54 @@ fun MainTabContent(
               modifier = Modifier.fillMaxWidth().padding(bottom = Dimensions.Padding.medium))
 
           // The Blue Card
-          Box(contentAlignment = Alignment.BottomCenter) {
-            Card(
-                colors =
-                    CardDefaults.cardColors(
-                        containerColor =
-                            AppColors
-                                .neutral), // Using a blue-ish color similar to design, or could use
-                // AppColors.primary if it matches
-                shape = RoundedCornerShape(Dimensions.CornerRadius.medium),
-                modifier = Modifier.fillMaxWidth()) {
-                  Box(
-                      modifier =
-                          Modifier.fillMaxSize().padding(horizontal = Dimensions.Padding.large),
-                      contentAlignment = Alignment.Center) {
-                        // Email Address
-                        Text(
-                            text = userEmail,
-                            color = AppColors.textIcons,
-                            modifier = Modifier.align(Alignment.CenterStart))
+          Box(
+              contentAlignment = Alignment.BottomCenter,
+              modifier = Modifier.testTag(EmailVerificationTestTags.VERIFICATION_SECTION)) {
+                Card(
+                    colors = CardDefaults.cardColors(containerColor = AppColors.neutral),
+                    shape = RoundedCornerShape(Dimensions.CornerRadius.medium),
+                    modifier = Modifier.fillMaxWidth()) {
+                      Box(
+                          modifier =
+                              Modifier.fillMaxSize().padding(horizontal = Dimensions.Padding.large),
+                          contentAlignment = Alignment.Center) {
+                            // Email Address
+                            Text(
+                                text = userEmail,
+                                color = AppColors.textIcons,
+                                modifier =
+                                    Modifier.align(Alignment.CenterStart)
+                                        .testTag(EmailVerificationTestTags.USER_EMAIL))
 
-                        // Send Icon
-                        IconButton(
-                            onClick = {
-                              viewModel.sendVerificationEmail()
-                              viewModel.refreshEmailVerificationStatus()
-                              toast = ToastData(message = MainTabUi.PrivateInfo.TOAST_MSG)
-                            },
-                            enabled = online,
-                            modifier = Modifier.align(Alignment.CenterEnd)) {
-                              Icon(
-                                  imageVector = Icons.AutoMirrored.Filled.Send,
-                                  contentDescription = MainTabUi.PrivateInfo.SEND_ICON_DESC,
-                                  tint = AppColors.textIcons,
-                                  modifier = Modifier.size(Dimensions.IconSize.large))
-                            }
-                      }
-                }
+                            // Send Icon
+                            IconButton(
+                                onClick = {
+                                  viewModel.sendVerificationEmail()
+                                  viewModel.refreshEmailVerificationStatus()
+                                  toast = ToastData(message = MainTabUi.PrivateInfo.TOAST_MSG)
+                                },
+                                enabled = online,
+                                modifier =
+                                    Modifier.align(Alignment.CenterEnd)
+                                        .testTag(
+                                            EmailVerificationTestTags
+                                                .RESEND_MAIL_VERIFICATION_BTN)) {
+                                  Icon(
+                                      imageVector = Icons.AutoMirrored.Filled.Send,
+                                      contentDescription = MainTabUi.PrivateInfo.SEND_ICON_DESC,
+                                      tint = AppColors.textIcons,
+                                      modifier = Modifier.size(Dimensions.IconSize.large))
+                                }
+                          }
+                    }
 
-            // Toast Overlay - Positioned to float over content without layout shift
-            Box(modifier = Modifier.align(Alignment.BottomCenter).offset(y = 35.dp).zIndex(1f)) {
-              ToastHost(toast = toast, onToastFinished = { toast = null })
-            }
-          }
+                // Toast Overlay - Positioned to float over content without layout shift
+                Box(
+                    modifier =
+                        Modifier.align(Alignment.BottomCenter).offset(y = 35.dp).zIndex(1f)) {
+                      ToastHost(toast = toast, onToastFinished = { toast = null })
+                    }
+              }
 
           Spacer(modifier = Modifier.height(Dimensions.Spacing.xxxLarge))
         }

--- a/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
@@ -345,6 +345,8 @@ object MainTabUi {
   }
 }
 
+const val VERIFICATION_OFFSET = 35
+
 sealed class ProfilePage {
   data object Main : ProfilePage()
 
@@ -692,10 +694,9 @@ fun MainTabContent(
                           }
                     }
 
-                // Toast Overlay - Positioned to float over content without layout shift
                 Box(
                     modifier =
-                        Modifier.align(Alignment.BottomCenter).offset(y = 35.dp).zIndex(1f)) {
+                        Modifier.align(Alignment.BottomCenter).offset(y = VERIFICATION_OFFSET.dp).zIndex(1f)) {
                       ToastHost(toast = toast, onToastFinished = { toast = null })
                     }
               }

--- a/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
@@ -243,6 +243,8 @@ object MainTabUi {
   val AVATAR_SIZE = 130.dp
   val OFFSET_X = 4.dp
   val OFFSET_Y = (-4).dp
+  val OFFSET_EMAIL = 35.dp
+  val PADDING_BOTTOM_SCROLL = 100.dp
   const val MAX_NOTIF_COUNT = 9
 
   object Misc {
@@ -287,8 +289,6 @@ object MainTabUi {
 
     const val TOAST_MSG = "Sent"
     const val SEND_ICON_DESC = "Resend Verification Email"
-    const val VERIFIED_MSG = "Account Verified"
-    const val UNVERIFIED_MSG = "Account not Verified"
     const val EMAIL_INVALID_MSG = "Invalid Email Format"
     const val ROLES_TITLE = "Your Roles"
     const val SELL_ITEMS_LABEL = "Sell Items"
@@ -345,8 +345,6 @@ object MainTabUi {
   }
 }
 
-const val VERIFICATION_OFFSET = 35
-
 sealed class ProfilePage {
   data object Main : ProfilePage()
 
@@ -387,6 +385,7 @@ fun MainTab(
   val offlineData by OfflineModeManager.offlineModeFlow.collectAsStateWithLifecycle()
 
   val businesses by viewModel.businesses.collectAsState()
+  val uiState by viewModel.uiState.collectAsState()
 
   val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
 
@@ -453,13 +452,10 @@ fun MainTab(
         }
     ProfilePage.Email ->
         SubPageScaffold("Email Settings", onBack = { currentPage = ProfilePage.Main }) {
-          val uiState by viewModel.uiState.collectAsState()
-
           // Get email from Firebase Auth instead of Firestore account
           // Refresh whenever this page is composed or uiState changes
           val currentUser = FirebaseProvider.auth.currentUser
           val email = currentUser?.email ?: account.email
-          val isVerified = uiState.isEmailVerified
 
           // Refresh email and verification status when entering this section
           LaunchedEffect(currentPage) {
@@ -696,7 +692,9 @@ fun MainTabContent(
 
                 Box(
                     modifier =
-                        Modifier.align(Alignment.BottomCenter).offset(y = VERIFICATION_OFFSET.dp).zIndex(1f)) {
+                        Modifier.align(Alignment.BottomCenter)
+                            .offset(y = MainTabUi.OFFSET_EMAIL)
+                            .zIndex(1f)) {
                       ToastHost(toast = toast, onToastFinished = { toast = null })
                     }
               }
@@ -780,6 +778,10 @@ fun MainTabContent(
                     onDelete()
                   })
             }
+
+        if (!uiState.isEmailVerified) {
+          Spacer(modifier = Modifier.height(MainTabUi.PADDING_BOTTOM_SCROLL))
+        }
       }
 }
 

--- a/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
@@ -645,7 +645,7 @@ fun MainTabContent(
         Spacer(modifier = Modifier.height(Dimensions.Spacing.xLarge))
 
         // Email verification part
-        val notVerified = uiState.isEmailVerified
+        val notVerified = !uiState.isEmailVerified
         Text(
             text = "Email",
             fontSize = Dimensions.TextSize.heading,
@@ -655,7 +655,7 @@ fun MainTabContent(
             contentAlignment = Alignment.BottomCenter,
             modifier = Modifier.testTag(EmailVerificationTestTags.VERIFICATION_SECTION)) {
               Card(
-                  border = BorderStroke(0.5.dp, AppColors.textIcons),
+                  border = BorderStroke(Dimensions.DividerThickness.thin, AppColors.textIcons),
                   colors =
                       CardDefaults.cardColors(
                           containerColor =

--- a/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
@@ -655,7 +655,10 @@ fun MainTabContent(
             contentAlignment = Alignment.BottomCenter,
             modifier = Modifier.testTag(EmailVerificationTestTags.VERIFICATION_SECTION)) {
               Card(
-                  border = BorderStroke(Dimensions.DividerThickness.thin, AppColors.textIcons),
+                  border =
+                      if (!notVerified)
+                          BorderStroke(Dimensions.DividerThickness.standard, AppColors.divider)
+                      else null,
                   colors =
                       CardDefaults.cardColors(
                           containerColor =

--- a/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
@@ -645,7 +645,7 @@ fun MainTabContent(
         Spacer(modifier = Modifier.height(Dimensions.Spacing.xLarge))
 
         // Email verification part
-        val notVerified = !uiState.isEmailVerified
+        val notVerified = uiState.isEmailVerified
         Text(
             text = "Email",
             fontSize = Dimensions.TextSize.heading,
@@ -667,7 +667,8 @@ fun MainTabContent(
                   modifier = Modifier.fillMaxWidth()) {
                     Box(
                         modifier =
-                            Modifier.fillMaxSize().padding(horizontal = Dimensions.Padding.large),
+                            Modifier.fillMaxSize()
+                                .padding(start = Dimensions.Padding.extraLarge, end = 0.dp),
                         contentAlignment = Alignment.Center) {
                           // Email Address
                           Text(
@@ -690,6 +691,7 @@ fun MainTabContent(
                                   Modifier.align(Alignment.CenterEnd)
                                       .testTag(
                                           EmailVerificationTestTags.RESEND_MAIL_VERIFICATION_BTN)) {
+                                Spacer(modifier = Modifier.width(Dimensions.Spacing.large))
                                 Icon(
                                     imageVector =
                                         if (notVerified) Icons.AutoMirrored.Filled.Send

--- a/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
@@ -1303,7 +1303,6 @@ fun EmailSection(
     errorMsg: String? = null,
     successMsg: String? = null
 ) {
-  var toast by remember { mutableStateOf<ToastData?>(null) }
   var localEmail by remember { mutableStateOf(email) }
   var showErrors by remember { mutableStateOf(false) }
   var newEmail by remember { mutableStateOf("") }
@@ -1371,6 +1370,7 @@ fun EmailSection(
 
       FocusableInputField(
           label = { Text(text = MainTabUi.EmailSection.NEW_EMAIL_INPUT_FIELD) },
+          enabled = online,
           value = newEmail,
           onValueChange = { new ->
             newEmail = new
@@ -1405,6 +1405,7 @@ fun EmailSection(
 
       FocusableInputField(
           label = { Text(text = MainTabUi.EmailSection.CONFIRM_EMAIL_INPUT_FIELD) },
+          enabled = online,
           value = confirmEmail,
           onValueChange = { new ->
             confirmEmail = new
@@ -1431,6 +1432,7 @@ fun EmailSection(
 
       FocusableInputField(
           label = { Text(text = MainTabUi.EmailSection.PASSWORD_INPUT_FIELD) },
+          enabled = online,
           value = password,
           onValueChange = { password = it },
           visualTransformation =
@@ -1564,7 +1566,7 @@ fun RolesSection(
     online: Boolean
 ) {
 
-  var expanded by remember { mutableStateOf(!hasNoRoles(account)) }
+  var expanded by remember { mutableStateOf(hasNoRoles(account)) }
 
   var isShopChecked by remember { mutableStateOf(account.shopOwner) }
   var isSpaceRented by remember { mutableStateOf(account.spaceRenter) }


### PR DESCRIPTION
### Description
This PR moves the email verification logic out of the subscaffold "Manage your email" and places it into the main page of the profile screen. The section is only displayed while the user has not verified his email, it is placed within the center of the screen with an eye-catching color to ensure that this step is performed asap by the user.
Email verification is a small step that however unlocks many extra features within the app and a layer of security.

Within this PR there is also a bit of code cleanup within the email related sections of the screen.

Demo:

https://github.com/user-attachments/assets/59ccc435-2da2-4de2-bf5a-1ed354ac7b1b

