### PR TITLE
Fix/add handle description

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/ui/CreateAccountScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/CreateAccountScreenTest.kt
@@ -9,6 +9,7 @@ import com.github.meeplemeet.model.account.Account
 import com.github.meeplemeet.model.account.CreateAccountViewModel
 import com.github.meeplemeet.ui.account.CreateAccountScreen
 import com.github.meeplemeet.ui.account.CreateAccountTestTags
+import com.github.meeplemeet.ui.components.CommonComponentsTestTags
 import com.github.meeplemeet.ui.theme.AppTheme
 import com.github.meeplemeet.ui.theme.ThemeMode
 import com.github.meeplemeet.utils.Checkpoint
@@ -81,6 +82,32 @@ class CreateAccountScreenTest : FirestoreTests() {
       handleField().performTextInput(h1)
       submitBtn().assertIsNotEnabled()
       clearFields()
+    }
+
+    checkpoint("Handle icon displays toast") {
+      // Basic behavior
+      compose.onNodeWithTag(CreateAccountTestTags.HANDLE_INFO_ICON).performClick()
+      compose
+          .onNodeWithTag(CommonComponentsTestTags.CLOSABLE_TOAST, useUnmergedTree = true)
+          .assertExists()
+          .assertTextContains("A unique name others use to find and recognize you.")
+      compose.waitForIdle()
+      compose
+          .onNodeWithTag(
+              CommonComponentsTestTags.CLOSABLE_TOAST_CLOSE_BUTTON, useUnmergedTree = true)
+          .performClick()
+      compose.waitForIdle()
+
+      // Assert that the icon acts as a toggle
+      compose.onNodeWithTag(CreateAccountTestTags.HANDLE_INFO_ICON).performClick()
+      compose
+          .onNodeWithTag(CommonComponentsTestTags.CLOSABLE_TOAST, useUnmergedTree = true)
+          .assertExists()
+          .assertTextContains("A unique name others use to find and recognize you.")
+      compose.onNodeWithTag(CreateAccountTestTags.HANDLE_INFO_ICON).performClick()
+      compose
+          .onNodeWithTag(CommonComponentsTestTags.CLOSABLE_TOAST, useUnmergedTree = true)
+          .assertDoesNotExist()
     }
 
     /* 3. handle already taken */

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/MainTabComposableTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/MainTabComposableTest.kt
@@ -23,6 +23,7 @@ import com.github.meeplemeet.ui.account.PreferencesSectionTestTags
 import com.github.meeplemeet.ui.account.PrivateInfoTestTags
 import com.github.meeplemeet.ui.account.ProfileNavigationTestTags
 import com.github.meeplemeet.ui.account.PublicInfoTestTags
+import com.github.meeplemeet.ui.components.CommonComponentsTestTags
 import com.github.meeplemeet.ui.theme.AppTheme
 import com.github.meeplemeet.utils.Checkpoint
 import com.github.meeplemeet.utils.FirestoreTests
@@ -515,14 +516,6 @@ class MainTabComposableTest : FirestoreTests() {
       compose.subPageBackButton().performClick()
       compose.waitForIdle()
       compose.publicInfoRoot().assertExists()
-
-      compose.settingsRowBusinesses().performClick()
-      compose.waitForIdle()
-      compose.rolesTitle().assertExists().performClick()
-      compose.roleShopCheckbox().assertExists() // UI updated correctly
-
-      compose.subPageBackButton().performClick()
-      compose.waitForIdle()
     }
 
     // ---------------------------------------------------------------------
@@ -551,6 +544,32 @@ class MainTabComposableTest : FirestoreTests() {
       compose.delAccountPopupConfirm().assertExists().performClick()
       assert(delClicked)
       compose.waitForIdle()
+    }
+
+    checkpoint("Handle icon displays toast") {
+      // Basic behavior
+      compose.onNodeWithTag(PublicInfoTestTags.HANDLE_INFO_ICON).performClick()
+      compose
+          .onNodeWithTag(CommonComponentsTestTags.CLOSABLE_TOAST, useUnmergedTree = true)
+          .assertExists()
+          .assertTextContains("A unique name others use to find and recognize you.")
+      compose.waitForIdle()
+      compose
+          .onNodeWithTag(
+              CommonComponentsTestTags.CLOSABLE_TOAST_CLOSE_BUTTON, useUnmergedTree = true)
+          .performClick()
+      compose.waitForIdle()
+
+      // Assert that the icon acts as a toggle
+      compose.onNodeWithTag(PublicInfoTestTags.HANDLE_INFO_ICON).performClick()
+      compose
+          .onNodeWithTag(CommonComponentsTestTags.CLOSABLE_TOAST, useUnmergedTree = true)
+          .assertExists()
+          .assertTextContains("A unique name others use to find and recognize you.")
+      compose.onNodeWithTag(PublicInfoTestTags.HANDLE_INFO_ICON).performClick()
+      compose
+          .onNodeWithTag(CommonComponentsTestTags.CLOSABLE_TOAST, useUnmergedTree = true)
+          .assertDoesNotExist()
     }
   }
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/account/CreateAccountScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/CreateAccountScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.*
 import androidx.compose.material3.TextFieldDefaults

