### PR TITLE
Fix/theme preference display

### DIFF
--- a/app/src/main/java/com/github/meeplemeet/ui/MapScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/MapScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -120,6 +119,7 @@ import com.github.meeplemeet.ui.navigation.MeepleMeetScreen
 import com.github.meeplemeet.ui.navigation.NavigationActions
 import com.github.meeplemeet.ui.theme.AppColors
 import com.github.meeplemeet.ui.theme.Dimensions
+import com.github.meeplemeet.ui.theme.LocalThemeIsDark
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationCallback
 import com.google.android.gms.location.LocationRequest
@@ -538,7 +538,7 @@ fun MapScreen(
         Box(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
 
           // --- Google Map content ---
-          val isDarkTheme = isSystemInDarkTheme()
+          val isDarkTheme = LocalThemeIsDark.current
           val mapStyleOptions =
               if (isDarkTheme) {
                 MapStyleOptions.loadRawResourceStyle(context, R.raw.map_style_dark)

--- a/app/src/main/java/com/github/meeplemeet/ui/posts/PostScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/posts/PostScreen.kt
@@ -478,7 +478,7 @@ fun PostScreen(
 private fun PostTopBar(onBack: () -> Unit) {
   CenterAlignedTopAppBar(
       colors =
-          TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.surface),
+          TopAppBarDefaults.topAppBarColors(containerColor = MessagingColors.neutralBackground),
       navigationIcon = {
         IconButton(onClick = onBack, modifier = Modifier.testTag(PostTags.NAV_BACK_BTN)) {
           Icon(
@@ -791,7 +791,7 @@ private fun PostCard(
         }
 
     HorizontalDivider(
-        color = MessagingColors.divider, thickness = Dimensions.DividerThickness.thick)
+        color = MessagingColors.thickDivider, thickness = Dimensions.DividerThickness.thick)
   }
 }
 

--- a/app/src/main/java/com/github/meeplemeet/ui/posts/PostsOverviewScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/posts/PostsOverviewScreen.kt
@@ -228,7 +228,7 @@ public fun FeedCard(
         modifier =
             Modifier.fillMaxWidth()
                 .clickable(onClick = onClick)
-                .background(MessagingColors.messagingSurface)
+                .background(AppColors.primary)
                 .padding(
                     horizontal = Dimensions.Spacing.large, vertical = Dimensions.Spacing.large),
         horizontalArrangement = Arrangement.spacedBy(Dimensions.Spacing.large)) {
@@ -236,8 +236,7 @@ public fun FeedCard(
           Box(
               modifier =
                   Modifier.size(Dimensions.AvatarSize.large)
-                      .clip(RoundedCornerShape(Dimensions.CornerRadius.medium))
-                      .background(MessagingColors.messagingBackground),
+                      .clip(RoundedCornerShape(Dimensions.CornerRadius.medium)),
               contentAlignment = Alignment.Center) {
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.Article,

--- a/app/src/main/java/com/github/meeplemeet/ui/theme/MessagingColors.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/theme/MessagingColors.kt
@@ -47,7 +47,7 @@ object MessagingColors {
 
   // Dividers
   val divider: Color
-    @Composable get() = if (LocalThemeIsDark.current) Color(0xFFAAAAAAA) else Color(0xFFE5E5EA)
+    @Composable get() = if (LocalThemeIsDark.current) Color(0xFFAAAAAA) else Color(0xFFE5E5EA)
 
   val thickDivider: Color
     @Composable get() = if (LocalThemeIsDark.current) Color(0xFF151E26) else Color(0xFFE5E5EA)

--- a/app/src/main/java/com/github/meeplemeet/ui/theme/MessagingColors.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/theme/MessagingColors.kt
@@ -1,6 +1,5 @@
 package com.github.meeplemeet.ui.theme
 
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 
@@ -8,70 +7,70 @@ import androidx.compose.ui.graphics.Color
 object MessagingColors {
   // WhatsApp-style colors
   val whatsappGreen: Color
-    @Composable get() = if (isSystemInDarkTheme()) Color(0xFF00A884) else Color(0xFF25D366)
+    @Composable get() = if (LocalThemeIsDark.current) Color(0xFF00A884) else Color(0xFF25D366)
 
   val whatsappGreenLight: Color
-    @Composable get() = if (isSystemInDarkTheme()) Color(0xFF005C4B) else Color(0xFFDCF8C6)
+    @Composable get() = if (LocalThemeIsDark.current) Color(0xFF005C4B) else Color(0xFFDCF8C6)
 
   val whatsappLightGreen: Color
-    @Composable get() = if (isSystemInDarkTheme()) Color(0xFF1F3933) else Color(0xFFE1F5DC)
+    @Composable get() = if (LocalThemeIsDark.current) Color(0xFF1F3933) else Color(0xFFE1F5DC)
 
   // Reddit-style colors
   val redditOrange: Color
-    @Composable get() = if (isSystemInDarkTheme()) Color(0xFFFF5722) else Color(0xFFFF4500)
+    @Composable get() = if (LocalThemeIsDark.current) Color(0xFFFF5722) else Color(0xFFFF4500)
 
   val redditBlue: Color
-    @Composable get() = if (isSystemInDarkTheme()) Color(0xFF5E9AFF) else Color(0xFF1A73E8)
+    @Composable get() = if (LocalThemeIsDark.current) Color(0xFF5E9AFF) else Color(0xFF1A73E8)
 
   val redditBlueBg: Color
-    @Composable get() = if (isSystemInDarkTheme()) Color(0xFF1A2F4D) else Color(0xFFE8F0FE)
+    @Composable get() = if (LocalThemeIsDark.current) Color(0xFF1A2F4D) else Color(0xFFE8F0FE)
 
   // Background and surface colors
   val messagingBackground: Color
-    @Composable get() = if (isSystemInDarkTheme()) Color(0xFF0B141A) else Color(0xFFF5F5F5)
+    @Composable get() = if (LocalThemeIsDark.current) Color(0xFF0B141A) else Color(0xFFF5F5F5)
 
   val messagingSurface: Color
-    @Composable get() = if (isSystemInDarkTheme()) Color(0xFF1E2C35) else Color(0xFFFFFFFF)
+    @Composable get() = if (LocalThemeIsDark.current) Color(0xFF1E2C35) else Color(0xFFFFFFFF)
 
   val inputBackground: Color
-    @Composable get() = if (isSystemInDarkTheme()) Color(0xFF2A3942) else Color(0xFFF5F5F5)
+    @Composable get() = if (LocalThemeIsDark.current) Color(0xFF2A3942) else Color(0xFFF5F5F5)
 
   // Text colors
   val primaryText: Color
-    @Composable get() = if (isSystemInDarkTheme()) Color(0xFFE8E8E8) else Color(0xFF1C1C1E)
+    @Composable get() = if (LocalThemeIsDark.current) Color(0xFFE8E8E8) else Color(0xFF1C1C1E)
 
   val secondaryText: Color
-    @Composable get() = if (isSystemInDarkTheme()) Color(0xFF8E979F) else Color(0xFF8E8E93)
+    @Composable get() = if (LocalThemeIsDark.current) Color(0xFF8E979F) else Color(0xFF8E8E93)
 
   val metadataText: Color
-    @Composable get() = if (isSystemInDarkTheme()) Color(0xFF6B7C87) else Color(0xFF667781)
+    @Composable get() = if (LocalThemeIsDark.current) Color(0xFF6B7C87) else Color(0xFF667781)
 
   // Dividers
   val divider: Color
-    @Composable get() = if (isSystemInDarkTheme()) Color(0xFF2A3942) else Color(0xFFE5E5EA)
+    @Composable get() = if (LocalThemeIsDark.current) Color(0xFFAAAAAAA) else Color(0xFFE5E5EA)
 
   val thickDivider: Color
-    @Composable get() = if (isSystemInDarkTheme()) Color(0xFF151E26) else Color(0xFFE5E5EA)
+    @Composable get() = if (LocalThemeIsDark.current) Color(0xFF151E26) else Color(0xFFE5E5EA)
 
   // Bubble colors
   val messageBubbleOwn: Color
-    @Composable get() = if (isSystemInDarkTheme()) Color(0xFF005C4B) else Color(0xFFDCF8C6)
+    @Composable get() = if (LocalThemeIsDark.current) Color(0xFF005C4B) else Color(0xFFDCF8C6)
 
   val messageBubbleOther: Color
-    @Composable get() = if (isSystemInDarkTheme()) Color(0xFF1E2C35) else Color(0xFFFFFFFF)
+    @Composable get() = if (LocalThemeIsDark.current) Color(0xFF1E2C35) else Color(0xFFFFFFFF)
 
   // Avatar placeholder
   val avatarBackground: Color
-    @Composable get() = if (isSystemInDarkTheme()) Color(0xFFBD6B47) else Color(0xFFFF4500)
+    @Composable get() = if (LocalThemeIsDark.current) Color(0xFFBD6B47) else Color(0xFFFF4500)
 
   // Poll/selection colors
   val selectionBackground: Color
-    @Composable get() = if (isSystemInDarkTheme()) Color(0xFF1F3933) else Color(0xFFE8F5E9)
+    @Composable get() = if (LocalThemeIsDark.current) Color(0xFF1F3933) else Color(0xFFE8F5E9)
 
   val neutralBackground: Color
-    @Composable get() = if (isSystemInDarkTheme()) Color(0xFF2A3942) else Color(0xFFF5F5F5)
+    @Composable get() = if (LocalThemeIsDark.current) Color(0xFF2A3942) else Color(0xFFF5F5F5)
 
   // Icon tints
   val iconTint: Color
-    @Composable get() = if (isSystemInDarkTheme()) Color(0xFF8E979F) else Color(0xFF667781)
+    @Composable get() = if (LocalThemeIsDark.current) Color(0xFF8E979F) else Color(0xFF667781)
 }

--- a/app/src/main/java/com/github/meeplemeet/ui/theme/Theme.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/theme/Theme.kt
@@ -5,6 +5,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.compositionLocalOf
 import kotlinx.serialization.Serializable
 
 /**
@@ -64,6 +66,12 @@ val darkColors =
 val highContrastColors = darkColorScheme()
 
 /**
+ * CompositionLocal to provide the current theme mode (Dark/Light) to the app. This allows
+ * components to check if the app is currently in dark mode, independent of the system setting.
+ */
+val LocalThemeIsDark = compositionLocalOf { false }
+
+/**
  * The theme entry point, the app should be wrapped in this composable.
  *
  * @param themeMode The theme mode to use, defaults to [ThemeMode.SYSTEM_DEFAULT]
@@ -85,6 +93,8 @@ fun AppTheme(themeMode: ThemeMode = ThemeMode.SYSTEM_DEFAULT, content: @Composab
         else -> lightColors
       }
 
-  MaterialTheme(
-      colorScheme = colors, typography = appTypography, shapes = appShapes, content = content)
+  CompositionLocalProvider(LocalThemeIsDark provides isDark) {
+    MaterialTheme(
+        colorScheme = colors, typography = appTypography, shapes = appShapes, content = content)
+  }
 }


### PR DESCRIPTION
### Overview  
This PR resolves color inconsistencies between the LIGHT and DARK themes on several screens.

### Details  
The issue stemmed from using `isSystemInDarkTheme()` instead of relying on the user’s selected theme preference within the app. The fix introduces a single source of truth: the user’s theme preference stored in the `Account` object.

Affected screens:
- DiscussionScreen.kt  
- PostOverviewScreen.kt  
- PostScreen.kt  
- MapScreen.kt  