### PR TITLE
Add travel time estimates to map marker previews

### DIFF
--- a/app/src/androidTest/java/com/github/meeplemeet/integration/FirestoreMarkerPreviewTest.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/integration/FirestoreMarkerPreviewTest.kt
@@ -4,9 +4,9 @@ package com.github.meeplemeet.integration
 
 import com.github.meeplemeet.model.account.Account
 import com.github.meeplemeet.model.discussions.Discussion
-import com.github.meeplemeet.model.map.MarkerPreview
 import com.github.meeplemeet.model.map.PinType
 import com.github.meeplemeet.model.map.StorableGeoPin
+import com.github.meeplemeet.model.map.previews.MarkerPreview
 import com.github.meeplemeet.model.shared.game.GAMES_COLLECTION_PATH
 import com.github.meeplemeet.model.shared.game.Game
 import com.github.meeplemeet.model.shared.game.GameNoUid

--- a/app/src/androidTest/java/com/github/meeplemeet/utils/FirestoreTests.kt
+++ b/app/src/androidTest/java/com/github/meeplemeet/utils/FirestoreTests.kt
@@ -8,8 +8,8 @@ import com.github.meeplemeet.model.account.HandlesRepository
 import com.github.meeplemeet.model.auth.AuthenticationRepository
 import com.github.meeplemeet.model.discussions.DiscussionRepository
 import com.github.meeplemeet.model.images.ImageRepository
-import com.github.meeplemeet.model.map.MarkerPreviewRepository
 import com.github.meeplemeet.model.map.StorableGeoPinRepository
+import com.github.meeplemeet.model.map.previews.MarkerPreviewRepository
 import com.github.meeplemeet.model.offline.OfflineModeManager
 import com.github.meeplemeet.model.posts.PostRepository
 import com.github.meeplemeet.model.sessions.SessionRepository

--- a/app/src/main/java/com/github/meeplemeet/MainActivity.kt
+++ b/app/src/main/java/com/github/meeplemeet/MainActivity.kt
@@ -42,9 +42,9 @@ import com.github.meeplemeet.model.account.HandlesRepository
 import com.github.meeplemeet.model.auth.AuthenticationRepository
 import com.github.meeplemeet.model.discussions.DiscussionRepository
 import com.github.meeplemeet.model.images.ImageRepository
-import com.github.meeplemeet.model.map.MarkerPreviewRepository
 import com.github.meeplemeet.model.map.PinType
 import com.github.meeplemeet.model.map.StorableGeoPinRepository
+import com.github.meeplemeet.model.map.previews.MarkerPreviewRepository
 import com.github.meeplemeet.model.offline.OfflineModeManager
 import com.github.meeplemeet.model.posts.PostRepository
 import com.github.meeplemeet.model.sessions.SessionRepository

--- a/app/src/main/java/com/github/meeplemeet/model/map/MapViewModel.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/map/MapViewModel.kt
@@ -10,6 +10,8 @@ import com.github.meeplemeet.model.map.cluster.Cluster
 import com.github.meeplemeet.model.map.cluster.ClusterItem
 import com.github.meeplemeet.model.map.cluster.ClusterManager
 import com.github.meeplemeet.model.map.cluster.DistanceBasedClusterStrategy
+import com.github.meeplemeet.model.map.previews.MarkerPreview
+import com.github.meeplemeet.model.map.previews.MarkerPreviewRepository
 import com.github.meeplemeet.model.sessions.SessionRepository
 import com.github.meeplemeet.model.shared.location.Location
 import com.google.firebase.firestore.GeoPoint