--- a/app/src/main/java/com/github/meeplemeet/ui/account/CreateAccountScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/CreateAccountScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.meeplemeet.R
@@ -294,7 +293,9 @@ fun CreateAccountScreen(
                         message = toast?.message ?: "",
                         onDismiss = { toast = null },
                         modifier =
-                            Modifier.align(Alignment.TopEnd).zIndex(10f).offset(y = (-60).dp))
+                            Modifier.align(Alignment.TopEnd)
+                                .zIndex(Dimensions.ZIndex.foregroundMax)
+                                .offset(y = -Dimensions.Spacing.xxxxLarge))
                   }
                 }
 

--- a/app/src/main/java/com/github/meeplemeet/ui/account/CreateAccountScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/CreateAccountScreen.kt
@@ -17,6 +17,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.QuestionMark
 import androidx.compose.material3.*
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.*
@@ -30,12 +32,15 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.meeplemeet.R
 import com.github.meeplemeet.model.account.Account
 import com.github.meeplemeet.model.account.CreateAccountViewModel
 import com.github.meeplemeet.ui.FocusableInputField
 import com.github.meeplemeet.ui.UiBehaviorConfig
+import com.github.meeplemeet.ui.components.ToastData
 import com.github.meeplemeet.ui.discussions.AddDiscussionTestTags
 import com.github.meeplemeet.ui.theme.AppColors
 import com.github.meeplemeet.ui.theme.Dimensions
@@ -45,7 +50,7 @@ import com.github.meeplemeet.utils.KeyboardUtils
  * Finds the Activity from a Context by traversing the context hierarchy. Returns null if no
  * Activity is found.
  */
