### PR TITLE
Add ownership filter and refactor geo-pin handling

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/integration/MapViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/MapViewModelTest.kt
@@ -107,7 +107,7 @@ class MapViewModelTest : FirestoreTests() {
   @Test
   fun initialClusters_isEmpty() {
     val viewModel = MapViewModel(clusterManager = ClusterManager(singleClusterStrategy))
-    val clusters = viewModel.getClusters()
+    val clusters = viewModel.getClusters(testAccount1)
 
     assertTrue(clusters.isEmpty())
   }
@@ -268,7 +268,7 @@ class MapViewModelTest : FirestoreTests() {
     viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
     delay(3000)
 
-    val clusters = viewModel.getClusters()
+    val clusters = viewModel.getClusters(testAccount1)
 
     assertEquals(1, clusters.size)
     assertTrue(clusters[0].items.size >= 2)
@@ -298,7 +298,7 @@ class MapViewModelTest : FirestoreTests() {
     viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
     delay(3000)
 
-    val clusters = viewModel.getClusters()
+    val clusters = viewModel.getClusters(testAccount1)
 
     assertTrue(clusters.size >= 2)
     assertTrue(clusters.all { it.items.size == 1 })
@@ -321,13 +321,13 @@ class MapViewModelTest : FirestoreTests() {
     viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
     delay(3000)
 
-    val clusters1 = viewModel.getClusters()
+    val clusters1 = viewModel.getClusters(testAccount1)
     val state1 = viewModel.uiState.value
     assertNotNull(state1.clusterCache)
 
     val cacheVersion = state1.cacheVersion
 
-    val clusters2 = viewModel.getClusters()
+    val clusters2 = viewModel.getClusters(testAccount1)
     val state2 = viewModel.uiState.value
 
     assertEquals(cacheVersion, state2.clusterCache!!.version)
@@ -350,7 +350,7 @@ class MapViewModelTest : FirestoreTests() {
     viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
     delay(3000)
 
-    viewModel.getClusters()
+    viewModel.getClusters(testAccount1)
     val version1 = viewModel.uiState.value.cacheVersion
 
     viewModel.updateFilters(setOf(PinType.SHOP))
@@ -358,7 +358,7 @@ class MapViewModelTest : FirestoreTests() {
     val version2 = viewModel.uiState.value.cacheVersion
     assertTrue(version2 > version1)
 
-    viewModel.getClusters()
+    viewModel.getClusters(testAccount1)
     val cache2 = viewModel.uiState.value.clusterCache
     assertNotNull(cache2)
     assertEquals(version2, cache2!!.version)
@@ -380,7 +380,7 @@ class MapViewModelTest : FirestoreTests() {
     viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
     delay(3000)
 
-    viewModel.getClusters()
+    viewModel.getClusters(testAccount1)
     val version1 = viewModel.uiState.value.cacheVersion
 
     viewModel.updateZoomLevel(16f)
@@ -405,7 +405,7 @@ class MapViewModelTest : FirestoreTests() {
     viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
     delay(3000)
 
-    viewModel.getClusters()
+    viewModel.getClusters(testAccount1)
     val version1 = viewModel.uiState.value.cacheVersion
 
     val shop2 =
@@ -451,7 +451,7 @@ class MapViewModelTest : FirestoreTests() {
     delay(3000)
 
     viewModel.updateFilters(setOf(PinType.SHOP))
-    val clusters = viewModel.getClusters()
+    val clusters = viewModel.getClusters(testAccount1)
 
     assertTrue(clusters.all { cluster -> cluster.items.all { it.geoPin.type == PinType.SHOP } })
 
@@ -473,11 +473,11 @@ class MapViewModelTest : FirestoreTests() {
     viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
     delay(3000)
 
-    assertTrue(viewModel.getClusters().isNotEmpty())
+    assertTrue(viewModel.getClusters(testAccount1).isNotEmpty())
 
     viewModel.updateFilters(emptySet())
 
-    val clusters = viewModel.getClusters()
+    val clusters = viewModel.getClusters(testAccount1)
     assertTrue(clusters.isEmpty())
 
     shopRepository.deleteShop(shop.id)
@@ -570,7 +570,7 @@ class MapViewModelTest : FirestoreTests() {
     viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
     delay(3000)
 
-    val clusters = viewModel.getClusters()
+    val clusters = viewModel.getClusters(testAccount1)
     assertTrue(clusters.isNotEmpty())
 
     val cluster = clusters[0]
@@ -609,7 +609,7 @@ class MapViewModelTest : FirestoreTests() {
     viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
     delay(3000)
 
-    val cluster = viewModel.getClusters()[0]
+    val cluster = viewModel.getClusters(testAccount1)[0]
     viewModel.selectCluster(cluster)
     delay(4500)
 
@@ -651,7 +651,7 @@ class MapViewModelTest : FirestoreTests() {
     viewModel.startGeoQuery(testLocation, radiusKm = 10.0, currentUserId = testAccount1.uid)
     delay(3000)
 
-    val cluster = viewModel.getClusters()[0]
+    val cluster = viewModel.getClusters(testAccount1)[0]
     viewModel.selectCluster(cluster)
     delay(4500)
 

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/MapScreenTest.kt
@@ -342,6 +342,52 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
       composeRule.waitForIdle()
     }
 
+    checkpoint("ownedFilter_notVisibleForRegularUser") {
+      currentAccountState.value = regularAccount
+      composeRule.waitForIdle()
+
+      composeRule.onNodeWithTag(MapScreenTestTags.FILTER_BUTTON).performClick()
+      composeRule.waitForIdle()
+
+      composeRule.onNodeWithTag(MapScreenTestTags.FILTER_OWNED_SWITCH).assertDoesNotExist()
+    }
+
+    checkpoint("ownedFilter_visibleForShopOwner") {
+      currentAccountState.value = shopOwnerAccount
+      composeRule.waitForIdle()
+
+      composeRule.onNodeWithTag(MapScreenTestTags.FILTER_BUTTON).performClick()
+      composeRule.waitForIdle()
+
+      composeRule.onNodeWithTag(MapScreenTestTags.FILTER_OWNED_SWITCH).assertIsDisplayed()
+    }
+
+    checkpoint("ownedFilter_visibleForSpaceRenter") {
+      currentAccountState.value = spaceRenterAccount
+      composeRule.waitForIdle()
+
+      composeRule.onNodeWithTag(MapScreenTestTags.FILTER_BUTTON).performClick()
+      composeRule.waitForIdle()
+
+      composeRule.onNodeWithTag(MapScreenTestTags.FILTER_OWNED_SWITCH).assertIsDisplayed()
+    }
+
+    checkpoint("ownedFilter_canBeToggled") {
+      currentAccountState.value = shopOwnerAccount
+      composeRule.waitForIdle()
+
+      composeRule.onNodeWithTag(MapScreenTestTags.FILTER_BUTTON).performClick()
+      composeRule.waitForIdle()
+
+      composeRule.onNodeWithTag(MapScreenTestTags.FILTER_OWNED_SWITCH).assertIsDisplayed()
+      composeRule.onNodeWithTag(MapScreenTestTags.FILTER_OWNED_SWITCH).performClick()
+      composeRule.waitForIdle()
+
+      // Toggle back off
+      composeRule.onNodeWithTag(MapScreenTestTags.FILTER_OWNED_SWITCH).performClick()
+      composeRule.waitForIdle()
+    }
+
     checkpoint("filterIntegration_hidesAndShowsPins") {
       runBlocking {
         val shop =

--- a/app/src/androidTest/java/com/github/meeplemeet/ui/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/ui/MapScreenTest.kt
@@ -365,7 +365,7 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
             testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
         delay(5000)
 
-        val initialClusters = viewModel.getClusters()
+        val initialClusters = viewModel.getClusters(regularAccount)
         assertTrue(initialClusters.size >= 2)
 
         composeRule.onNodeWithTag(MapScreenTestTags.FILTER_BUTTON).performClick()
@@ -374,7 +374,7 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
           !viewModel.uiState.value.activeFilters.contains(PinType.SHOP)
         }
 
-        val filteredClusters = viewModel.getClusters()
+        val filteredClusters = viewModel.getClusters(regularAccount)
         assertTrue(
             filteredClusters.all { cluster ->
               cluster.items.all { it.geoPin.type != PinType.SHOP }
@@ -430,7 +430,7 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
             testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
         delay(5000)
 
-        val clusters = noClusterViewModel.getClusters()
+        val clusters = noClusterViewModel.getClusters(regularAccount)
         val cluster = clusters.find { it.items.size == 1 && it.items[0].geoPin.uid == shop.id }
         assertNotNull(cluster)
         assertEquals(1, cluster!!.items.size)
@@ -467,7 +467,7 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
             testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
         delay(5000)
 
-        val clusters = noClusterViewModel.getClusters()
+        val clusters = noClusterViewModel.getClusters(regularAccount)
         val cluster = clusters.find { it.items[0].geoPin.uid == shop.id }
         assertNotNull(cluster)
 
@@ -511,7 +511,7 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
             testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
         delay(5000)
 
-        val clusters = noClusterViewModel.getClusters()
+        val clusters = noClusterViewModel.getClusters(regularAccount)
         val cluster = clusters.find { it.items[0].geoPin.uid == shop.id }
         assertNotNull(cluster)
 
@@ -543,7 +543,7 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
             testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
         delay(5000)
 
-        val clusters = noClusterViewModel.getClusters()
+        val clusters = noClusterViewModel.getClusters(regularAccount)
         val cluster = clusters.find { it.items[0].geoPin.uid == shop.id }
         assertNotNull(cluster)
 
@@ -599,7 +599,7 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
             testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
         delay(5000)
 
-        val clusters = noClusterViewModel.getClusters()
+        val clusters = noClusterViewModel.getClusters(regularAccount)
         val cluster = clusters.find { it.items[0].geoPin.uid == discussion.uid }
         assertNotNull(cluster)
 
@@ -657,7 +657,7 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
             testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
         delay(5000)
 
-        val clusters = noClusterViewModel.getClusters()
+        val clusters = noClusterViewModel.getClusters(regularAccount)
         val sessionCluster = clusters.find { it.items[0].geoPin.uid == discussion.uid }
         assertNull(sessionCluster)
 
@@ -668,7 +668,7 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
             testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = shopOwnerAccount.uid)
         delay(5000)
 
-        val ownerClusters = ownerViewModel.getClusters()
+        val ownerClusters = ownerViewModel.getClusters(regularAccount)
         val ownerSessionCluster = ownerClusters.find { it.items[0].geoPin.uid == discussion.uid }
         assertNotNull(ownerSessionCluster)
 
@@ -728,7 +728,7 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
             testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
         delay(5000)
 
-        val clusters = singleClusterViewModel.getClusters()
+        val clusters = singleClusterViewModel.getClusters(regularAccount)
         assertEquals(1, clusters.size)
         assertTrue(clusters[0].items.size >= 2)
 
@@ -773,7 +773,7 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
             testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
         delay(5000)
 
-        val clusters = singleClusterViewModel.getClusters()
+        val clusters = singleClusterViewModel.getClusters(regularAccount)
         singleClusterViewModel.selectCluster(clusters[0])
 
         composeRule.waitForIdle()
@@ -809,7 +809,7 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
             testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
         delay(5000)
 
-        val clusters = singleClusterViewModel.getClusters()
+        val clusters = singleClusterViewModel.getClusters(regularAccount)
         assertTrue(clusters.isNotEmpty())
 
         // Select the cluster and show the sheet
@@ -856,7 +856,7 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
             testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
         delay(5000)
 
-        val clusters = singleClusterViewModel.getClusters()
+        val clusters = singleClusterViewModel.getClusters(regularAccount)
         singleClusterViewModel.selectCluster(clusters[0])
         delay(5000)
 
@@ -903,7 +903,7 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
             testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
         delay(5000)
 
-        val clusters = singleClusterViewModel.getClusters()
+        val clusters = singleClusterViewModel.getClusters(regularAccount)
         assertTrue(clusters[0].items.size >= 2)
 
         singleClusterViewModel.selectCluster(clusters[0])
@@ -941,7 +941,7 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
             testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
         delay(5000)
 
-        val clusters = singleClusterViewModel.getClusters()
+        val clusters = singleClusterViewModel.getClusters(regularAccount)
         assertEquals(1, clusters.size)
         assertTrue(clusters[0].items.size >= 5)
 
@@ -972,7 +972,7 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
             testLocation, radiusKm = DEFAULT_TEST_KM, currentUserId = regularAccount.uid)
         delay(5000)
 
-        val allTypeClusters = singleClusterViewModel.getClusters()
+        val allTypeClusters = singleClusterViewModel.getClusters(regularAccount)
         assertTrue(allTypeClusters[0].items.size >= 2)
 
         // Filter to only shops
@@ -982,7 +982,7 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
           !singleClusterViewModel.uiState.value.activeFilters.contains(PinType.SPACE)
         }
 
-        val shopOnlyClusters = singleClusterViewModel.getClusters()
+        val shopOnlyClusters = singleClusterViewModel.getClusters(regularAccount)
         assertTrue(shopOnlyClusters[0].items.all { it.geoPin.type == PinType.SHOP })
 
         shopRepository.deleteShop(shop.id)
@@ -1028,12 +1028,12 @@ class MapScreenTest : FirestoreTests(), OnMapsSdkInitializedCallback {
 
         mapViewModel.updateZoomLevel(initialZoom)
         delay(5000)
-        val clustersAtInitialZoom = mapViewModel.getClusters()
+        val clustersAtInitialZoom = mapViewModel.getClusters(regularAccount)
 
         // Change zoom level
         mapViewModel.updateZoomLevel(newZoom)
         delay(5000)
-        val clustersAtNewZoom = mapViewModel.getClusters()
+        val clustersAtNewZoom = mapViewModel.getClusters(regularAccount)
 
         val state = mapViewModel.uiState.value
         assertEquals(newZoom, state.currentZoomLevel)

--- a/app/src/main/java/com/github/meeplemeet/model/map/StorableGeoPin.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/map/StorableGeoPin.kt
@@ -15,8 +15,9 @@ enum class PinType {
  *
  * @property uid Globally unique identifier of the pin (Firestore document ID).
  * @property type Type of the pin (e.g. SHOP, SESSION, SPACE).
+ * @property ownerId Non-null if the pin represent a business (SPACE, SHOP).
  */
-data class StorableGeoPin(val uid: String, val type: PinType)
+data class StorableGeoPin(val uid: String, val type: PinType, val ownerId: String? = null)
 
 /** A geo-pin along with its current geographic location. */
 data class GeoPinWithLocation(val geoPin: StorableGeoPin, val location: GeoPoint)
@@ -26,7 +27,8 @@ data class GeoPinWithLocation(val geoPin: StorableGeoPin, val location: GeoPoint
  *
  * Firestore stores the UID as the document ID, so it is omitted from the stored object.
  */
-@Serializable data class StorableGeoPinNoUid(val type: PinType = PinType.SHOP)
+@Serializable
+data class StorableGeoPinNoUid(val type: PinType = PinType.SHOP, val ownerId: String? = null)
 
 /**
  * Converts a full [StorableGeoPin] into its Firestore-storable form [StorableGeoPinNoUid].
@@ -34,7 +36,7 @@ data class GeoPinWithLocation(val geoPin: StorableGeoPin, val location: GeoPoint
  * @param pin The map pin instance to convert.
  * @return The stripped-down form without UID for storage.
  */
-fun toNoUid(pin: StorableGeoPin): StorableGeoPinNoUid = StorableGeoPinNoUid(pin.type)
+fun toNoUid(pin: StorableGeoPin): StorableGeoPinNoUid = StorableGeoPinNoUid(pin.type, pin.ownerId)
 
 /**
  * Reconstructs a full [StorableGeoPin] object from its Firestore representation.
@@ -44,4 +46,4 @@ fun toNoUid(pin: StorableGeoPin): StorableGeoPinNoUid = StorableGeoPinNoUid(pin.
  * @return A fully constructed [StorableGeoPin] instance.
  */
 fun fromNoUid(id: String, noUid: StorableGeoPinNoUid): StorableGeoPin =
-    StorableGeoPin(id, noUid.type)
+    StorableGeoPin(id, noUid.type, noUid.ownerId)

--- a/app/src/main/java/com/github/meeplemeet/model/map/StorableGeoPinRepository.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/map/StorableGeoPinRepository.kt
@@ -103,6 +103,19 @@ class StorableGeoPinRepository(private val geoOps: GeoFirestoreOperations? = nul
   }
 
   /**
+   * Updates only the geographic location of an existing geo-pin.
+   *
+   * This method does not modify any metadata (type, ownerId) and should be used when the associated
+   * object changes address without changing ownership.
+   *
+   * @param ref ID of the pin to update.
+   * @param location New geographic location.
+   */
+  suspend fun updateGeoPinLocation(ref: String, location: Location) {
+    retry("update geolocation for $ref") { setGeoLocation(ref, location) }
+  }
+
+  /**
    * Deletes a geo-pin document and removes its geolocation data.
    *
    * Geolocation removal is attempted with retry logic to handle transient failures. The Firestore

--- a/app/src/main/java/com/github/meeplemeet/model/sessions/SessionRepository.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/sessions/SessionRepository.kt
@@ -5,7 +5,6 @@ import com.github.meeplemeet.model.FirestoreRepository
 import com.github.meeplemeet.model.discussions.Discussion
 import com.github.meeplemeet.model.discussions.DiscussionNoUid
 import com.github.meeplemeet.model.discussions.DiscussionRepository
-import com.github.meeplemeet.model.map.PinType
 import com.github.meeplemeet.model.shared.location.Location
 import com.google.firebase.Timestamp
 import com.google.firebase.firestore.FieldPath
@@ -48,7 +47,7 @@ class SessionRepository(
     val session = Session(name, gameId, gameName, date, location, participants.toList())
     discussions.document(discussionId).update(DiscussionNoUid::session.name, session).await()
 
-    geoPinsRepo.upsertGeoPin(ref = discussionId, type = PinType.SESSION, location = location)
+    geoPinsRepo.upsertSessionGeoPin(ref = discussionId, location = location)
 
     return discussionRepo.getDiscussion(discussionId)
   }
@@ -95,7 +94,7 @@ class SessionRepository(
 
     discussions.document(discussionId).update(updates).await()
 
-    if (location != null) geoPinsRepo.upsertGeoPin(discussionId, PinType.SESSION, location)
+    if (location != null) geoPinsRepo.updateGeoPinLocation(discussionId, location)
 
     return discussionRepo.getDiscussion(discussionId)
   }

--- a/app/src/main/java/com/github/meeplemeet/model/shops/ShopRepository.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/shops/ShopRepository.kt
@@ -65,7 +65,8 @@ class ShopRepository(
             photoCollectionUrl)
     collection.document(shop.id).set(toNoUid(shop)).await()
 
-    geoPinRepository.upsertGeoPin(ref = shop.id, type = PinType.SHOP, location = address)
+    geoPinRepository.upsertBusinessGeoPin(
+        ref = shop.id, type = PinType.SHOP, location = address, ownerId = owner.uid)
 
     accountRepository.addShopId(owner.uid, shop.id)
 
@@ -169,7 +170,7 @@ class ShopRepository(
 
     collection.document(id).update(updates).await()
 
-    if (address != null) geoPinRepository.upsertGeoPin(id, PinType.SHOP, address)
+    if (address != null) geoPinRepository.updateGeoPinLocation(id, address)
   }
 
   /**

--- a/app/src/main/java/com/github/meeplemeet/model/space_renter/SpaceRenterRepository.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/space_renter/SpaceRenterRepository.kt
@@ -69,7 +69,8 @@ class SpaceRenterRepository(
             photoCollectionUrl)
     collection.document(spaceRenter.id).set(toNoUid(spaceRenter)).await()
 
-    geoPinRepository.upsertGeoPin(ref = spaceRenter.id, type = PinType.SPACE, location = address)
+    geoPinRepository.upsertBusinessGeoPin(
+        ref = spaceRenter.id, type = PinType.SPACE, location = address, ownerId = owner.uid)
 
     accountRepository.addSpaceRenterId(owner.uid, spaceRenter.id)
 
@@ -177,7 +178,7 @@ class SpaceRenterRepository(
 
     collection.document(id).update(updates).await()
 
-    if (address != null) geoPinRepository.upsertGeoPin(id, PinType.SPACE, address)
+    if (address != null) geoPinRepository.updateGeoPinLocation(id, address)
   }
 
   /**

--- a/app/src/main/java/com/github/meeplemeet/ui/MapScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/MapScreen.kt
@@ -76,6 +76,8 @@ import androidx.compose.material3.SingleChoiceSegmentedButtonRowScope
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -89,6 +91,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.lerp
@@ -167,6 +170,7 @@ object MapScreenTestTags {
   const val FILTER_SHOP_CHIP = "filterShop"
   const val FILTER_SPACE_CHIP = "filterSpace"
   const val FILTER_SESSIONS_CHIP = "filterSession"
+  const val FILTER_OWNED_SWITCH = "filterOwnedSwitch"
   const val MARKER_PREVIEW_SHEET = "markerPreviewSheet"
   const val PREVIEW_TITLE = "previewTitle"
   const val PREVIEW_ADDRESS = "previewAddress"
@@ -325,6 +329,7 @@ fun MapScreen(
   var isCameraCentered by remember { mutableStateOf(false) }
   var isQueryLaunched by remember { mutableStateOf(false) }
   var includeTypes by remember { mutableStateOf(PinType.entries.toSet()) }
+  var showOwnedOnly by remember { mutableStateOf(false) }
 
   // --- UI controls (filters & creation) ---
   var showFilterButtons by remember { mutableStateOf(false) }
@@ -423,6 +428,9 @@ fun MapScreen(
 
   /** Updates the ViewModel filters whenever the set of included pin types changes. */
   LaunchedEffect(includeTypes) { viewModel.updateFilters(includeTypes) }
+
+  /** Updates the ViewModel owned-only filter whenever it changes. */
+  LaunchedEffect(showOwnedOnly) { viewModel.setShowOwnedBusinessesOnly(showOwnedOnly) }
 
   /** Displays any error message emitted by the ViewModel in a snackbar. */
   LaunchedEffect(uiState.errorMsg) {
@@ -581,7 +589,7 @@ fun MapScreen(
                       mapStyleOptions = mapStyleOptions, isMyLocationEnabled = permissionGranted),
               uiSettings =
                   MapUiSettings(myLocationButtonEnabled = false, zoomControlsEnabled = false)) {
-                val clusters = viewModel.getClusters()
+                val clusters = viewModel.getClusters(account = account)
 
                 clusters
                     .filter { it.items.isNotEmpty() }
@@ -655,68 +663,16 @@ fun MapScreen(
                                   Dimensions.ButtonSize.standard +
                                   Dimensions.Spacing.medium,
                           y = Dimensions.Padding.medium)) {
-                Surface(
-                    modifier =
-                        Modifier.widthIn(
-                                max =
-                                    Dimensions.ComponentWidth.spaceLabelWidth.plus(
-                                        Dimensions.Padding.extraMedium))
-                            .wrapContentHeight(),
-                    tonalElevation = Dimensions.Elevation.high,
-                    shape = RoundedCornerShape(Dimensions.CornerRadius.large),
-                    color = AppColors.primary.copy(alpha = 0.95f)) {
-                      Column(
-                          modifier =
-                              Modifier.padding(
-                                  horizontal = Dimensions.Padding.medium,
-                                  vertical = Dimensions.Padding.mediumSmall),
-                          verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.small)) {
-                            PinType.entries.forEach { type ->
-                              val selected = includeTypes.contains(type)
-                              FilterChip(
-                                  selected = selected,
-                                  onClick = {
-                                    includeTypes =
-                                        if (selected) includeTypes - type else includeTypes + type
-                                  },
-                                  label = {
-                                    Text(
-                                        text =
-                                            type.name.lowercase().replaceFirstChar {
-                                              it.uppercaseChar()
-                                            },
-                                        color = AppColors.textIcons,
-                                        style = MaterialTheme.typography.labelLarge)
-                                  },
-                                  leadingIcon = {
-                                    Checkbox(
-                                        checked = selected,
-                                        onCheckedChange = null,
-                                        modifier = Modifier.size(Dimensions.IconSize.medium))
-                                  },
-                                  colors =
-                                      SelectableChipColors(
-                                          containerColor = AppColors.primary,
-                                          leadingIconColor = Color.Transparent,
-                                          trailingIconColor = Color.Transparent,
-                                          disabledContainerColor = Color.Transparent,
-                                          disabledLabelColor = Color.Transparent,
-                                          disabledLeadingIconColor = Color.Transparent,
-                                          disabledTrailingIconColor = Color.Transparent,
-                                          disabledSelectedContainerColor = Color.Transparent,
-                                          selectedLabelColor = Color.Transparent,
-                                          selectedLeadingIconColor = Color.Transparent,
-                                          selectedTrailingIconColor = Color.Transparent,
-                                          labelColor = AppColors.textIcons,
-                                          selectedContainerColor = Color.Transparent),
-                                  modifier =
-                                      Modifier.testTag(pinTypeTestTag(type))
-                                          .height(Dimensions.Padding.huge)
-                                          .background(AppColors.primary)
-                                          .fillMaxWidth())
-                            }
-                          }
-                    }
+                FilterPanel(
+                    includeTypes = includeTypes,
+                    onTypeToggle = { type ->
+                      includeTypes =
+                          if (includeTypes.contains(type)) includeTypes - type
+                          else includeTypes + type
+                    },
+                    showOwnedOnly = showOwnedOnly,
+                    onOwnedOnlyToggle = { showOwnedOnly = !showOwnedOnly },
+                    canFilterOwned = account.shopOwner || account.spaceRenter)
               }
 
           // --- Dialog for business creation if ambiguous ---
@@ -1514,6 +1470,132 @@ private fun StaticVerticalMapMenu(
                 Icon(Icons.Default.AddLocationAlt, contentDescription = "Create")
               }
         }
+      }
+}
+
+/**
+ * Filter panel with Switch toggle for "My Businesses" filter.
+ *
+ * Features:
+ * - Minimal backgrounds on FilterChips (outline only)
+ * - Text on left, Switch on right for intuitive layout
+ * - Compact switch scaled to match checkbox size
+ *
+ * @param includeTypes currently active pin type filters
+ * @param onTypeToggle callback when a pin type chip is toggled
+ * @param showOwnedOnly whether to show only user-owned businesses
+ * @param onOwnedOnlyToggle callback when the owned-only switch is toggled
+ * @param canFilterOwned whether the user can filter by ownership (shop owner or space renter)
+ */
+@Composable
+private fun FilterPanel(
+    includeTypes: Set<PinType>,
+    onTypeToggle: (PinType) -> Unit,
+    showOwnedOnly: Boolean,
+    onOwnedOnlyToggle: () -> Unit,
+    canFilterOwned: Boolean
+) {
+  Surface(
+      modifier =
+          Modifier.widthIn(
+                  min = Dimensions.ComponentWidth.spaceLabelWidth,
+                  max = Dimensions.ComponentWidth.spaceLabelWidth.times(1.5f))
+              .wrapContentHeight(),
+      tonalElevation = Dimensions.Elevation.high,
+      shape = RoundedCornerShape(Dimensions.CornerRadius.large),
+      color = AppColors.primary.copy(alpha = 0.95f)) {
+        Column(
+            modifier =
+                Modifier.padding(
+                    horizontal = Dimensions.Padding.medium,
+                    vertical = Dimensions.Padding.mediumSmall),
+            verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.extraSmall)) {
+              // Pin type filters
+              PinType.entries.forEach { type ->
+                val selected = includeTypes.contains(type)
+                FilterChip(
+                    selected = selected,
+                    onClick = { onTypeToggle(type) },
+                    label = {
+                      Text(
+                          text = type.name.lowercase().replaceFirstChar { it.uppercaseChar() },
+                          color = AppColors.textIcons,
+                          style = MaterialTheme.typography.labelLarge)
+                    },
+                    leadingIcon = {
+                      Checkbox(
+                          checked = selected,
+                          onCheckedChange = null,
+                          modifier = Modifier.size(Dimensions.IconSize.medium))
+                    },
+                    colors =
+                        SelectableChipColors(
+                            containerColor = Color.Transparent,
+                            leadingIconColor = Color.Transparent,
+                            trailingIconColor = Color.Transparent,
+                            disabledContainerColor = Color.Transparent,
+                            disabledLabelColor = Color.Transparent,
+                            disabledLeadingIconColor = Color.Transparent,
+                            disabledTrailingIconColor = Color.Transparent,
+                            disabledSelectedContainerColor = Color.Transparent,
+                            selectedLabelColor = Color.Transparent,
+                            selectedLeadingIconColor = Color.Transparent,
+                            selectedTrailingIconColor = Color.Transparent,
+                            labelColor = AppColors.textIcons,
+                            selectedContainerColor = Color.Transparent),
+                    modifier =
+                        Modifier.testTag(pinTypeTestTag(type))
+                            .height(Dimensions.Padding.xxxLarge)
+                            .fillMaxWidth())
+              }
+
+              // Owned businesses filter
+              if (canFilterOwned) {
+                HorizontalDivider(
+                    modifier =
+                        Modifier.fillMaxWidth().padding(vertical = Dimensions.Spacing.extraSmall),
+                    thickness = Dimensions.DividerThickness.standard,
+                    color = AppColors.textIcons.copy(alpha = 0.3f))
+
+                Row(
+                    modifier =
+                        Modifier.testTag(MapScreenTestTags.FILTER_OWNED_SWITCH)
+                            .fillMaxWidth()
+                            .height(Dimensions.Padding.xxxLarge)
+                            .clickable { onOwnedOnlyToggle() }
+                            .padding(horizontal = Dimensions.Padding.mediumSmall),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween) {
+                      Text(
+                          text = "My Businesses",
+                          color = AppColors.textIcons,
+                          style = MaterialTheme.typography.labelLarge,
+                          maxLines = 1,
+                          overflow = TextOverflow.Ellipsis,
+                          modifier = Modifier.weight(1f, fill = false))
+
+                      Spacer(modifier = Modifier.width(Dimensions.Spacing.small))
+
+                      // Box to center the scaled switch
+                      Box(
+                          modifier = Modifier.size(Dimensions.IconSize.medium),
+                          contentAlignment = Alignment.Center) {
+                            Switch(
+                                checked = showOwnedOnly,
+                                onCheckedChange = { onOwnedOnlyToggle() },
+                                modifier = Modifier.scale(0.7f),
+                                colors =
+                                    SwitchDefaults.colors(
+                                        checkedThumbColor = AppColors.textIcons,
+                                        checkedTrackColor = AppColors.neutral.copy(alpha = 0.8f),
+                                        uncheckedThumbColor =
+                                            AppColors.textIcons.copy(alpha = 0.5f),
+                                        uncheckedTrackColor =
+                                            AppColors.textIcons.copy(alpha = 0.3f)))
+                          }
+                    }
+              }
+            }
       }
 }
 


### PR DESCRIPTION
This PR adds an ownership-based filter to the map and cleans up geo-pin creation/update flows to support it efficiently.

### Map filtering
- Add **“My businesses only”** filter, independent from pin type filters
- Filter applies only to **SHOP** and **SPACE** pins (sessions remain visible)
- Centralize filtering logic in `GeoPinWithLocation.matchesFilters`
- Update `MapViewModel` cluster computation to include ownership filtering

### Data & repositories
- Add nullable `ownerId` to `StorableGeoPin`
- Make low-level `upsertGeoPin` private
- Introduce explicit wrappers:
  - Business geo-pin creation (SHOP / SPACE with required `ownerId`)
  - Session geo-pin creation (no ownership)
- Add `updateGeoPinLocation` to update position without overwriting metadata

### UI
- Refactor map filters into a dedicated `FilterPanel` composable
- Add a switch for the ownership filter with clear labeling
- Keep ownership filter independent from pin type chips

### Tests
- Fix geo-pin repository tests impacted by `ownerId` and private upsert
- Add tests for `updateGeoPinLocation`
- Update ViewModel tests for new `getClusters(account)` signature
- Add tests for ownership-based filtering in `MapViewModel`
- Add UI tests for the new filter panel

### Impact
- Enable efficient client-side filtering without extra fetches
- Prevent accidental metadata overwrites when updating locations
- Clearer separation of concerns between creation and update flows

### Testing
- Toggle “My businesses only” and verify only owned shops/spaces remain
- Ensure sessions are always visible
- Update a shop location and confirm ownership data is preserved
- Verify clusters update correctly when filters change

_Reformulated with Copilot._