--- a/app/src/main/java/com/github/meeplemeet/model/map/previews/MarkerPreview.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/map/previews/MarkerPreview.kt
@@ -1,4 +1,4 @@
-package com.github.meeplemeet.model.map
+package com.github.meeplemeet.model.map.previews
 
 /**
  * Lightweight UI model displayed when a user taps on a map marker.

--- a/app/src/main/java/com/github/meeplemeet/model/map/previews/MarkerPreviewRepository.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/map/previews/MarkerPreviewRepository.kt
@@ -1,8 +1,9 @@
-package com.github.meeplemeet.model.map
+package com.github.meeplemeet.model.map.previews
 
 import com.github.meeplemeet.RepositoryProvider
 import com.github.meeplemeet.model.discussions.DiscussionRepository
-import com.github.meeplemeet.model.map.MarkerPreview.*
+import com.github.meeplemeet.model.map.PinType
+import com.github.meeplemeet.model.map.StorableGeoPin
 import com.github.meeplemeet.model.shops.OpeningHours
 import com.github.meeplemeet.model.shops.ShopRepository
 import com.github.meeplemeet.model.space_renter.SpaceRenterRepository
@@ -31,12 +32,16 @@ class MarkerPreviewRepository(
 ) {
 
   /**
-   * Transforms a list of [StorableGeoPin]s into their corresponding [MarkerPreview]s in parallel.
+   * Transforms a list of [com.github.meeplemeet.model.map.StorableGeoPin]s into their corresponding
+   * [MarkerPreview]s in parallel.
    *
    * Each pin is fetched according to its type:
-   * - [PinType.SHOP] → fetches the shop and builds a [ShopMarkerPreview]
-   * - [PinType.SESSION] → fetches the session and game to build a [SessionMarkerPreview]
-   * - [PinType.SPACE] → fetches the space renter and builds a [SpaceMarkerPreview]
+   * - [com.github.meeplemeet.model.map.PinType.SHOP] → fetches the shop and builds a
+   *   [MarkerPreview.ShopMarkerPreview]
+   * - [com.github.meeplemeet.model.map.PinType.SESSION] → fetches the session and game to build a
+   *   [MarkerPreview.SessionMarkerPreview]
+   * - [com.github.meeplemeet.model.map.PinType.SPACE] → fetches the space renter and builds a
+   *   [MarkerPreview.SpaceMarkerPreview]
    *
    * @param pins List of pins to transform
    * @return List of [MarkerPreview?]s. A preview may be `null` if the corresponding entity could
@@ -53,7 +58,7 @@ class MarkerPreviewRepository(
           .map { pin ->
             async {
               val shop = shopRepository.getShop(pin.uid)
-              ShopMarkerPreview(
+              MarkerPreview.ShopMarkerPreview(
                   name = shop.name,
                   address = shop.address.name,
                   open = isOpenNow(shop.openingHours))
@@ -68,7 +73,7 @@ class MarkerPreviewRepository(
             async {
               val session = discussionRepository.getDiscussion(pin.uid).session
               session?.let {
-                SessionMarkerPreview(
+                MarkerPreview.SessionMarkerPreview(
                     title = it.name,
                     address = it.location.name,
                     game = it.gameName,
@@ -84,7 +89,7 @@ class MarkerPreviewRepository(
           .map { pin ->
             async {
               val space = spaceRenterRepository.getSpaceRenter(pin.uid)
-              SpaceMarkerPreview(
+              MarkerPreview.SpaceMarkerPreview(
                   name = space.name,
                   address = space.address.name,
                   open = isOpenNow(space.openingHours))
@@ -115,14 +120,14 @@ class MarkerPreviewRepository(
       PinType.SHOP -> {
         val shop = shopRepository.getShop(pin.uid)
         shop.let {
-          ShopMarkerPreview(
+          MarkerPreview.ShopMarkerPreview(
               name = it.name, address = it.address.name, open = isOpenNow(it.openingHours))
         }
       }
       PinType.SESSION -> {
         val session = discussionRepository.getDiscussion(pin.uid).session
         session?.let {
-          SessionMarkerPreview(
+          MarkerPreview.SessionMarkerPreview(
               title = it.name,
               address = it.location.name,
               game = it.gameName,
@@ -132,7 +137,7 @@ class MarkerPreviewRepository(
       PinType.SPACE -> {
         val space = spaceRenterRepository.getSpaceRenter(pin.uid)
         space.let {
-          SpaceMarkerPreview(
+          MarkerPreview.SpaceMarkerPreview(
               name = it.name, address = it.address.name, open = isOpenNow(it.openingHours))
         }
       }

--- a/app/src/main/java/com/github/meeplemeet/model/map/routes/TravelInfo.kt
+++ b/app/src/main/java/com/github/meeplemeet/model/map/routes/TravelInfo.kt
@@ -1,0 +1,45 @@
+package com.github.meeplemeet.model.map.routes
+
+/**
+ * Available modes of transportation for route calculation.
+ *
+ * Used to determine both approximate and real travel times.
+ */
+enum class TransportMode {
+  /** Walking speed, typically ~5 km/h */
+  WALKING,
+  /** Bicycling speed, typically ~15 km/h */
+  BICYCLING,
+  /** Driving speed, typically ~50 km/h in urban areas */
+  DRIVING
+}
+
+/**
+ * Default speeds in meters per second used for approximate travel time calculation.
+ *
+ * These are used only for local estimation to avoid unnecessary API calls.
+ */
+object DefaultTravelSpeeds {
+  const val WALKING = 5_000 / 3_600.0
+  const val BICYCLING = 15_000 / 3_600.0
+  const val DRIVING = 50_000 / 3_600.0
+}
+
+/**
+ * Travel information between two geographic points.
+ *
+ * Can represent either an approximate value (local calculation using distance + default speed) or a
+ * precise value retrieved from a routing API.
+ *
+ * @property distanceMeters Distance between origin and destination in meters.
+ * @property durationSeconds Estimated duration of the trip in seconds.
+ * @property isApproximate True if the travel info is approximate; false if retrieved from a routing
+ *   API.
+ * @property mode Mode of transportation used to compute this travel info.
+ */
+data class TravelInfo(
+    val distanceMeters: Double,
+    val durationSeconds: Double,
+    val isApproximate: Boolean,
+    val mode: TransportMode
+)