-private fun Context.findActivity(): Activity? {
+fun Context.findActivity(): Activity? {
   var context = this
   while (context is ContextWrapper) {
     if (context is Activity) return context
@@ -70,8 +75,6 @@ object CreateAccountScreenUi {
   val extraLargePadding = Dimensions.Padding.extraLarge
   val smallPadding = Dimensions.Padding.small
   val mediumPadding = Dimensions.Padding.medium
-  val largePadding = Dimensions.Padding.large
-  val tinyPadding = Dimensions.Padding.tiny
   val extraLargeSpacing = Dimensions.Spacing.extraLarge
   val mediumSpacing = Dimensions.Spacing.medium
   val xxLargeSpacing = Dimensions.Spacing.xxLarge
@@ -107,6 +110,7 @@ fun CreateAccountScreen(
   var isShopChecked by remember { mutableStateOf(false) }
   var isSpaceRented by remember { mutableStateOf(false) }
   var isInputFocused by remember { mutableStateOf(false) }
+  var toast by remember { mutableStateOf<ToastData?>(null) }
   val focusManager = LocalFocusManager.current
   val scrollState = rememberScrollState()
   val activity = LocalContext.current.findActivity()
@@ -196,161 +200,190 @@ fun CreateAccountScreen(
               }
         }
       }) { padding ->
-        Column(
-            modifier =
-                Modifier.fillMaxSize()
-                    .imePadding()
-                    .verticalScroll(scrollState)
-                    .background(AppColors.primary)
-                    .pointerInput(Unit) { detectTapGestures(onTap = { focusManager.clearFocus() }) }
-                    .padding(CreateAccountScreenUi.xxLargePadding),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Top) {
+        Box(modifier = Modifier.fillMaxSize()) {
+          Column(
+              modifier =
+                  Modifier.fillMaxSize()
+                      .imePadding()
+                      .verticalScroll(scrollState)
+                      .background(AppColors.primary)
+                      .pointerInput(Unit) {
+                        detectTapGestures(onTap = { focusManager.clearFocus() })
+                      }
+                      .padding(CreateAccountScreenUi.xxLargePadding),
+              horizontalAlignment = Alignment.CenterHorizontally,
+              verticalArrangement = Arrangement.Top) {
 
-              // App logo displayed on top of text.
-              val isDarkTheme = isSystemInDarkTheme()
-              Box(
-                  modifier =
-                      Modifier.size(
-                          Dimensions.IconSize.massive
-                              .times(3)
-                              .plus(Dimensions.Padding.extraLarge))) {
-                    Image(
-                        painter =
-                            painterResource(
-                                id =
-                                    if (isDarkTheme) R.drawable.logo_dark
-                                    else R.drawable.logo_clear),
-                        contentDescription = "Meeple Meet Logo",
-                        modifier = Modifier.fillMaxSize())
-                  }
-              /** Title text shown below the image placeholder. */
-              Text(
-                  "You're almost there!",
-                  style =
-                      TextStyle(
-                          fontSize = Dimensions.TextSize.extraLarge, color = AppColors.neutral),
-                  modifier = Modifier.padding(bottom = CreateAccountScreenUi.extraLargePadding))
-
-              /** Input field for entering the user's unique handle. */
-              FocusableInputField(
-                  value = handle,
-                  onValueChange = {
-                    handle = it
-                    if (it.isNotBlank()) {
-                      showErrors = true
-                      viewModel.checkHandleAvailable(it)
-                    } else {
-                      showErrors = false
+                // App logo displayed on top of text.
+                val isDarkTheme = isSystemInDarkTheme()
+                Box(
+                    modifier =
+                        Modifier.size(
+                            Dimensions.IconSize.massive
+                                .times(3)
+                                .plus(Dimensions.Padding.extraLarge))) {
+                      Image(
+                          painter =
+                              painterResource(
+                                  id =
+                                      if (isDarkTheme) R.drawable.logo_dark
+                                      else R.drawable.logo_clear),
+                          contentDescription = "Meeple Meet Logo",
+                          modifier = Modifier.fillMaxSize())
                     }
-                  },
-                  label = { Text("Handle") },
-                  singleLine = true,
-                  textStyle = TextStyle(color = AppColors.textIcons),
-                  colors =
-                      TextFieldDefaults.colors(
-                          focusedIndicatorColor = AppColors.textIcons,
-                          unfocusedIndicatorColor = AppColors.textIconsFade,
-                          cursorColor = AppColors.textIcons,
-                          focusedLabelColor = AppColors.textIcons,
-                          unfocusedContainerColor = Color.Transparent,
-                          focusedContainerColor = Color.Transparent,
-                          errorContainerColor = Color.Transparent,
-                          disabledContainerColor = Color.Transparent,
-                          unfocusedLabelColor = AppColors.textIconsFade,
-                          focusedTextColor = AppColors.textIcons,
-                          unfocusedTextColor = AppColors.textIconsFade),
-                  isError = showErrors && errorMessage.isNotBlank(),
-                  modifier =
-                      Modifier.fillMaxWidth()
-                          .onFocusChanged { isInputFocused = it.isFocused }
-                          .testTag(CreateAccountTestTags.HANDLE_FIELD))
-
-              /** Error message displayed if handle validation fails. */
-              if (showErrors && errorMessage.isNotBlank()) {
+                /** Title text shown below the image placeholder. */
                 Text(
-                    text = errorMessage,
-                    color = AppColors.textIconsFade,
-                    style = MaterialTheme.typography.bodySmall,
+                    "You're almost there!",
+                    style =
+                        TextStyle(
+                            fontSize = Dimensions.TextSize.extraLarge, color = AppColors.neutral),
+                    modifier = Modifier.padding(bottom = CreateAccountScreenUi.extraLargePadding))
+
+                /** Input field for entering the user's unique handle. */
+                FocusableInputField(
+                    value = handle,
+                    onValueChange = {
+                      handle = it
+                      if (it.isNotBlank()) {
+                        showErrors = true
+                        viewModel.checkHandleAvailable(it)
+                      } else {
+                        showErrors = false
+                      }
+                    },
+                    label = { Text("Handle") },
+                    singleLine = true,
+                    trailingIcon = {
+                      Icon(
+                          imageVector = Icons.Default.QuestionMark,
+                          contentDescription = "Handle information",
+                          modifier =
+                              Modifier.clickable {
+                                    toast =
+                                        if (toast == null)
+                                            ToastData(
+                                                "A unique name others use to find and recognize you.")
+                                        else null
+                                  }
+                                  .testTag("Hello-World"))
+                    },
+                    textStyle = TextStyle(color = AppColors.textIcons),
+                    colors =
+                        TextFieldDefaults.colors(
+                            focusedIndicatorColor = AppColors.textIcons,
+                            unfocusedIndicatorColor = AppColors.textIconsFade,
+                            cursorColor = AppColors.textIcons,
+                            focusedLabelColor = AppColors.textIcons,
+                            unfocusedContainerColor = Color.Transparent,
+                            focusedContainerColor = Color.Transparent,
+                            errorContainerColor = Color.Transparent,
+                            disabledContainerColor = Color.Transparent,
+                            unfocusedLabelColor = AppColors.textIconsFade,
+                            focusedTextColor = AppColors.textIcons,
+                            unfocusedTextColor = AppColors.textIconsFade),
+                    isError = showErrors && errorMessage.isNotBlank(),
                     modifier =
                         Modifier.fillMaxWidth()
-                            .padding(
-                                start = CreateAccountScreenUi.extraLargePadding,
-                                top = CreateAccountScreenUi.smallPadding)
-                            .testTag(CreateAccountTestTags.HANDLE_ERROR))
-              }
+                            .onFocusChanged { isInputFocused = it.isFocused }
+                            .testTag(CreateAccountTestTags.HANDLE_FIELD))
 
-              Spacer(modifier = Modifier.height(CreateAccountScreenUi.extraLargeSpacing))
+                /** Error message displayed if handle validation fails. */
+                if (showErrors && errorMessage.isNotBlank()) {
+                  Text(
+                      text = errorMessage,
+                      color = AppColors.textIconsFade,
+                      style = MaterialTheme.typography.bodySmall,
+                      modifier =
+                          Modifier.fillMaxWidth()
+                              .padding(
+                                  start = CreateAccountScreenUi.extraLargePadding,
+                                  top = CreateAccountScreenUi.smallPadding)
+                              .testTag(CreateAccountTestTags.HANDLE_ERROR))
+                }
 
-              /** Input field for entering the user's display username. */
-              FocusableInputField(
-                  value = username,
-                  onValueChange = {
-                    username = it
-                    usernameError = validateUsername(username)
-                  },
-                  label = { Text("Username") },
-                  singleLine = true,
-                  colors =
-                      TextFieldDefaults.colors(
-                          focusedIndicatorColor = AppColors.textIcons,
-                          unfocusedIndicatorColor = AppColors.textIconsFade,
-                          cursorColor = AppColors.textIcons,
-                          focusedLabelColor = AppColors.textIcons,
-                          unfocusedContainerColor = Color.Transparent,
-                          focusedContainerColor = Color.Transparent,
-                          errorContainerColor = Color.Transparent,
-                          disabledContainerColor = Color.Transparent,
-                          unfocusedLabelColor = AppColors.textIconsFade,
-                          focusedTextColor = AppColors.textIcons,
-                          unfocusedTextColor = AppColors.textIconsFade),
-                  isError = usernameError != null,
-                  textStyle = TextStyle(color = AppColors.textIcons),
-                  modifier =
-                      Modifier.fillMaxWidth()
-                          .onFocusChanged { isInputFocused = it.isFocused }
-                          .testTag(CreateAccountTestTags.USERNAME_FIELD))
+                Spacer(modifier = Modifier.height(CreateAccountScreenUi.extraLargeSpacing))
 
-              /** Error message displayed if username validation fails. */
-              if (usernameError != null) {
-                Text(
-                    text = usernameError!!,
-                    color = AppColors.textIconsFade,
-                    style = MaterialTheme.typography.bodySmall,
+                /** Input field for entering the user's display username. */
+                FocusableInputField(
+                    value = username,
+                    onValueChange = {
+                      username = it
+                      usernameError = validateUsername(username)
+                    },
+                    label = { Text("Username") },
+                    singleLine = true,
+                    colors =
+                        TextFieldDefaults.colors(
+                            focusedIndicatorColor = AppColors.textIcons,
+                            unfocusedIndicatorColor = AppColors.textIconsFade,
+                            cursorColor = AppColors.textIcons,
+                            focusedLabelColor = AppColors.textIcons,
+                            unfocusedContainerColor = Color.Transparent,
+                            focusedContainerColor = Color.Transparent,
+                            errorContainerColor = Color.Transparent,
+                            disabledContainerColor = Color.Transparent,
+                            unfocusedLabelColor = AppColors.textIconsFade,
+                            focusedTextColor = AppColors.textIcons,
+                            unfocusedTextColor = AppColors.textIconsFade),
+                    isError = usernameError != null,
+                    textStyle = TextStyle(color = AppColors.textIcons),
                     modifier =
                         Modifier.fillMaxWidth()
-                            .padding(
-                                start = CreateAccountScreenUi.extraLargePadding,
-                                top = CreateAccountScreenUi.smallPadding)
-                            .testTag(CreateAccountTestTags.USERNAME_ERROR))
+                            .onFocusChanged { isInputFocused = it.isFocused }
+                            .testTag(CreateAccountTestTags.USERNAME_FIELD))
+
+                /** Error message displayed if username validation fails. */
+                if (usernameError != null) {
+                  Text(
+                      text = usernameError!!,
+                      color = AppColors.textIconsFade,
+                      style = MaterialTheme.typography.bodySmall,
+                      modifier =
+                          Modifier.fillMaxWidth()
+                              .padding(
+                                  start = CreateAccountScreenUi.extraLargePadding,
+                                  top = CreateAccountScreenUi.smallPadding)
+                              .testTag(CreateAccountTestTags.USERNAME_ERROR))
+                }
+
+                // Spacing between input fields and text
+                Spacer(modifier = Modifier.height(CreateAccountScreenUi.xxLargeSpacing))
+
+                Text(
+                    text = "I also want to:",
+                    color = AppColors.textIcons,
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier =
+                        Modifier.fillMaxWidth()
+                            .padding(bottom = CreateAccountScreenUi.mediumPadding))
+
+                RoleCheckBox(
+                    online = true,
+                    isChecked = isShopChecked,
+                    onCheckedChange = { checked: Boolean -> isShopChecked = checked },
+                    label = "Sell items",
+                    description = "List your shop and the games it offers.",
+                    testTag = CreateAccountTestTags.CHECKBOX_OWNER)
+
+                RoleCheckBox(
+                    online = true,
+                    isChecked = isSpaceRented,
+                    onCheckedChange = { checked: Boolean -> isSpaceRented = checked },
+                    label = "Rent out spaces",
+                    description = "Offer your play spaces for other players to book.",
+                    testTag = CreateAccountTestTags.CHECKBOX_RENTER)
               }
 
-              // Spacing between input fields and text
-              Spacer(modifier = Modifier.height(CreateAccountScreenUi.xxLargeSpacing))
-
-              Text(
-                  text = "I also want to:",
-                  color = AppColors.textIcons,
-                  style = MaterialTheme.typography.bodyMedium,
-                  modifier =
-                      Modifier.fillMaxWidth().padding(bottom = CreateAccountScreenUi.mediumPadding))
-
-              RoleCheckBox(
-                  online = true,
-                  isChecked = isShopChecked,
-                  onCheckedChange = { checked: Boolean -> isShopChecked = checked },
-                  label = "Sell items",
-                  description = "List your shop and the games it offers.",
-                  testTag = CreateAccountTestTags.CHECKBOX_OWNER)
-
-              RoleCheckBox(
-                  online = true,
-                  isChecked = isSpaceRented,
-                  onCheckedChange = { checked: Boolean -> isSpaceRented = checked },
-                  label = "Rent out spaces",
-                  description = "Offer your play spaces for other players to book.",
-                  testTag = CreateAccountTestTags.CHECKBOX_RENTER)
-            }
+          if (toast != null) {
+            ClosableToast(
+                message = toast?.message ?: "",
+                onDismiss = { toast = null },
+                modifier =
+                    Modifier.align(Alignment.CenterEnd)
+                        .zIndex(10f)
+                        .offset(y = if (isInputFocused) 40.dp else (-110).dp, x = (-20).dp))
+          }
+        }
       }
 }
 
@@ -396,6 +429,36 @@ fun RoleCheckBox(
                   text = description,
                   color = AppColors.textIconsFade,
                   style = MaterialTheme.typography.bodySmall)
+            }
+      }
+}
+
+@Composable
+fun ClosableToast(message: String, onDismiss: () -> Unit, modifier: Modifier = Modifier) {
+  Surface(
+      modifier = modifier.widthIn(max = 280.dp),
+      color = AppColors.secondary,
+      shape = RoundedCornerShape(Dimensions.CornerRadius.medium),
+      shadowElevation = Dimensions.Elevation.high) {
+        Row(
+            modifier =
+                Modifier.padding(
+                    start = Dimensions.Padding.extraLarge,
+                    end = Dimensions.Padding.small,
+                    top = Dimensions.Padding.small,
+                    bottom = Dimensions.Padding.small),
+            verticalAlignment = Alignment.CenterVertically) {
+              Text(
+                  text = message,
+                  color = AppColors.textIcons,
+                  style = MaterialTheme.typography.bodyMedium,
+                  modifier = Modifier.weight(1f))
+              Spacer(modifier = Modifier.width(Dimensions.Spacing.medium))
+              Icon(
+                  imageVector = Icons.Filled.Close,
+                  contentDescription = "Close",
+                  tint = AppColors.textIcons,
+                  modifier = Modifier.size(20.dp).clickable { onDismiss() })
             }
       }
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/account/CreateAccountScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/CreateAccountScreen.kt
@@ -17,7 +17,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.QuestionMark
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.*
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.*
@@ -66,6 +67,7 @@ object CreateAccountTestTags {
   const val SUBMIT_BUTTON = "CreateAccountSubmitButton"
   const val CHECKBOX_OWNER = "CreateAccountCheckboxOwner"
   const val CHECKBOX_RENTER = "CreateAccountCheckboxRenter"
+  const val HANDLE_INFO_ICON = "CreateAccountHandleInfoIcon"
 }
 
 object CreateAccountScreenUi {
@@ -255,7 +257,7 @@ fun CreateAccountScreen(
                       singleLine = true,
                       trailingIcon = {
                         Icon(
-                            imageVector = Icons.Default.QuestionMark,
+                            imageVector = Icons.Outlined.Info,
                             contentDescription = "Handle information",
                             modifier =
                                 Modifier.clickable {
@@ -265,7 +267,7 @@ fun CreateAccountScreen(
                                                   "A unique name others use to find and recognize you.")
                                           else null
                                     }
-                                    .testTag("Hello-World"))
+                                    .testTag(CreateAccountTestTags.HANDLE_INFO_ICON))
                       },
                       textStyle = TextStyle(color = AppColors.textIcons),
                       colors =

--- a/app/src/main/java/com/github/meeplemeet/ui/account/CreateAccountScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/CreateAccountScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.QuestionMark
 import androidx.compose.material3.*
 import androidx.compose.material3.TextFieldDefaults
@@ -40,7 +39,7 @@ import com.github.meeplemeet.model.account.Account
 import com.github.meeplemeet.model.account.CreateAccountViewModel
 import com.github.meeplemeet.ui.FocusableInputField
 import com.github.meeplemeet.ui.UiBehaviorConfig
-import com.github.meeplemeet.ui.components.ToastData
+import com.github.meeplemeet.ui.components.ClosableToast
 import com.github.meeplemeet.ui.discussions.AddDiscussionTestTags
 import com.github.meeplemeet.ui.theme.AppColors
 import com.github.meeplemeet.ui.theme.Dimensions
@@ -240,52 +239,62 @@ fun CreateAccountScreen(
                     modifier = Modifier.padding(bottom = CreateAccountScreenUi.extraLargePadding))
 
                 /** Input field for entering the user's unique handle. */
-                FocusableInputField(
-                    value = handle,
-                    onValueChange = {
-                      handle = it
-                      if (it.isNotBlank()) {
-                        showErrors = true
-                        viewModel.checkHandleAvailable(it)
-                      } else {
-                        showErrors = false
-                      }
-                    },
-                    label = { Text("Handle") },
-                    singleLine = true,
-                    trailingIcon = {
-                      Icon(
-                          imageVector = Icons.Default.QuestionMark,
-                          contentDescription = "Handle information",
-                          modifier =
-                              Modifier.clickable {
-                                    toast =
-                                        if (toast == null)
-                                            ToastData(
-                                                "A unique name others use to find and recognize you.")
-                                        else null
-                                  }
-                                  .testTag("Hello-World"))
-                    },
-                    textStyle = TextStyle(color = AppColors.textIcons),
-                    colors =
-                        TextFieldDefaults.colors(
-                            focusedIndicatorColor = AppColors.textIcons,
-                            unfocusedIndicatorColor = AppColors.textIconsFade,
-                            cursorColor = AppColors.textIcons,
-                            focusedLabelColor = AppColors.textIcons,
-                            unfocusedContainerColor = Color.Transparent,
-                            focusedContainerColor = Color.Transparent,
-                            errorContainerColor = Color.Transparent,
-                            disabledContainerColor = Color.Transparent,
-                            unfocusedLabelColor = AppColors.textIconsFade,
-                            focusedTextColor = AppColors.textIcons,
-                            unfocusedTextColor = AppColors.textIconsFade),
-                    isError = showErrors && errorMessage.isNotBlank(),
-                    modifier =
-                        Modifier.fillMaxWidth()
-                            .onFocusChanged { isInputFocused = it.isFocused }
-                            .testTag(CreateAccountTestTags.HANDLE_FIELD))
+                Box(modifier = Modifier.fillMaxWidth()) {
+                  FocusableInputField(
+                      value = handle,
+                      onValueChange = {
+                        handle = it
+                        if (it.isNotBlank()) {
+                          showErrors = true
+                          viewModel.checkHandleAvailable(it)
+                        } else {
+                          showErrors = false
+                        }
+                      },
+                      label = { Text("Handle") },
+                      singleLine = true,
+                      trailingIcon = {
+                        Icon(
+                            imageVector = Icons.Default.QuestionMark,
+                            contentDescription = "Handle information",
+                            modifier =
+                                Modifier.clickable {
+                                      toast =
+                                          if (toast == null)
+                                              ToastData(
+                                                  "A unique name others use to find and recognize you.")
+                                          else null
+                                    }
+                                    .testTag("Hello-World"))
+                      },
+                      textStyle = TextStyle(color = AppColors.textIcons),
+                      colors =
+                          TextFieldDefaults.colors(
+                              focusedIndicatorColor = AppColors.textIcons,
+                              unfocusedIndicatorColor = AppColors.textIconsFade,
+                              cursorColor = AppColors.textIcons,
+                              focusedLabelColor = AppColors.textIcons,
+                              unfocusedContainerColor = Color.Transparent,
+                              focusedContainerColor = Color.Transparent,
+                              errorContainerColor = Color.Transparent,
+                              disabledContainerColor = Color.Transparent,
+                              unfocusedLabelColor = AppColors.textIconsFade,
+                              focusedTextColor = AppColors.textIcons,
+                              unfocusedTextColor = AppColors.textIconsFade),
+                      isError = showErrors && errorMessage.isNotBlank(),
+                      modifier =
+                          Modifier.fillMaxWidth()
+                              .onFocusChanged { isInputFocused = it.isFocused }
+                              .testTag(CreateAccountTestTags.HANDLE_FIELD))
+
+                  if (toast != null) {
+                    ClosableToast(
+                        message = toast?.message ?: "",
+                        onDismiss = { toast = null },
+                        modifier =
+                            Modifier.align(Alignment.TopEnd).zIndex(10f).offset(y = (-60).dp))
+                  }
+                }
 
                 /** Error message displayed if handle validation fails. */
                 if (showErrors && errorMessage.isNotBlank()) {
@@ -373,16 +382,6 @@ fun CreateAccountScreen(
                     description = "Offer your play spaces for other players to book.",
                     testTag = CreateAccountTestTags.CHECKBOX_RENTER)
               }
-
-          if (toast != null) {
-            ClosableToast(
-                message = toast?.message ?: "",
-                onDismiss = { toast = null },
-                modifier =
-                    Modifier.align(Alignment.CenterEnd)
-                        .zIndex(10f)
-                        .offset(y = if (isInputFocused) 40.dp else (-110).dp, x = (-20).dp))
-          }
         }
       }
 }
