### PR TITLE
Deleted messages no longer shown in discussion previews

### DIFF
--- a/app/src/main/java/com/github/meeplemeet/model/discussions/DiscussionViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/discussions/DiscussionViewModel.kt
@@ -137,11 +137,18 @@ class DiscussionViewModel(
    * @throws IllegalArgumentException if sender is not the message author
    * @see DiscussionRepository.deleteMessage for low-level deletion
    */
-  fun deleteMessage(discussion: Discussion, message: Message, sender: Account) {
+  fun deleteMessage(
+      discussion: Discussion,
+      message: Message,
+      sender: Account,
+      lastMessage: Message?
+  ) {
     if (message.senderId != sender.uid)
         throw IllegalArgumentException("Can not delete someone else's message")
 
-    viewModelScope.launch { discussionRepository.deleteMessage(discussion.uid, message.uid) }
+    viewModelScope.launch {
+      discussionRepository.deleteMessage(discussion, message.uid, lastMessage)
+    }
   }
 
   /**

--- a/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/discussions/DiscussionScreen.kt
@@ -646,7 +646,12 @@ fun DiscussionScreen(
                             selectedMessageAnchor = null
                             scope.launch {
                               try {
-                                viewModel.deleteMessage(discussion, actionMessage, account)
+                                val lastMessage =
+                                    if (messages.last().uid != actionMessage.uid) messages.last()
+                                    else if (messages.size > 1) messages[messages.size - 2]
+                                    else null
+                                viewModel.deleteMessage(
+                                    discussion, actionMessage, account, lastMessage)
                               } catch (e: Exception) {
                                 snackbarHostState.showSnackbar(
                                     message =


### PR DESCRIPTION
When a message is deleted, it is no longer shown in the preview and if it was the only message in the discussion, the preview is reset.