--- a/app/src/main/java/com/github/meeplemeet/ui/MapScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/MapScreen.kt
@@ -113,9 +113,9 @@ import com.github.meeplemeet.R
 import com.github.meeplemeet.model.account.Account
 import com.github.meeplemeet.model.map.GeoPinWithLocation
 import com.github.meeplemeet.model.map.MapViewModel
-import com.github.meeplemeet.model.map.MarkerPreview
 import com.github.meeplemeet.model.map.PinType
 import com.github.meeplemeet.model.map.StorableGeoPin
+import com.github.meeplemeet.model.map.previews.MarkerPreview
 import com.github.meeplemeet.model.shared.location.Location
 import com.github.meeplemeet.ui.navigation.BottomBarWithVerification
 import com.github.meeplemeet.ui.navigation.MeepleMeetScreen

--- a/app/src/main/java/com/github/meeplemeet/ui/MapScreen.kt
+++ b/app/src/main/java/com/github/meeplemeet/ui/MapScreen.kt
@@ -182,6 +182,10 @@ object MapScreenTestTags {
   const val FILTER_OWNED_SWITCH = "filterOwnedSwitch"
   const val MARKER_PREVIEW_SHEET = "markerPreviewSheet"
   const val PREVIEW_TITLE = "previewTitle"
+  const val PREVIEW_TIME_ESTIMATES = "previewTimeEstimates"
+  const val PREVIEW_TIME_CAR = "previewTimeCar"
+  const val PREVIEW_TIME_BIKE = "previewTimeBike"
+  const val PREVIEW_TIME_WALK = "previewTimeWalk"
   const val PREVIEW_ADDRESS = "previewAddress"
   const val PREVIEW_OPENING_HOURS = "previewOpeningHours"
   const val PREVIEW_GAME = "previewGame"
@@ -1100,14 +1104,20 @@ private fun MarkerPreviewSheet(
             Row(
                 horizontalArrangement = Arrangement.spacedBy(Dimensions.Spacing.xLarge),
                 verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.fillMaxWidth()) {
-                  IconText(icon = Icons.Default.DirectionsCar, text = est.driving.toTimeString())
+                modifier =
+                    Modifier.fillMaxWidth().testTag(MapScreenTestTags.PREVIEW_TIME_ESTIMATES)) {
+                  IconText(
+                      icon = Icons.Default.DirectionsCar,
+                      text = est.driving.toTimeString(),
+                      testTag = MapScreenTestTags.PREVIEW_TIME_CAR)
                   IconText(
                       icon = Icons.AutoMirrored.Filled.DirectionsBike,
-                      text = est.bicycling.toTimeString())
+                      text = est.bicycling.toTimeString(),
+                      testTag = MapScreenTestTags.PREVIEW_TIME_BIKE)
                   IconText(
                       icon = Icons.AutoMirrored.Filled.DirectionsWalk,
-                      text = est.walking.toTimeString())
+                      text = est.walking.toTimeString(),
+                      testTag = MapScreenTestTags.PREVIEW_TIME_WALK)
                 }
 
             Spacer(modifier = Modifier.height(Dimensions.Spacing.medium))
@@ -1198,11 +1208,11 @@ private fun MarkerPreviewSheet(
 }
 
 @Composable
-private fun IconText(icon: ImageVector, text: String) {
+private fun IconText(icon: ImageVector, text: String, testTag: String) {
   Row(verticalAlignment = Alignment.CenterVertically) {
     Icon(icon, contentDescription = null)
     Spacer(Modifier.width(Dimensions.Spacing.small))
-    Text(text, style = MaterialTheme.typography.bodySmall)
+    Text(text, style = MaterialTheme.typography.bodySmall, modifier = Modifier.testTag(testTag))
   }
 }
 


### PR DESCRIPTION
This PR adds distance and travel time estimates to map marker previews.

### Travel models
- Add `TransportMode` enum (WALKING, BICYCLING, DRIVING)
- Add `DefaultTravelSpeeds` for local estimation
- Introduce `TravelInfo` to represent distance, duration, approximation status, and transport mode

### Map UI
- Compute travel estimates using Haversine distance + default speeds
- Display distance next to the marker title
- Display estimated travel times for driving, biking, and walking
- Enforce a minimum display of **1 minute** (avoid `0m`)

### Tests
- Add UI tests for travel time display in marker previews

_Generated with Copilot._