@@ -429,36 +428,6 @@ fun RoleCheckBox(
                   text = description,
                   color = AppColors.textIconsFade,
                   style = MaterialTheme.typography.bodySmall)
-            }
-      }
-}
-
-@Composable
-fun ClosableToast(message: String, onDismiss: () -> Unit, modifier: Modifier = Modifier) {
-  Surface(
-      modifier = modifier.widthIn(max = 280.dp),
-      color = AppColors.secondary,
-      shape = RoundedCornerShape(Dimensions.CornerRadius.medium),
-      shadowElevation = Dimensions.Elevation.high) {
-        Row(
-            modifier =
-                Modifier.padding(
-                    start = Dimensions.Padding.extraLarge,
-                    end = Dimensions.Padding.small,
-                    top = Dimensions.Padding.small,
-                    bottom = Dimensions.Padding.small),
-            verticalAlignment = Alignment.CenterVertically) {
-              Text(
-                  text = message,
-                  color = AppColors.textIcons,
-                  style = MaterialTheme.typography.bodyMedium,
-                  modifier = Modifier.weight(1f))
-              Spacer(modifier = Modifier.width(Dimensions.Spacing.medium))
-              Icon(
-                  imageVector = Icons.Filled.Close,
-                  contentDescription = "Close",
-                  tint = AppColors.textIcons,
-                  modifier = Modifier.size(20.dp).clickable { onDismiss() })
             }
       }
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
@@ -41,10 +41,10 @@ import androidx.compose.material.icons.filled.Email
 import androidx.compose.material.icons.filled.Group
 import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.Person
-import androidx.compose.material.icons.filled.QuestionMark
 import androidx.compose.material.icons.filled.Store
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.NotificationsNone
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -115,6 +115,7 @@ object PublicInfoTestTags {
 
   // ROOT
   const val PUBLIC_INFO = "public_info_root"
+  const val HANDLE_INFO_ICON = "handle_info_icon"
 
   // ------------------------------------------------------------
   // SECTION 1 — Avatar
@@ -1032,15 +1033,17 @@ fun PublicInfoInputs(
               },
               trailingIcon = {
                 Icon(
-                    imageVector = Icons.Default.QuestionMark,
+                    imageVector = Icons.Outlined.Info,
                     contentDescription = "Handle information",
                     modifier =
                         Modifier.clickable {
-                          toast =
-                              if (toast == null)
-                                  ToastData("A unique name others use to find and recognize you.")
-                              else null
-                        })
+                              toast =
+                                  if (toast == null)
+                                      ToastData(
+                                          "A unique name others use to find and recognize you.")
+                                  else null
+                            }
+                            .testTag(PublicInfoTestTags.HANDLE_INFO_ICON))
               })
 
           if (errorHandle) {

--- a/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
@@ -1127,7 +1127,10 @@ fun PublicInfoInputs(
       ClosableToast(
           message = toast?.message ?: "",
           onDismiss = { toast = null },
-          modifier = Modifier.align(Alignment.TopEnd).zIndex(10f).offset(y = (-60).dp))
+          modifier =
+              Modifier.align(Alignment.TopEnd)
+                  .zIndex(Dimensions.ZIndex.foregroundMax)
+                  .offset(y = -Dimensions.Spacing.xxxxLarge))
     }
   }
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/account/MainTab.kt
@@ -986,7 +986,6 @@ fun PublicInfoInputs(
   var name by remember { mutableStateOf(account.name) }
   var desc by remember { mutableStateOf(account.description ?: "") }
   var toast by remember { mutableStateOf<ToastData?>(null) }
-  var isInputFocused by remember { mutableStateOf(false) }
 
   Box(modifier = Modifier.fillMaxWidth()) {
     Column(
@@ -1027,7 +1026,6 @@ fun PublicInfoInputs(
               isError = errorHandle,
               onFocusChanged = { focused ->
                 onInputFocusChanged(focused)
-                isInputFocused = focused
                 if (!focused && !errorHandle)
                     viewModel.setAccountHandle(account, newHandle = handle)
               },

--- a/app/src/main/java/com/github/meeplemeet/ui/components/CommonComponents.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/CommonComponents.kt
@@ -606,13 +606,11 @@ fun ClosableToast(
     message: String,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
-    testTag: String = CommonComponentsTestTags.CLOSABLE_TOAST,
-    closeButtonTestTag: String = CommonComponentsTestTags.CLOSABLE_TOAST_CLOSE_BUTTON
 ) {
   Surface(
       modifier = modifier.fillMaxWidth(),
       color = AppColors.secondary,
-      shape = androidx.compose.foundation.shape.RoundedCornerShape(Dimensions.CornerRadius.medium),
+      shape = RoundedCornerShape(Dimensions.CornerRadius.medium),
       shadowElevation = Dimensions.Elevation.high) {
         Row(
             modifier =
@@ -626,7 +624,7 @@ fun ClosableToast(
                   text = message,
                   color = AppColors.textIcons,
                   style = MaterialTheme.typography.bodyMedium,
-                  modifier = Modifier.weight(1f).testTag(testTag))
+                  modifier = Modifier.weight(1f).testTag(CommonComponentsTestTags.CLOSABLE_TOAST))
               Spacer(modifier = Modifier.width(Dimensions.Spacing.medium))
               Icon(
                   imageVector = Icons.Filled.Close,
@@ -635,7 +633,7 @@ fun ClosableToast(
                   modifier =
                       Modifier.size(Dimensions.IconSize.extraLarge)
                           .clickable { onDismiss() }
-                          .testTag(closeButtonTestTag)
+                          .testTag(CommonComponentsTestTags.CLOSABLE_TOAST_CLOSE_BUTTON)
                           .padding(end = Dimensions.Padding.extraMedium))
             }
       }

--- a/app/src/main/java/com/github/meeplemeet/ui/components/CommonComponents.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/CommonComponents.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
@@ -32,6 +33,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.AddAPhoto
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Block
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.Person
@@ -588,6 +590,43 @@ fun ConfirmationDialog(
         },
         modifier = Modifier.testTag(dialogTestTag))
   }
+}
+
+/**
+ * A toast that can be closed by clicking on the close icon.
+ *
+ * @param message The message to display.
+ * @param onDismiss Callback when the toast is dismissed.
+ * @param modifier Modifier to be applied to the toast.
+ */
+@Composable
+fun ClosableToast(message: String, onDismiss: () -> Unit, modifier: Modifier = Modifier) {
+  androidx.compose.material3.Surface(
+      modifier = modifier.widthIn(max = 280.dp),
+      color = AppColors.secondary,
+      shape = androidx.compose.foundation.shape.RoundedCornerShape(Dimensions.CornerRadius.medium),
+      shadowElevation = Dimensions.Elevation.high) {
+        Row(
+            modifier =
+                Modifier.padding(
+                    start = Dimensions.Padding.extraLarge,
+                    end = Dimensions.Padding.small,
+                    top = Dimensions.Padding.small,
+                    bottom = Dimensions.Padding.small),
+            verticalAlignment = Alignment.CenterVertically) {
+              Text(
+                  text = message,
+                  color = AppColors.textIcons,
+                  style = MaterialTheme.typography.bodyMedium,
+                  modifier = Modifier.weight(1f))
+              Spacer(modifier = Modifier.width(Dimensions.Spacing.medium))
+              Icon(
+                  imageVector = Icons.Filled.Close,
+                  contentDescription = "Close",
+                  tint = AppColors.textIcons,
+                  modifier = Modifier.size(20.dp).clickable { onDismiss() })
+            }
+      }
 }
 
 /**

--- a/app/src/main/java/com/github/meeplemeet/ui/components/CommonComponents.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/components/CommonComponents.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
@@ -33,8 +32,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.AddAPhoto
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Block
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.PersonAdd
@@ -54,6 +53,7 @@ import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -105,6 +105,8 @@ object CommonComponentsTestTags {
   const val CONFIRMATION_DIALOG_MESSAGE = "ConfirmationDialogMessage"
   const val CONFIRMATION_DIALOG_CONFIRM = "ConfirmationDialogConfirm"
   const val CONFIRMATION_DIALOG_CANCEL = "ConfirmationDialogCancel"
+  const val CLOSABLE_TOAST = "ClosableToast"
+  const val CLOSABLE_TOAST_CLOSE_BUTTON = "ClosableToastCloseButton"
   const val USER_PROFILE_POPUP_DESCRIPTION = "UserProfilePopupDescription"
   const val USER_PROFILE_POPUP_HANDLE = "UserProfilePopupHandle"
   const val USER_PROFILE_POPUP_USERNAME = "UserProfilePopupUsername"
@@ -600,9 +602,15 @@ fun ConfirmationDialog(
  * @param modifier Modifier to be applied to the toast.
  */
 @Composable
-fun ClosableToast(message: String, onDismiss: () -> Unit, modifier: Modifier = Modifier) {
-  androidx.compose.material3.Surface(
-      modifier = modifier.widthIn(max = 280.dp),
+fun ClosableToast(
+    message: String,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+    testTag: String = CommonComponentsTestTags.CLOSABLE_TOAST,
+    closeButtonTestTag: String = CommonComponentsTestTags.CLOSABLE_TOAST_CLOSE_BUTTON
+) {
+  Surface(
+      modifier = modifier.fillMaxWidth(),
       color = AppColors.secondary,
       shape = androidx.compose.foundation.shape.RoundedCornerShape(Dimensions.CornerRadius.medium),
       shadowElevation = Dimensions.Elevation.high) {
@@ -618,13 +626,17 @@ fun ClosableToast(message: String, onDismiss: () -> Unit, modifier: Modifier = M
                   text = message,
                   color = AppColors.textIcons,
                   style = MaterialTheme.typography.bodyMedium,
-                  modifier = Modifier.weight(1f))
+                  modifier = Modifier.weight(1f).testTag(testTag))
               Spacer(modifier = Modifier.width(Dimensions.Spacing.medium))
               Icon(
                   imageVector = Icons.Filled.Close,
                   contentDescription = "Close",
                   tint = AppColors.textIcons,
-                  modifier = Modifier.size(20.dp).clickable { onDismiss() })
+                  modifier =
+                      Modifier.size(Dimensions.IconSize.extraLarge)
+                          .clickable { onDismiss() }
+                          .testTag(closeButtonTestTag)
+                          .padding(end = Dimensions.Padding.extraMedium))
             }
       }
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/theme/Dimensions.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/theme/Dimensions.kt
@@ -244,4 +244,10 @@ object Dimensions {
     const val expanded: Float = 180f
     const val collapsed: Float = 0f
   }
+
+  object ZIndex {
+    const val background: Float = 0f
+    const val foreground: Float = 1f
+    const val foregroundMax: Float = 10f
+  }
 }


### PR DESCRIPTION
### Overview
This PR adds a handle description to help users understanding what a handle is. The modifications happen in `MainTab.kt` and `CreateAccountScreen.kt`. 

### UI details
I've added an question mark icon within the handle input field. Upon click, a small toast appears explaining what a handle is to users. The toast can be dismissed through the `X` icon or by clicking again the question mark icon.

Demo:

https://github.com/user-attachments/assets/1155d373-5150-4e0f-986c-2b1a61d6d340

